### PR TITLE
Configure semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ node_js:
 
 jobs:
     include:
-        - state: verify
-          script: commitlint-travis
         - stage: test
+          script: commitlint-travis
           script: npm test
-        - state: release
+
+        - stage: release
           script: npm run build
+          on:
+            branch: master
           deploy:
-              provider: script
               skip_cleanup: true
+              provider: script
               script: npm run release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,23 @@
 language: node_js
 
 node_js:
-    - lts/*
+  - lts/*
+
+stages:
+  - analyse commits
+  - test
+  - name: release
+    if: branch = master
 
 jobs:
-    include:
-        - stage: test
-          script: commitlint-travis
-          script: npm test
-
-        - stage: release
-          script: npm run build
-          on:
-            branch: master
-          deploy:
-              skip_cleanup: true
-              provider: script
-              script: npm run release
+  include:
+    - stage: analyse commits
+      script: commitlint-travis
+    - stage: test
+      script: npm test
+    - stage: release
+      script: npm run build
+      deploy:
+        skip_cleanup: true
+        provider: script
+        script: npm run release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,17 @@
 language: node_js
+
 node_js:
     - lts/*
+
+jobs:
+    include:
+        - state: verify
+          script: commitlint-travis
+        - stage: test
+          script: npm test
+        - state: release
+          script: npm run build
+          deploy:
+              provider: script
+              skip_cleanup: true
+              script: npm run release

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The main goal of this package is to provide an easy to configure and straightfor
 [![Npm total downloads badge](https://img.shields.io/npm/dt/@coveord/platform-client?style=flat-square)](https://www.npmjs.com/package/react-vapor)
 [![license](https://img.shields.io/hexpm/l/plug.svg?style=flat-square)](LICENSE)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release)
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 The main goal of this package is to provide an easy to configure and straightforward way of querying Coveo Cloud APIs using JavaScript.
 
+[![Build Status](https://img.shields.io/travis/coveo/platform-client.svg?style=flat-square)](https://travis-ci.org/coveo/platform-client)
+[![Npm total downloads badge](https://img.shields.io/npm/dt/@coveord/platform-client?style=flat-square)](https://www.npmjs.com/package/react-vapor)
+[![license](https://img.shields.io/hexpm/l/plug.svg?style=flat-square)](LICENSE)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+
 ## Getting started
 
 ### Install

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@coveord/platform-client",
-    "version": "0.0.0",
+    "version": "0.0.0-development",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -217,6 +217,274 @@
                 "minimist": "^1.2.0"
             }
         },
+        "@commitlint/cli": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-8.2.0.tgz",
+            "integrity": "sha512-8fJ5pmytc38yw2QWbTTJmXLfSiWPwMkHH4govo9zJ/+ERPBF2jvlxD/dQvk24ezcizjKc6LFka2edYC4OQ+Dgw==",
+            "dev": true,
+            "requires": {
+                "@commitlint/format": "^8.2.0",
+                "@commitlint/lint": "^8.2.0",
+                "@commitlint/load": "^8.2.0",
+                "@commitlint/read": "^8.2.0",
+                "babel-polyfill": "6.26.0",
+                "chalk": "2.4.2",
+                "get-stdin": "7.0.0",
+                "lodash": "4.17.14",
+                "meow": "5.0.0",
+                "resolve-from": "5.0.0",
+                "resolve-global": "1.0.0"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.14",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+                    "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+                    "dev": true
+                }
+            }
+        },
+        "@commitlint/config-conventional": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-8.2.0.tgz",
+            "integrity": "sha512-HuwlHQ3DyVhpK9GHgTMhJXD8Zp8PGIQVpQGYh/iTrEU6TVxdRC61BxIDZvfWatCaiG617Z/U8maRAFrqFM4TqA==",
+            "dev": true
+        },
+        "@commitlint/ensure": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-8.2.0.tgz",
+            "integrity": "sha512-XZZih/kcRrqK7lEORbSYCfqQw6byfsFbLygRGVdJMlCPGu9E2MjpwCtoj5z7y/lKfUB3MJaBhzn2muJqS1gC6A==",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.14"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.14",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+                    "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+                    "dev": true
+                }
+            }
+        },
+        "@commitlint/execute-rule": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-8.2.0.tgz",
+            "integrity": "sha512-9MBRthHaulbWTa8ReG2Oii2qc117NuvzhZdnkuKuYLhker7sUXGFcVhLanuWUKGyfyI2o9zVr/NHsNbCCsTzAA==",
+            "dev": true
+        },
+        "@commitlint/format": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-8.2.0.tgz",
+            "integrity": "sha512-sA77agkDEMsEMrlGhrLtAg8vRexkOofEEv/CZX+4xlANyAz2kNwJvMg33lcL65CBhqKEnRRJRxfZ1ZqcujdKcQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1"
+            }
+        },
+        "@commitlint/is-ignored": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-8.2.0.tgz",
+            "integrity": "sha512-ADaGnKfbfV6KD1pETp0Qf7XAyc75xTy3WJlbvPbwZ4oPdBMsXF0oXEEGMis6qABfU2IXan5/KAJgAFX3vdd0jA==",
+            "dev": true,
+            "requires": {
+                "@types/semver": "^6.0.1",
+                "semver": "6.2.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+                    "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+                    "dev": true
+                }
+            }
+        },
+        "@commitlint/lint": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-8.2.0.tgz",
+            "integrity": "sha512-ch9JN8aR37ufdjoWv50jLfvFz9rWMgLW5HEkMGLsM/51gjekmQYS5NJg8S2+6F5+jmralAO7VkUMI6FukXKX0A==",
+            "dev": true,
+            "requires": {
+                "@commitlint/is-ignored": "^8.2.0",
+                "@commitlint/parse": "^8.2.0",
+                "@commitlint/rules": "^8.2.0",
+                "babel-runtime": "^6.23.0",
+                "lodash": "4.17.14"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.14",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+                    "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+                    "dev": true
+                }
+            }
+        },
+        "@commitlint/load": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-8.2.0.tgz",
+            "integrity": "sha512-EV6PfAY/p83QynNd1llHxJiNxKmp43g8+7dZbyfHFbsGOdokrCnoelAVZ+WGgktXwLN/uXyfkcIAxwac015UYw==",
+            "dev": true,
+            "requires": {
+                "@commitlint/execute-rule": "^8.2.0",
+                "@commitlint/resolve-extends": "^8.2.0",
+                "babel-runtime": "^6.23.0",
+                "chalk": "2.4.2",
+                "cosmiconfig": "^5.2.0",
+                "lodash": "4.17.14",
+                "resolve-from": "^5.0.0"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.14",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+                    "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+                    "dev": true
+                }
+            }
+        },
+        "@commitlint/message": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-8.2.0.tgz",
+            "integrity": "sha512-LNsSwDLIFgE3nb/Sb1PIluYNy4Q8igdf4tpJCdv5JJDf7CZCZt3ZTglj0YutZZorpRRuHJsVIB2+dI4bVH3bFw==",
+            "dev": true
+        },
+        "@commitlint/parse": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-8.2.0.tgz",
+            "integrity": "sha512-vzouqroTXG6QXApkrps0gbeSYW6w5drpUk7QAeZIcaCSPsQXDM8eqqt98ZzlzLJHo5oPNXPX1AAVSTrssvHemA==",
+            "dev": true,
+            "requires": {
+                "conventional-changelog-angular": "^1.3.3",
+                "conventional-commits-parser": "^2.1.0",
+                "lodash": "^4.17.11"
+            }
+        },
+        "@commitlint/read": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-8.2.0.tgz",
+            "integrity": "sha512-1tBai1VuSQmsOTsvJr3Fi/GZqX3zdxRqYe/yN4i3cLA5S2Y4QGJ5I3l6nGZlKgm/sSelTCVKHltrfWU8s5H7SA==",
+            "dev": true,
+            "requires": {
+                "@commitlint/top-level": "^8.2.0",
+                "@marionebl/sander": "^0.6.0",
+                "babel-runtime": "^6.23.0",
+                "git-raw-commits": "^1.3.0"
+            }
+        },
+        "@commitlint/resolve-extends": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-8.2.0.tgz",
+            "integrity": "sha512-cwi0HUsDcD502HBP8huXfTkVuWmeo1Fiz3GKxNwMBBsJV4+bKa7QrtxbNpXhVuarX7QjWfNTvmW6KmFS7YK9uw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "^12.0.2",
+                "import-fresh": "^3.0.0",
+                "lodash": "4.17.14",
+                "resolve-from": "^5.0.0",
+                "resolve-global": "^1.0.0"
+            },
+            "dependencies": {
+                "import-fresh": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+                    "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+                    "dev": true,
+                    "requires": {
+                        "parent-module": "^1.0.0",
+                        "resolve-from": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "resolve-from": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                            "dev": true
+                        }
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.14",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+                    "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+                    "dev": true
+                }
+            }
+        },
+        "@commitlint/rules": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-8.2.0.tgz",
+            "integrity": "sha512-FlqSBBP2Gxt5Ibw+bxdYpzqYR6HI8NIBpaTBhAjSEAduQtdWFMOhF0zsgkwH7lHN7opaLcnY2fXxAhbzTmJQQA==",
+            "dev": true,
+            "requires": {
+                "@commitlint/ensure": "^8.2.0",
+                "@commitlint/message": "^8.2.0",
+                "@commitlint/to-lines": "^8.2.0",
+                "babel-runtime": "^6.23.0"
+            }
+        },
+        "@commitlint/to-lines": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-8.2.0.tgz",
+            "integrity": "sha512-LXTYG3sMenlN5qwyTZ6czOULVcx46uMy+MEVqpvCgptqr/MZcV/C2J+S2o1DGwj1gOEFMpqrZaE3/1R2Q+N8ng==",
+            "dev": true
+        },
+        "@commitlint/top-level": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-8.2.0.tgz",
+            "integrity": "sha512-Yaw4KmYNy31/HhRUuZ+fupFcDalnfpdu4JGBgGAqS9aBHdMSSWdWqtAaDaxdtWjTZeN3O0sA2gOhXwvKwiDwvw==",
+            "dev": true,
+            "requires": {
+                "find-up": "^4.0.0"
+            }
+        },
+        "@commitlint/travis-cli": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/travis-cli/-/travis-cli-8.2.0.tgz",
+            "integrity": "sha512-SXZh9qpAWwvzW2KlG5HOxnci1KMkUZOqr2wKMzgXuV+BS5jhkZaPsKvrrs85FZtUWdJuqFNHTVXKoetgWgMXpQ==",
+            "dev": true,
+            "requires": {
+                "@commitlint/cli": "^8.2.0",
+                "babel-runtime": "6.26.0",
+                "execa": "0.11.0"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.11.0.tgz",
+                    "integrity": "sha512-k5AR22vCt1DcfeiRixW46U5tMLtBg44ssdJM9PiXw3D8Bn5qyxFCSnKY/eR22y+ctFDGPqafpaXg2G4Emyua4A==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                }
+            }
+        },
         "@jest/console": {
             "version": "24.9.0",
             "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -425,6 +693,17 @@
                 "@types/yargs": "^13.0.0"
             }
         },
+        "@marionebl/sander": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
+            "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.3",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.2"
+            }
+        },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -461,6 +740,101 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@octokit/endpoint": {
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.3.5.tgz",
+            "integrity": "sha512-f8KqzIrnzPLiezDsZZPB+K8v8YSv6aKFl7eOu59O46lmlW4HagWl1U6NWl6LmT8d1w7NsKBI3paVtzcnRGO1gw==",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^3.0.0",
+                "universal-user-agent": "^4.0.0"
+            },
+            "dependencies": {
+                "is-plain-object": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+                    "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+                    "dev": true,
+                    "requires": {
+                        "isobject": "^4.0.0"
+                    }
+                },
+                "isobject": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+                    "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+                    "dev": true
+                }
+            }
+        },
+        "@octokit/request": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.1.0.tgz",
+            "integrity": "sha512-I15T9PwjFs4tbWyhtFU2Kq7WDPidYMvRB7spmxoQRZfxSmiqullG+Nz+KbSmpkfnlvHwTr1e31R5WReFRKMXjg==",
+            "dev": true,
+            "requires": {
+                "@octokit/endpoint": "^5.1.0",
+                "@octokit/request-error": "^1.0.1",
+                "deprecation": "^2.0.0",
+                "is-plain-object": "^3.0.0",
+                "node-fetch": "^2.3.0",
+                "once": "^1.4.0",
+                "universal-user-agent": "^4.0.0"
+            },
+            "dependencies": {
+                "is-plain-object": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+                    "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+                    "dev": true,
+                    "requires": {
+                        "isobject": "^4.0.0"
+                    }
+                },
+                "isobject": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+                    "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+                    "dev": true
+                },
+                "node-fetch": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+                    "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+                    "dev": true
+                }
+            }
+        },
+        "@octokit/request-error": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.4.tgz",
+            "integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
+            "dev": true,
+            "requires": {
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            }
+        },
+        "@octokit/rest": {
+            "version": "16.29.0",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.29.0.tgz",
+            "integrity": "sha512-t01+Hz6sUJx2/HzY4KSgmST5n7KcTYr8i6+UwqS6TkgyjyA6YmeTxVhZrQUobEXaDdQFxs1dRhh1hgmOo6OF9Q==",
+            "dev": true,
+            "requires": {
+                "@octokit/request": "^5.0.0",
+                "@octokit/request-error": "^1.0.2",
+                "atob-lite": "^2.0.0",
+                "before-after-hook": "^2.0.0",
+                "btoa-lite": "^1.0.0",
+                "deprecation": "^2.0.0",
+                "lodash.get": "^4.4.2",
+                "lodash.set": "^4.3.2",
+                "lodash.uniq": "^4.5.0",
+                "octokit-pagination-methods": "^1.1.0",
+                "once": "^1.4.0",
+                "universal-user-agent": "^4.0.0"
+            }
+        },
         "@samverschueren/stream-to-observable": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -468,6 +842,529 @@
             "dev": true,
             "requires": {
                 "any-observable": "^0.3.0"
+            }
+        },
+        "@semantic-release/commit-analyzer": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.3.0.tgz",
+            "integrity": "sha512-sh51MVlV8VyrvGIemcvzueDADX/8qGbAgce1F0CtQv8hNKYyhdaJeHzfiM1rNXwCynDmcQj+Yq9rrWt71tBd/Q==",
+            "dev": true,
+            "requires": {
+                "conventional-changelog-angular": "^5.0.0",
+                "conventional-commits-filter": "^2.0.0",
+                "conventional-commits-parser": "^3.0.0",
+                "debug": "^4.0.0",
+                "import-from": "^3.0.0",
+                "lodash": "^4.17.4"
+            },
+            "dependencies": {
+                "conventional-changelog-angular": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
+                    "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
+                    "dev": true,
+                    "requires": {
+                        "compare-func": "^1.3.1",
+                        "q": "^1.5.1"
+                    }
+                },
+                "conventional-commits-parser": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
+                    "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
+                    "dev": true,
+                    "requires": {
+                        "JSONStream": "^1.0.4",
+                        "is-text-path": "^1.0.0",
+                        "lodash": "^4.2.1",
+                        "meow": "^4.0.0",
+                        "split2": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "trim-off-newlines": "^1.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "meow": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+                    "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                    "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@semantic-release/error": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
+            "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
+            "dev": true
+        },
+        "@semantic-release/github": {
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-5.4.3.tgz",
+            "integrity": "sha512-nFoG1whDZettsGsMRE64kCFRpGSHxQxiKtUltKw67uYO7Q62049HGcdH7pZh/ipn+Uq2cG4Zef/g1vxVVaK82w==",
+            "dev": true,
+            "requires": {
+                "@octokit/rest": "^16.27.0",
+                "@semantic-release/error": "^2.2.0",
+                "aggregate-error": "^3.0.0",
+                "bottleneck": "^2.18.1",
+                "debug": "^4.0.0",
+                "dir-glob": "^3.0.0",
+                "fs-extra": "^8.0.0",
+                "globby": "^10.0.0",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1",
+                "issue-parser": "^4.0.0",
+                "lodash": "^4.17.4",
+                "mime": "^2.4.3",
+                "p-filter": "^2.0.0",
+                "p-retry": "^4.0.0",
+                "parse-github-url": "^1.0.1",
+                "url-join": "^4.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
+        "@semantic-release/npm": {
+            "version": "5.1.15",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.1.15.tgz",
+            "integrity": "sha512-MUUKOOtqsX/aJZJIjiAdw7SkCH+D3De060l1HhTlqrwTB7PzMtXcUMen6Prd1Hv8+gknUFkSWhVmi8tIaGDVnA==",
+            "dev": true,
+            "requires": {
+                "@semantic-release/error": "^2.2.0",
+                "aggregate-error": "^3.0.0",
+                "execa": "^2.0.2",
+                "fs-extra": "^8.0.0",
+                "lodash": "^4.17.15",
+                "nerf-dart": "^1.0.0",
+                "normalize-url": "^4.0.0",
+                "npm": "^6.10.3",
+                "rc": "^1.2.8",
+                "read-pkg": "^5.0.0",
+                "registry-auth-token": "^4.0.0"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.4.tgz",
+                    "integrity": "sha512-VcQfhuGD51vQUQtKIq2fjGDLDbL6N1DTQVpYzxZ7LPIXw3HqTuIz6uxRmpV1qf8i31LHf2kjiaGI+GdHwRgbnQ==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.5",
+                        "get-stream": "^5.0.0",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^3.0.0",
+                        "onetime": "^5.1.0",
+                        "p-finally": "^2.0.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "is-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+                    "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                },
+                "p-finally": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+                    "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+                    "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+                    "dev": true
+                }
+            }
+        },
+        "@semantic-release/release-notes-generator": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-7.3.0.tgz",
+            "integrity": "sha512-6ozBLHM9XZR6Z8PFSKssLtwBYc5l1WOnxj034F8051QOo3TMKDDPKwdj2Niyc+e7ru7tGa3Ftq7nfN0YnD6//A==",
+            "dev": true,
+            "requires": {
+                "conventional-changelog-angular": "^5.0.0",
+                "conventional-changelog-writer": "^4.0.0",
+                "conventional-commits-filter": "^2.0.0",
+                "conventional-commits-parser": "^3.0.0",
+                "debug": "^4.0.0",
+                "get-stream": "^5.0.0",
+                "import-from": "^3.0.0",
+                "into-stream": "^5.0.0",
+                "lodash": "^4.17.4",
+                "read-pkg-up": "^6.0.0"
+            },
+            "dependencies": {
+                "conventional-changelog-angular": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
+                    "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
+                    "dev": true,
+                    "requires": {
+                        "compare-func": "^1.3.1",
+                        "q": "^1.5.1"
+                    }
+                },
+                "conventional-commits-parser": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
+                    "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
+                    "dev": true,
+                    "requires": {
+                        "JSONStream": "^1.0.4",
+                        "is-text-path": "^1.0.0",
+                        "lodash": "^4.2.1",
+                        "meow": "^4.0.0",
+                        "split2": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "trim-off-newlines": "^1.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "meow": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+                    "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "read-pkg-up": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+                            "dev": true,
+                            "requires": {
+                                "find-up": "^2.0.0",
+                                "read-pkg": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "parse-json": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+                    "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-6.0.0.tgz",
+                    "integrity": "sha512-odtTvLl+EXo1eTsMnoUHRmg/XmXdTkwXVxy4VFE9Kp6cCq7b3l7QMdBndND3eAFzrbSAXC/WCUOQQ9rLjifKZw==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^4.0.0",
+                        "read-pkg": "^5.1.1",
+                        "type-fest": "^0.5.0"
+                    },
+                    "dependencies": {
+                        "find-up": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                            "dev": true,
+                            "requires": {
+                                "locate-path": "^5.0.0",
+                                "path-exists": "^4.0.0"
+                            }
+                        },
+                        "locate-path": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                            "dev": true,
+                            "requires": {
+                                "p-locate": "^4.1.0"
+                            }
+                        },
+                        "p-limit": {
+                            "version": "2.2.1",
+                            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+                            "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+                            "dev": true,
+                            "requires": {
+                                "p-try": "^2.0.0"
+                            }
+                        },
+                        "p-locate": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                            "dev": true,
+                            "requires": {
+                                "p-limit": "^2.2.0"
+                            }
+                        },
+                        "p-try": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                            "dev": true
+                        },
+                        "path-exists": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                            "dev": true
+                        },
+                        "read-pkg": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                            "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+                            "dev": true,
+                            "requires": {
+                                "@types/normalize-package-data": "^2.4.0",
+                                "normalize-package-data": "^2.5.0",
+                                "parse-json": "^5.0.0",
+                                "type-fest": "^0.6.0"
+                            },
+                            "dependencies": {
+                                "type-fest": {
+                                    "version": "0.6.0",
+                                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                                    "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                                    "dev": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "type-fest": {
+                    "version": "0.5.2",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+                    "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+                    "dev": true
+                }
             }
         },
         "@types/anymatch": {
@@ -590,6 +1487,18 @@
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+            "dev": true
+        },
+        "@types/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+            "dev": true
+        },
+        "@types/semver": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.0.2.tgz",
+            "integrity": "sha512-G1Ggy7/9Nsa1Jt2yiBR2riEuyK2DFNnqow6R7cromXPMNynackRY1vqFTLz/gwnef1LHokbXThcPhqMRjUbkpQ==",
             "dev": true
         },
         "@types/source-list-map": {
@@ -874,6 +1783,16 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
+        "JSONStream": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+            "dev": true,
+            "requires": {
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
+            }
+        },
         "abab": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
@@ -909,6 +1828,15 @@
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
             "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
             "dev": true
+        },
+        "agent-base": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+            "dev": true,
+            "requires": {
+                "es6-promisify": "^5.0.0"
+            }
         },
         "aggregate-error": {
             "version": "3.0.0",
@@ -965,6 +1893,12 @@
                 "color-convert": "^1.9.0"
             }
         },
+        "ansicolors": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+            "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+            "dev": true
+        },
         "any-observable": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
@@ -996,6 +1930,12 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "argv-formatter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+            "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=",
+            "dev": true
+        },
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -1024,6 +1964,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "dev": true
+        },
+        "array-ify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+            "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
             "dev": true
         },
         "array-union": {
@@ -1137,6 +2083,12 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
+        },
+        "atob-lite": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+            "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
             "dev": true
         },
         "autoprefixer": {
@@ -1313,6 +2265,25 @@
                 "@types/babel__traverse": "^7.0.6"
             }
         },
+        "babel-polyfill": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+            "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "regenerator-runtime": "^0.10.5"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.10.5",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                    "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+                    "dev": true
+                }
+            }
+        },
         "babel-preset-jest": {
             "version": "24.9.0",
             "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
@@ -1321,6 +2292,16 @@
             "requires": {
                 "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
                 "babel-plugin-jest-hoist": "^24.9.0"
+            }
+        },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "dev": true,
+            "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
             }
         },
         "bail": {
@@ -1405,6 +2386,12 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "before-after-hook": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+            "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
+            "dev": true
+        },
         "big.js": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1427,6 +2414,12 @@
             "version": "4.11.8",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
             "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+            "dev": true
+        },
+        "bottleneck": {
+            "version": "2.19.5",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+            "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
             "dev": true
         },
         "brace-expansion": {
@@ -1597,6 +2590,12 @@
                 "node-int64": "^0.4.0"
             }
         },
+        "btoa-lite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+            "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+            "dev": true
+        },
         "buffer": {
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -1689,6 +2688,12 @@
                 "unset-value": "^1.0.0"
             }
         },
+        "cachedir": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.2.0.tgz",
+            "integrity": "sha512-VvxA0xhNqIIfg0V9AmJkDg91DaJwryutH5rVEZAhcNi4iJFj9f+QxmAjgK1LT9I8OgToX27fypX6/MeCXVbBjQ==",
+            "dev": true
+        },
         "call-me-maybe": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -1759,6 +2764,16 @@
                 "rsvp": "^4.8.4"
             }
         },
+        "cardinal": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+            "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+            "dev": true,
+            "requires": {
+                "ansicolors": "~0.3.2",
+                "redeyed": "~2.1.0"
+            }
+        },
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -1804,6 +2819,12 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
             "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
+            "dev": true
+        },
+        "chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
             "dev": true
         },
         "chokidar": {
@@ -1993,6 +3014,15 @@
                 "restore-cursor": "^2.0.0"
             }
         },
+        "cli-table": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+            "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+            "dev": true,
+            "requires": {
+                "colors": "1.0.3"
+            }
+        },
         "cli-truncate": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
@@ -2039,6 +3069,12 @@
                     }
                 }
             }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
         },
         "cliui": {
             "version": "5.0.0",
@@ -2104,6 +3140,12 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
+        "colors": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+            "dev": true
+        },
         "combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2125,11 +3167,84 @@
             "integrity": "sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ==",
             "dev": true
         },
+        "commitizen": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.0.3.tgz",
+            "integrity": "sha512-lxu0F/Iq4dudoFeIl5pY3h3CQJzkmQuh3ygnaOvqhAD8Wu2pYBI17ofqSuPHNsBTEOh1r1AVa9kR4Hp0FAHKcQ==",
+            "dev": true,
+            "requires": {
+                "cachedir": "2.2.0",
+                "cz-conventional-changelog": "3.0.1",
+                "dedent": "0.7.0",
+                "detect-indent": "6.0.0",
+                "find-node-modules": "2.0.0",
+                "find-root": "1.1.0",
+                "fs-extra": "8.1.0",
+                "glob": "7.1.4",
+                "inquirer": "6.5.0",
+                "is-utf8": "^0.2.1",
+                "lodash": "4.17.15",
+                "minimist": "1.2.0",
+                "shelljs": "0.7.6",
+                "strip-bom": "4.0.0",
+                "strip-json-comments": "3.0.1"
+            },
+            "dependencies": {
+                "cz-conventional-changelog": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.0.1.tgz",
+                    "integrity": "sha512-7KASIwB8/ClEyCRvQrCPbN7WkQnUSjSSVNyPM+gDJ0jskLi8h8N2hrdpyeCk7fIqKMRzziqVSOBTB8yyLTMHGQ==",
+                    "dev": true,
+                    "requires": {
+                        "@commitlint/load": ">6.1.1",
+                        "chalk": "^2.4.1",
+                        "conventional-commit-types": "^2.0.0",
+                        "lodash.map": "^4.5.1",
+                        "longest": "^2.0.1",
+                        "right-pad": "^1.0.1",
+                        "word-wrap": "^1.0.3"
+                    }
+                },
+                "strip-bom": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+                    "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+                    "dev": true
+                },
+                "strip-json-comments": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+                    "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+                    "dev": true
+                }
+            }
+        },
         "commondir": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
             "dev": true
+        },
+        "compare-func": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+            "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+            "dev": true,
+            "requires": {
+                "array-ify": "^1.0.0",
+                "dot-prop": "^3.0.0"
+            },
+            "dependencies": {
+                "dot-prop": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+                    "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+                    "dev": true,
+                    "requires": {
+                        "is-obj": "^1.0.0"
+                    }
+                }
+            }
         },
         "component-emitter": {
             "version": "1.3.0",
@@ -2170,6 +3285,268 @@
             "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
             "dev": true
         },
+        "conventional-changelog-angular": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+            "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+            "dev": true,
+            "requires": {
+                "compare-func": "^1.3.1",
+                "q": "^1.5.1"
+            }
+        },
+        "conventional-changelog-writer": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.7.tgz",
+            "integrity": "sha512-p/wzs9eYaxhFbrmX/mCJNwJuvvHR+j4Fd0SQa2xyAhYed6KBiZ780LvoqUUvsayP4R1DtC27czalGUhKV2oabw==",
+            "dev": true,
+            "requires": {
+                "compare-func": "^1.3.1",
+                "conventional-commits-filter": "^2.0.2",
+                "dateformat": "^3.0.0",
+                "handlebars": "^4.1.2",
+                "json-stringify-safe": "^5.0.1",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "semver": "^6.0.0",
+                "split": "^1.0.0",
+                "through2": "^3.0.0"
+            },
+            "dependencies": {
+                "conventional-commits-filter": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz",
+                    "integrity": "sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==",
+                    "dev": true,
+                    "requires": {
+                        "lodash.ismatch": "^4.4.0",
+                        "modify-values": "^1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "meow": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+                    "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                    "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^3.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+                    "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2 || 3"
+                    }
+                }
+            }
+        },
+        "conventional-commit-types": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.1.1.tgz",
+            "integrity": "sha512-0Ts+fEdmjqYDOQ1yZ+LNgdSPO335XZw9qC10M7CxtLP3nIMGmeMhmkM8Taffa4+MXN13bRPlp0CtH+QfOzKTzw==",
+            "dev": true
+        },
+        "conventional-commits-filter": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
+            "integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
+            "dev": true,
+            "requires": {
+                "is-subset": "^0.1.1",
+                "modify-values": "^1.0.0"
+            }
+        },
+        "conventional-commits-parser": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+            "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.4",
+                "is-text-path": "^1.0.0",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "split2": "^2.0.0",
+                "through2": "^2.0.0",
+                "trim-off-newlines": "^1.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "meow": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+                    "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                    "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^3.0.0"
+                    }
+                }
+            }
+        },
         "convert-source-map": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -2197,6 +3574,12 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
+        },
+        "core-js": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+            "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
             "dev": true
         },
         "core-util-is": {
@@ -2326,6 +3709,31 @@
             "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
             "dev": true
         },
+        "cz-conventional-changelog": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.0.2.tgz",
+            "integrity": "sha512-MPxERbtQyVp0nnpCBiwzKGKmMBSswmCV3Jpef3Axqd5f3c/SOc6VFiSUlclOyZXBn3Xtf4snzt4O15hBTRb2gA==",
+            "dev": true,
+            "requires": {
+                "@commitlint/load": ">6.1.1",
+                "chalk": "^2.4.1",
+                "commitizen": "^4.0.3",
+                "conventional-commit-types": "^2.0.0",
+                "lodash.map": "^4.5.1",
+                "longest": "^2.0.1",
+                "right-pad": "^1.0.1",
+                "word-wrap": "^1.0.3"
+            }
+        },
+        "dargs": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+            "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
+            "dev": true,
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2371,6 +3779,12 @@
             "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
             "dev": true
         },
+        "dateformat": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+            "dev": true
+        },
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2414,6 +3828,12 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
             "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+            "dev": true
+        },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true
         },
         "deep-is": {
@@ -2505,6 +3925,12 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
+        "deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+            "dev": true
+        },
         "des.js": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -2519,6 +3945,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
             "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+            "dev": true
+        },
+        "detect-indent": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+            "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
             "dev": true
         },
         "detect-newline": {
@@ -2640,6 +4072,15 @@
                 "is-obj": "^1.0.0"
             }
         },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            }
+        },
         "duplexify": {
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -2739,6 +4180,16 @@
             "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
             "dev": true
         },
+        "env-ci": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-4.1.1.tgz",
+            "integrity": "sha512-eTgpkALDeYRGNhYM2fO9LKsWDifoUgKL7hxpPZqFMP2IU7f+r89DtKqCmk3yQB/jxS8CmZTfKnWO5TiIDFs9Hw==",
+            "dev": true,
+            "requires": {
+                "execa": "^1.0.0",
+                "java-properties": "^1.0.0"
+            }
+        },
         "errno": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -2784,6 +4235,21 @@
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
+            }
+        },
+        "es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+            "dev": true
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "^4.0.3"
             }
         },
         "escape-string-regexp": {
@@ -3003,6 +4469,17 @@
                         "is-plain-object": "^2.0.4"
                     }
                 }
+            }
+        },
+        "external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+            "dev": true,
+            "requires": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
             }
         },
         "extglob": {
@@ -3281,6 +4758,22 @@
                 }
             }
         },
+        "find-node-modules": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.0.0.tgz",
+            "integrity": "sha512-8MWIBRgJi/WpjjfVXumjPKCtmQ10B+fjx6zmSA+770GMJirLhWIzg8l763rhjl9xaeaHbnxPNRQKq2mgMhr+aw==",
+            "dev": true,
+            "requires": {
+                "findup-sync": "^3.0.0",
+                "merge": "^1.2.1"
+            }
+        },
+        "find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "dev": true
+        },
         "find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3289,6 +4782,24 @@
             "requires": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
+            }
+        },
+        "find-versions": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.1.0.tgz",
+            "integrity": "sha512-NCTfNiVzeE/xL+roNDffGuRbrWI6atI18lTJ22vKp7rs2OhYzMK3W1dIdO2TUndH/QMcacM4d1uWwgcZcHK69Q==",
+            "dev": true,
+            "requires": {
+                "array-uniq": "^2.1.0",
+                "semver-regex": "^2.0.0"
+            },
+            "dependencies": {
+                "array-uniq": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
+                    "integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
+                    "dev": true
+                }
             }
         },
         "findup-sync": {
@@ -3381,6 +4892,17 @@
             "requires": {
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.0"
+            }
+        },
+        "fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-write-stream-atomic": {
@@ -3997,6 +5519,133 @@
                 "assert-plus": "^1.0.0"
             }
         },
+        "git-log-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+            "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
+            "dev": true,
+            "requires": {
+                "argv-formatter": "~1.0.0",
+                "spawn-error-forwarder": "~1.0.0",
+                "split2": "~1.0.0",
+                "stream-combiner2": "~1.1.1",
+                "through2": "~2.0.0",
+                "traverse": "~0.6.6"
+            },
+            "dependencies": {
+                "split2": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+                    "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
+                    "dev": true,
+                    "requires": {
+                        "through2": "~2.0.0"
+                    }
+                }
+            }
+        },
+        "git-raw-commits": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
+            "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
+            "dev": true,
+            "requires": {
+                "dargs": "^4.0.1",
+                "lodash.template": "^4.0.2",
+                "meow": "^4.0.0",
+                "split2": "^2.0.0",
+                "through2": "^2.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "meow": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+                    "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                    "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^3.0.0"
+                    }
+                }
+            }
+        },
         "glob": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -4025,6 +5674,15 @@
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
             "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
             "dev": true
+        },
+        "global-dirs": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+            "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+            "dev": true,
+            "requires": {
+                "ini": "^1.3.4"
+            }
         },
         "global-modules": {
             "version": "2.0.0",
@@ -4241,6 +5899,12 @@
                 "parse-passwd": "^1.0.0"
             }
         },
+        "hook-std": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
+            "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
+            "dev": true
+        },
         "hosted-git-info": {
             "version": "2.8.4",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
@@ -4289,6 +5953,27 @@
                 }
             }
         },
+        "http-proxy-agent": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "4",
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -4305,6 +5990,33 @@
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
+        },
+        "https-proxy-agent": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+            "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^4.3.0",
+                "debug": "^3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
         },
         "husky": {
             "version": "3.0.5",
@@ -4360,6 +6072,23 @@
             "requires": {
                 "caller-path": "^2.0.0",
                 "resolve-from": "^3.0.0"
+            }
+        },
+        "import-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+            "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+            "dev": true,
+            "requires": {
+                "resolve-from": "^5.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+                    "dev": true
+                }
             }
         },
         "import-lazy": {
@@ -4469,11 +6198,80 @@
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
             "dev": true
         },
+        "inquirer": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+            "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.2.0",
+                "chalk": "^2.4.2",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^2.0.0",
+                "lodash": "^4.17.12",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^6.4.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^5.1.0",
+                "through": "^2.3.6"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "figures": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+                    "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5"
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "interpret": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
             "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
             "dev": true
+        },
+        "into-stream": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.0.tgz",
+            "integrity": "sha512-cbDhb8qlxKMxPBk/QxTtYg1DQ4CwXmadu7quG3B7nrJsgSncEreF2kwWKZFdnjc/lSNNIkFPsjI7SM0Cx/QXPw==",
+            "dev": true,
+            "requires": {
+                "from2": "^2.3.0",
+                "p-is-promise": "^2.0.0"
+            }
         },
         "invariant": {
             "version": "2.2.4",
@@ -4773,6 +6571,12 @@
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
             "dev": true
         },
+        "is-subset": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+            "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+            "dev": true
+        },
         "is-supported-regexp-flag": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
@@ -4788,10 +6592,25 @@
                 "has-symbols": "^1.0.0"
             }
         },
+        "is-text-path": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+            "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+            "dev": true,
+            "requires": {
+                "text-extensions": "^1.0.0"
+            }
+        },
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
         "is-whitespace-character": {
@@ -4841,6 +6660,19 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
+        },
+        "issue-parser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-4.0.0.tgz",
+            "integrity": "sha512-1RmmAXHl5+cqTZ9dRr861xWy0Gkc9TWTEklgjKv+nhlB1dY1NmGBV8b20jTWRL5cPGpOIXkz84kEcDBM8Nc0cw==",
+            "dev": true,
+            "requires": {
+                "lodash.capitalize": "^4.2.1",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.uniqby": "^4.7.0"
+            }
         },
         "istanbul-lib-coverage": {
             "version": "2.0.5",
@@ -4931,6 +6763,12 @@
             "requires": {
                 "handlebars": "^4.1.2"
             }
+        },
+        "java-properties": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+            "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+            "dev": true
         },
         "jest": {
             "version": "24.9.0",
@@ -5493,6 +7331,21 @@
                 "minimist": "^1.2.0"
             }
         },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+            "dev": true
+        },
         "jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5877,16 +7730,107 @@
             "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
             "dev": true
         },
+        "lodash._reinterpolate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+            "dev": true
+        },
+        "lodash.capitalize": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+            "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
+            "dev": true
+        },
+        "lodash.escaperegexp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
+        },
+        "lodash.ismatch": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+            "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+            "dev": true
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+            "dev": true
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+            "dev": true
+        },
+        "lodash.map": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+            "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+            "dev": true
+        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
             "dev": true
         },
+        "lodash.set": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+            "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+            "dev": true
+        },
         "lodash.sortby": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
             "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
+        "lodash.template": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+            "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.templatesettings": "^4.0.0"
+            }
+        },
+        "lodash.templatesettings": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+            "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "^3.0.0"
+            }
+        },
+        "lodash.toarray": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+            "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+            "dev": true
+        },
+        "lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+            "dev": true
+        },
+        "lodash.uniqby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+            "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
             "dev": true
         },
         "log-symbols": {
@@ -5946,6 +7890,12 @@
                 }
             }
         },
+        "longest": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
+            "integrity": "sha1-eB4YMpaqlPbU2RbcM10NF676I/g=",
+            "dev": true
+        },
         "longest-streak": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
@@ -5980,6 +7930,12 @@
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
             }
+        },
+        "macos-release": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+            "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+            "dev": true
         },
         "make-dir": {
             "version": "2.1.0",
@@ -6061,6 +8017,26 @@
             "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
             "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
             "dev": true
+        },
+        "marked": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+            "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+            "dev": true
+        },
+        "marked-terminal": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-3.3.0.tgz",
+            "integrity": "sha512-+IUQJ5VlZoAFsM5MHNT7g3RHSkA3eETqhRCdXv4niUMAKHQ7lb1yvAcuGPmm4soxhmtX13u4Li6ZToXtvSEH+A==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.1.0",
+                "cardinal": "^2.1.1",
+                "chalk": "^2.4.1",
+                "cli-table": "^0.3.1",
+                "node-emoji": "^1.4.1",
+                "supports-hyperlinks": "^1.0.1"
+            }
         },
         "mathml-tag-names": {
             "version": "2.1.1",
@@ -6213,6 +8189,12 @@
                 }
             }
         },
+        "merge": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+            "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+            "dev": true
+        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6255,6 +8237,12 @@
                 "bn.js": "^4.0.0",
                 "brorand": "^1.0.1"
             }
+        },
+        "mime": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+            "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+            "dev": true
         },
         "mime-db": {
             "version": "1.40.0",
@@ -6370,6 +8358,12 @@
                 }
             }
         },
+        "modify-values": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+            "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+            "dev": true
+        },
         "move-concurrently": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -6388,6 +8382,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
             "dev": true
         },
         "nan": {
@@ -6428,11 +8428,26 @@
             "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
             "dev": true
         },
+        "nerf-dart": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+            "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
+            "dev": true
+        },
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
+        },
+        "node-emoji": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+            "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+            "dev": true,
+            "requires": {
+                "lodash.toarray": "^4.4.0"
+            }
         },
         "node-fetch": {
             "version": "2.1.2",
@@ -6546,6 +8561,3491 @@
             "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
             "dev": true
         },
+        "normalize-url": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+            "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
+            "dev": true
+        },
+        "npm": {
+            "version": "6.11.3",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-6.11.3.tgz",
+            "integrity": "sha512-K2h+MPzZiY39Xf6eHEdECe/LKoJXam4UCflz5kIxoskN3LQFeYs5fqBGT5i4TtM/aBk+86Mcf+jgXs/WuWAutQ==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.3.5",
+                "abbrev": "~1.1.1",
+                "ansicolors": "~0.3.2",
+                "ansistyles": "~0.1.3",
+                "aproba": "^2.0.0",
+                "archy": "~1.0.0",
+                "bin-links": "^1.1.3",
+                "bluebird": "^3.5.5",
+                "byte-size": "^5.0.1",
+                "cacache": "^12.0.3",
+                "call-limit": "^1.1.1",
+                "chownr": "^1.1.2",
+                "ci-info": "^2.0.0",
+                "cli-columns": "^3.1.2",
+                "cli-table3": "^0.5.1",
+                "cmd-shim": "^3.0.3",
+                "columnify": "~1.5.4",
+                "config-chain": "^1.1.12",
+                "debuglog": "*",
+                "detect-indent": "~5.0.0",
+                "detect-newline": "^2.1.0",
+                "dezalgo": "~1.0.3",
+                "editor": "~1.0.0",
+                "figgy-pudding": "^3.5.1",
+                "find-npm-prefix": "^1.0.2",
+                "fs-vacuum": "~1.2.10",
+                "fs-write-stream-atomic": "~1.0.10",
+                "gentle-fs": "^2.2.1",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.2",
+                "has-unicode": "~2.0.1",
+                "hosted-git-info": "^2.8.2",
+                "iferr": "^1.0.2",
+                "imurmurhash": "*",
+                "infer-owner": "^1.0.4",
+                "inflight": "~1.0.6",
+                "inherits": "^2.0.4",
+                "ini": "^1.3.5",
+                "init-package-json": "^1.10.3",
+                "is-cidr": "^3.0.0",
+                "json-parse-better-errors": "^1.0.2",
+                "lazy-property": "~1.0.0",
+                "libcipm": "^4.0.3",
+                "libnpm": "^3.0.1",
+                "libnpmaccess": "^3.0.2",
+                "libnpmhook": "^5.0.3",
+                "libnpmorg": "^1.0.1",
+                "libnpmsearch": "^2.0.2",
+                "libnpmteam": "^1.0.2",
+                "libnpx": "^10.2.0",
+                "lock-verify": "^2.1.0",
+                "lockfile": "^1.0.4",
+                "lodash._baseindexof": "*",
+                "lodash._baseuniq": "~4.6.0",
+                "lodash._bindcallback": "*",
+                "lodash._cacheindexof": "*",
+                "lodash._createcache": "*",
+                "lodash._getnative": "*",
+                "lodash.clonedeep": "~4.5.0",
+                "lodash.restparam": "*",
+                "lodash.union": "~4.6.0",
+                "lodash.uniq": "~4.5.0",
+                "lodash.without": "~4.4.0",
+                "lru-cache": "^5.1.1",
+                "meant": "~1.0.1",
+                "mississippi": "^3.0.0",
+                "mkdirp": "~0.5.1",
+                "move-concurrently": "^1.0.1",
+                "node-gyp": "^5.0.3",
+                "nopt": "~4.0.1",
+                "normalize-package-data": "^2.5.0",
+                "npm-audit-report": "^1.3.2",
+                "npm-cache-filename": "~1.0.2",
+                "npm-install-checks": "~3.0.0",
+                "npm-lifecycle": "^3.1.3",
+                "npm-package-arg": "^6.1.1",
+                "npm-packlist": "^1.4.4",
+                "npm-pick-manifest": "^3.0.2",
+                "npm-profile": "^4.0.2",
+                "npm-registry-fetch": "^4.0.0",
+                "npm-user-validate": "~1.0.0",
+                "npmlog": "~4.1.2",
+                "once": "~1.4.0",
+                "opener": "^1.5.1",
+                "osenv": "^0.1.5",
+                "pacote": "^9.5.8",
+                "path-is-inside": "~1.0.2",
+                "promise-inflight": "~1.0.1",
+                "qrcode-terminal": "^0.12.0",
+                "query-string": "^6.8.2",
+                "qw": "~1.0.1",
+                "read": "~1.0.7",
+                "read-cmd-shim": "^1.0.4",
+                "read-installed": "~4.0.3",
+                "read-package-json": "^2.1.0",
+                "read-package-tree": "^5.3.1",
+                "readable-stream": "^3.4.0",
+                "readdir-scoped-modules": "^1.1.0",
+                "request": "^2.88.0",
+                "retry": "^0.12.0",
+                "rimraf": "^2.6.3",
+                "safe-buffer": "^5.1.2",
+                "semver": "^5.7.1",
+                "sha": "^3.0.0",
+                "slide": "~1.1.6",
+                "sorted-object": "~2.0.1",
+                "sorted-union-stream": "~2.1.3",
+                "ssri": "^6.0.1",
+                "stringify-package": "^1.0.0",
+                "tar": "^4.4.10",
+                "text-table": "~0.2.0",
+                "tiny-relative-date": "^1.3.0",
+                "uid-number": "0.0.6",
+                "umask": "~1.1.0",
+                "unique-filename": "^1.1.1",
+                "unpipe": "~1.0.0",
+                "update-notifier": "^2.5.0",
+                "uuid": "^3.3.2",
+                "validate-npm-package-license": "^3.0.4",
+                "validate-npm-package-name": "~3.0.0",
+                "which": "^1.3.1",
+                "worker-farm": "^1.7.0",
+                "write-file-atomic": "^2.4.3"
+            },
+            "dependencies": {
+                "JSONStream": {
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "jsonparse": "^1.2.0",
+                        "through": ">=2.2.7 <3"
+                    }
+                },
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "agent-base": {
+                    "version": "4.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "es6-promisify": "^5.0.0"
+                    }
+                },
+                "agentkeepalive": {
+                    "version": "3.5.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "humanize-ms": "^1.2.1"
+                    }
+                },
+                "ajv": {
+                    "version": "5.5.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
+                    }
+                },
+                "ansi-align": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "ansicolors": {
+                    "version": "0.3.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansistyles": {
+                    "version": "0.1.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "archy": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "asap": {
+                    "version": "2.0.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "asn1": {
+                    "version": "0.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": "~2.1.0"
+                    }
+                },
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aws4": {
+                    "version": "1.8.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "^0.14.3"
+                    }
+                },
+                "bin-links": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "^3.5.3",
+                        "cmd-shim": "^3.0.0",
+                        "gentle-fs": "^2.0.1",
+                        "graceful-fs": "^4.1.15",
+                        "write-file-atomic": "^2.3.0"
+                    }
+                },
+                "bluebird": {
+                    "version": "3.5.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "boxen": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-align": "^2.0.0",
+                        "camelcase": "^4.0.0",
+                        "chalk": "^2.0.1",
+                        "cli-boxes": "^1.0.0",
+                        "string-width": "^2.0.0",
+                        "term-size": "^1.2.0",
+                        "widest-line": "^2.0.0"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-from": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "builtins": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "byline": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "byte-size": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cacache": {
+                    "version": "12.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "^3.5.5",
+                        "chownr": "^1.1.1",
+                        "figgy-pudding": "^3.5.1",
+                        "glob": "^7.1.4",
+                        "graceful-fs": "^4.1.15",
+                        "infer-owner": "^1.0.3",
+                        "lru-cache": "^5.1.1",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "move-concurrently": "^1.0.1",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^2.6.3",
+                        "ssri": "^6.0.1",
+                        "unique-filename": "^1.1.1",
+                        "y18n": "^4.0.0"
+                    }
+                },
+                "call-limit": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "capture-stack-trace": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "chownr": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ci-info": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cidr-regex": {
+                    "version": "2.0.10",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ip-regex": "^2.1.0"
+                    }
+                },
+                "cli-boxes": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cli-columns": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.0.0",
+                        "strip-ansi": "^3.0.1"
+                    }
+                },
+                "cli-table3": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "colors": "^1.1.2",
+                        "object-assign": "^4.1.0",
+                        "string-width": "^2.1.1"
+                    }
+                },
+                "cliui": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "clone": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cmd-shim": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "mkdirp": "~0.5.0"
+                    }
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "color-convert": {
+                    "version": "1.9.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "color-name": "^1.1.1"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "colors": {
+                    "version": "1.3.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "columnify": {
+                    "version": "1.5.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "strip-ansi": "^3.0.0",
+                        "wcwidth": "^1.0.0"
+                    }
+                },
+                "combined-stream": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "~1.0.0"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-stream": {
+                    "version": "1.6.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "config-chain": {
+                    "version": "1.1.12",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ini": "^1.3.4",
+                        "proto-list": "~1.2.1"
+                    }
+                },
+                "configstore": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "dot-prop": "^4.1.0",
+                        "graceful-fs": "^4.1.2",
+                        "make-dir": "^1.0.0",
+                        "unique-string": "^1.0.0",
+                        "write-file-atomic": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
+                    }
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "copy-concurrently": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.1.1",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "iferr": "^0.1.5",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "iferr": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "create-error-class": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "capture-stack-trace": "^1.0.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    },
+                    "dependencies": {
+                        "lru-cache": {
+                            "version": "4.1.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "pseudomap": "^1.0.2",
+                                "yallist": "^2.1.2"
+                            }
+                        },
+                        "yallist": {
+                            "version": "2.1.2",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "crypto-random-string": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cyclist": {
+                    "version": "0.2.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "debuglog": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "decode-uri-component": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "deep-extend": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "defaults": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "clone": "^1.0.2"
+                    }
+                },
+                "define-properties": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "object-keys": "^1.0.12"
+                    }
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "detect-indent": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "detect-newline": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "dezalgo": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "asap": "^2.0.0",
+                        "wrappy": "1"
+                    }
+                },
+                "dot-prop": {
+                    "version": "4.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-obj": "^1.0.0"
+                    }
+                },
+                "dotenv": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "duplexer3": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "duplexify": {
+                    "version": "3.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "~0.1.0",
+                        "safer-buffer": "^2.1.0"
+                    }
+                },
+                "editor": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "encoding": {
+                    "version": "0.1.12",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "iconv-lite": "~0.4.13"
+                    }
+                },
+                "end-of-stream": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.4.0"
+                    }
+                },
+                "env-paths": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "err-code": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "errno": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "prr": "~1.0.1"
+                    }
+                },
+                "es-abstract": {
+                    "version": "1.12.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.1.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.1",
+                        "is-callable": "^1.1.3",
+                        "is-regex": "^1.0.4"
+                    }
+                },
+                "es-to-primitive": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-callable": "^1.1.4",
+                        "is-date-object": "^1.0.1",
+                        "is-symbol": "^1.0.2"
+                    }
+                },
+                "es6-promise": {
+                    "version": "4.2.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "es6-promisify": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "es6-promise": "^4.0.3"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "get-stream": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "extend": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "extsprintf": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fast-deep-equal": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fast-json-stable-stringify": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "figgy-pudding": {
+                    "version": "3.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "find-npm-prefix": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "flush-write-stream": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "form-data": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "from2": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "fs-minipass": {
+                    "version": "1.2.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "fs-vacuum": {
+                    "version": "1.2.10",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "path-is-inside": "^1.0.1",
+                        "rimraf": "^2.5.2"
+                    }
+                },
+                "fs-write-stream-atomic": {
+                    "version": "1.0.10",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "iferr": "^0.1.5",
+                        "imurmurhash": "^0.1.4",
+                        "readable-stream": "1 || 2"
+                    },
+                    "dependencies": {
+                        "iferr": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "function-bind": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    },
+                    "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "genfun": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "gentle-fs": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.1.2",
+                        "chownr": "^1.1.2",
+                        "fs-vacuum": "^1.2.10",
+                        "graceful-fs": "^4.1.11",
+                        "iferr": "^0.1.5",
+                        "infer-owner": "^1.0.4",
+                        "mkdirp": "^0.5.1",
+                        "path-is-inside": "^1.0.2",
+                        "read-cmd-shim": "^1.0.1",
+                        "slide": "^1.1.6"
+                    },
+                    "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "iferr": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "get-caller-file": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "global-dirs": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ini": "^1.3.4"
+                    }
+                },
+                "got": {
+                    "version": "6.7.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "get-stream": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "har-schema": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "har-validator": {
+                    "version": "5.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^5.3.0",
+                        "har-schema": "^2.0.0"
+                    }
+                },
+                "has": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "^1.1.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "has-symbols": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "hosted-git-info": {
+                    "version": "2.8.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^5.1.1"
+                    }
+                },
+                "http-cache-semantics": {
+                    "version": "3.8.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "http-proxy-agent": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "4",
+                        "debug": "3.1.0"
+                    }
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "2.2.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^4.3.0",
+                        "debug": "^3.1.0"
+                    }
+                },
+                "humanize-ms": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.0.0"
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.4.23",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                },
+                "iferr": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "import-lazy": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "infer-owner": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "init-package-json": {
+                    "version": "1.10.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.1",
+                        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+                        "promzard": "^0.3.0",
+                        "read": "~1.0.1",
+                        "read-package-json": "1 || 2",
+                        "semver": "2.x || 3.x || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1",
+                        "validate-npm-package-name": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ip": {
+                    "version": "1.1.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ip-regex": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-callable": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-ci": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "ci-info": {
+                            "version": "1.6.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "is-cidr": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cidr-regex": "^2.0.10"
+                    }
+                },
+                "is-date-object": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "is-installed-globally": {
+                    "version": "0.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "global-dirs": "^0.1.0",
+                        "is-path-inside": "^1.0.0"
+                    }
+                },
+                "is-npm": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-obj": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-path-inside": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-is-inside": "^1.0.1"
+                    }
+                },
+                "is-redirect": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "has": "^1.0.1"
+                    }
+                },
+                "is-retry-allowed": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-symbol": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.0"
+                    }
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isexe": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-parse-better-errors": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.3.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "jsonparse": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "jsprim": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.3.0",
+                        "json-schema": "0.2.3",
+                        "verror": "1.10.0"
+                    }
+                },
+                "latest-version": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "package-json": "^4.0.0"
+                    }
+                },
+                "lazy-property": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^1.0.0"
+                    }
+                },
+                "libcipm": {
+                    "version": "4.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "bin-links": "^1.1.2",
+                        "bluebird": "^3.5.1",
+                        "figgy-pudding": "^3.5.1",
+                        "find-npm-prefix": "^1.0.2",
+                        "graceful-fs": "^4.1.11",
+                        "ini": "^1.3.5",
+                        "lock-verify": "^2.0.2",
+                        "mkdirp": "^0.5.1",
+                        "npm-lifecycle": "^3.0.0",
+                        "npm-logical-tree": "^1.2.1",
+                        "npm-package-arg": "^6.1.0",
+                        "pacote": "^9.1.0",
+                        "read-package-json": "^2.0.13",
+                        "rimraf": "^2.6.2",
+                        "worker-farm": "^1.6.0"
+                    }
+                },
+                "libnpm": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "bin-links": "^1.1.2",
+                        "bluebird": "^3.5.3",
+                        "find-npm-prefix": "^1.0.2",
+                        "libnpmaccess": "^3.0.2",
+                        "libnpmconfig": "^1.2.1",
+                        "libnpmhook": "^5.0.3",
+                        "libnpmorg": "^1.0.1",
+                        "libnpmpublish": "^1.1.2",
+                        "libnpmsearch": "^2.0.2",
+                        "libnpmteam": "^1.0.2",
+                        "lock-verify": "^2.0.2",
+                        "npm-lifecycle": "^3.0.0",
+                        "npm-logical-tree": "^1.2.1",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-profile": "^4.0.2",
+                        "npm-registry-fetch": "^4.0.0",
+                        "npmlog": "^4.1.2",
+                        "pacote": "^9.5.3",
+                        "read-package-json": "^2.0.13",
+                        "stringify-package": "^1.0.0"
+                    }
+                },
+                "libnpmaccess": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "get-stream": "^4.0.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpmconfig": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "figgy-pudding": "^3.5.1",
+                        "find-up": "^3.0.0",
+                        "ini": "^1.3.5"
+                    },
+                    "dependencies": {
+                        "find-up": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "locate-path": "^3.0.0"
+                            }
+                        },
+                        "locate-path": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "p-locate": "^3.0.0",
+                                "path-exists": "^3.0.0"
+                            }
+                        },
+                        "p-limit": {
+                            "version": "2.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "p-try": "^2.0.0"
+                            }
+                        },
+                        "p-locate": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "p-limit": "^2.0.0"
+                            }
+                        },
+                        "p-try": {
+                            "version": "2.2.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "libnpmhook": {
+                    "version": "5.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpmorg": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpmpublish": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.0.0",
+                        "lodash.clonedeep": "^4.5.0",
+                        "normalize-package-data": "^2.4.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-registry-fetch": "^4.0.0",
+                        "semver": "^5.5.1",
+                        "ssri": "^6.0.1"
+                    }
+                },
+                "libnpmsearch": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpmteam": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpx": {
+                    "version": "10.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "dotenv": "^5.0.1",
+                        "npm-package-arg": "^6.0.0",
+                        "rimraf": "^2.6.2",
+                        "safe-buffer": "^5.1.0",
+                        "update-notifier": "^2.3.0",
+                        "which": "^1.3.0",
+                        "y18n": "^4.0.0",
+                        "yargs": "^11.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "lock-verify": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "npm-package-arg": "^6.1.0",
+                        "semver": "^5.4.1"
+                    }
+                },
+                "lockfile": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "lodash._baseindexof": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash._baseuniq": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lodash._createset": "~4.0.0",
+                        "lodash._root": "~3.0.0"
+                    }
+                },
+                "lodash._bindcallback": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash._cacheindexof": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash._createcache": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lodash._getnative": "^3.0.0"
+                    }
+                },
+                "lodash._createset": {
+                    "version": "4.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash._getnative": {
+                    "version": "3.9.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash._root": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.clonedeep": {
+                    "version": "4.5.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.restparam": {
+                    "version": "3.6.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.union": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.uniq": {
+                    "version": "4.5.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.without": {
+                    "version": "4.4.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lowercase-keys": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "5.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "make-dir": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "make-fetch-happen": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agentkeepalive": "^3.4.1",
+                        "cacache": "^12.0.0",
+                        "http-cache-semantics": "^3.8.1",
+                        "http-proxy-agent": "^2.1.0",
+                        "https-proxy-agent": "^2.2.1",
+                        "lru-cache": "^5.1.1",
+                        "mississippi": "^3.0.0",
+                        "node-fetch-npm": "^2.0.2",
+                        "promise-retry": "^1.1.1",
+                        "socks-proxy-agent": "^4.0.0",
+                        "ssri": "^6.0.0"
+                    }
+                },
+                "meant": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mem": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "mime-db": {
+                    "version": "1.35.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.19",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "~1.35.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minipass": {
+                    "version": "2.3.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "yallist": {
+                            "version": "3.0.2",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "minizlib": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "mississippi": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^3.0.0",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "move-concurrently": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.1.1",
+                        "copy-concurrently": "^1.0.0",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.3"
+                    },
+                    "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mute-stream": {
+                    "version": "0.0.7",
+                    "bundled": true,
+                    "dev": true
+                },
+                "node-fetch-npm": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "encoding": "^0.1.11",
+                        "json-parse-better-errors": "^1.0.0",
+                        "safe-buffer": "^5.1.1"
+                    }
+                },
+                "node-gyp": {
+                    "version": "5.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "env-paths": "^1.0.0",
+                        "glob": "^7.0.3",
+                        "graceful-fs": "^4.1.2",
+                        "mkdirp": "^0.5.0",
+                        "nopt": "2 || 3",
+                        "npmlog": "0 || 1 || 2 || 3 || 4",
+                        "request": "^2.87.0",
+                        "rimraf": "2",
+                        "semver": "~5.3.0",
+                        "tar": "^4.4.8",
+                        "which": "1"
+                    },
+                    "dependencies": {
+                        "nopt": {
+                            "version": "3.0.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "abbrev": "1"
+                            }
+                        },
+                        "semver": {
+                            "version": "5.3.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                },
+                "normalize-package-data": {
+                    "version": "2.5.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^2.1.4",
+                        "resolve": "^1.10.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "resolve": {
+                            "version": "1.10.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "path-parse": "^1.0.6"
+                            }
+                        }
+                    }
+                },
+                "npm-audit-report": {
+                    "version": "1.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cli-table3": "^0.5.0",
+                        "console-control-strings": "^1.1.0"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "npm-cache-filename": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "npm-install-checks": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "semver": "^2.3.0 || 3.x || 4 || 5"
+                    }
+                },
+                "npm-lifecycle": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "byline": "^5.0.0",
+                        "graceful-fs": "^4.1.15",
+                        "node-gyp": "^5.0.2",
+                        "resolve-from": "^4.0.0",
+                        "slide": "^1.1.6",
+                        "uid-number": "0.0.6",
+                        "umask": "^1.1.0",
+                        "which": "^1.3.1"
+                    }
+                },
+                "npm-logical-tree": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "npm-package-arg": {
+                    "version": "6.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^2.7.1",
+                        "osenv": "^0.1.5",
+                        "semver": "^5.6.0",
+                        "validate-npm-package-name": "^3.0.0"
+                    }
+                },
+                "npm-packlist": {
+                    "version": "1.4.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
+                    }
+                },
+                "npm-pick-manifest": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "figgy-pudding": "^3.5.1",
+                        "npm-package-arg": "^6.0.0",
+                        "semver": "^5.4.1"
+                    }
+                },
+                "npm-profile": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.1.2 || 2",
+                        "figgy-pudding": "^3.4.1",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "npm-registry-fetch": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "JSONStream": "^1.3.4",
+                        "bluebird": "^3.5.1",
+                        "figgy-pudding": "^3.4.1",
+                        "lru-cache": "^5.1.1",
+                        "make-fetch-happen": "^5.0.0",
+                        "npm-package-arg": "^6.1.0"
+                    }
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^2.0.0"
+                    }
+                },
+                "npm-user-validate": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "oauth-sign": {
+                    "version": "0.9.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "object-keys": {
+                    "version": "1.0.12",
+                    "bundled": true,
+                    "dev": true
+                },
+                "object.getownpropertydescriptors": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "define-properties": "^1.1.2",
+                        "es-abstract": "^1.5.1"
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "opener": {
+                    "version": "1.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
+                    }
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
+                    }
+                },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "package-json": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "got": "^6.7.1",
+                        "registry-auth-token": "^3.0.1",
+                        "registry-url": "^3.0.3",
+                        "semver": "^5.1.0"
+                    }
+                },
+                "pacote": {
+                    "version": "9.5.8",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "^3.5.3",
+                        "cacache": "^12.0.2",
+                        "chownr": "^1.1.2",
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.1.0",
+                        "glob": "^7.1.3",
+                        "infer-owner": "^1.0.4",
+                        "lru-cache": "^5.1.1",
+                        "make-fetch-happen": "^5.0.0",
+                        "minimatch": "^3.0.4",
+                        "minipass": "^2.3.5",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "normalize-package-data": "^2.4.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-packlist": "^1.1.12",
+                        "npm-pick-manifest": "^3.0.0",
+                        "npm-registry-fetch": "^4.0.0",
+                        "osenv": "^0.1.5",
+                        "promise-inflight": "^1.0.1",
+                        "promise-retry": "^1.1.1",
+                        "protoduck": "^5.0.1",
+                        "rimraf": "^2.6.2",
+                        "safe-buffer": "^5.1.2",
+                        "semver": "^5.6.0",
+                        "ssri": "^6.0.1",
+                        "tar": "^4.4.10",
+                        "unique-filename": "^1.1.1",
+                        "which": "^1.3.1"
+                    },
+                    "dependencies": {
+                        "minipass": {
+                            "version": "2.3.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "parallel-transform": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-is-inside": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-parse": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "prepend-http": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "promise-inflight": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "promise-retry": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "err-code": "^1.0.0",
+                        "retry": "^0.10.0"
+                    },
+                    "dependencies": {
+                        "retry": {
+                            "version": "0.10.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "promzard": {
+                    "version": "0.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "read": "1"
+                    }
+                },
+                "proto-list": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "protoduck": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "genfun": "^5.0.0"
+                    }
+                },
+                "prr": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "psl": {
+                    "version": "1.1.29",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pump": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                },
+                "pumpify": {
+                    "version": "1.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "duplexify": "^3.6.0",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "pump": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "end-of-stream": "^1.1.0",
+                                "once": "^1.3.1"
+                            }
+                        }
+                    }
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "qrcode-terminal": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "query-string": {
+                    "version": "6.8.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "decode-uri-component": "^0.2.0",
+                        "split-on-first": "^1.0.0",
+                        "strict-uri-encode": "^2.0.0"
+                    }
+                },
+                "qw": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "rc": {
+                    "version": "1.2.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "read": {
+                    "version": "1.0.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mute-stream": "~0.0.4"
+                    }
+                },
+                "read-cmd-shim": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2"
+                    }
+                },
+                "read-installed": {
+                    "version": "4.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "debuglog": "^1.0.1",
+                        "graceful-fs": "^4.1.2",
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "slide": "~1.1.3",
+                        "util-extend": "^1.0.1"
+                    }
+                },
+                "read-package-json": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "json-parse-better-errors": "^1.0.1",
+                        "normalize-package-data": "^2.0.0",
+                        "slash": "^1.0.0"
+                    }
+                },
+                "read-package-tree": {
+                    "version": "5.3.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0",
+                        "util-promisify": "^2.1.0"
+                    }
+                },
+                "readable-stream": {
+                    "version": "3.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "readdir-scoped-modules": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "graceful-fs": "^4.1.2",
+                        "once": "^1.3.0"
+                    }
+                },
+                "registry-auth-token": {
+                    "version": "3.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "rc": "^1.1.6",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "registry-url": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "rc": "^1.0.1"
+                    }
+                },
+                "request": {
+                    "version": "2.88.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
+                    }
+                },
+                "require-directory": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "retry": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "run-queue": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.1.1"
+                    },
+                    "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver-diff": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "semver": "^5.0.3"
+                    }
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "sha": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2"
+                    }
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "slash": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "slide": {
+                    "version": "1.1.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "smart-buffer": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "socks": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ip": "^1.1.5",
+                        "smart-buffer": "4.0.2"
+                    }
+                },
+                "socks-proxy-agent": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "~4.2.1",
+                        "socks": "~2.3.2"
+                    },
+                    "dependencies": {
+                        "agent-base": {
+                            "version": "4.2.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "es6-promisify": "^5.0.0"
+                            }
+                        }
+                    }
+                },
+                "sorted-object": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "sorted-union-stream": {
+                    "version": "2.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "from2": "^1.3.0",
+                        "stream-iterate": "^1.1.0"
+                    },
+                    "dependencies": {
+                        "from2": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "inherits": "~2.0.1",
+                                "readable-stream": "~1.1.10"
+                            }
+                        },
+                        "isarray": {
+                            "version": "0.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "1.1.14",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
+                                "isarray": "0.0.1",
+                                "string_decoder": "~0.10.x"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "0.10.31",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "spdx-correct": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-expression-parse": "^3.0.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-exceptions": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "spdx-expression-parse": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-license-ids": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "split-on-first": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "sshpk": {
+                    "version": "1.14.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jsbn": "~0.1.0",
+                        "safer-buffer": "^2.0.2",
+                        "tweetnacl": "~0.14.0"
+                    }
+                },
+                "ssri": {
+                    "version": "6.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "figgy-pudding": "^3.5.1"
+                    }
+                },
+                "stream-each": {
+                    "version": "1.2.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
+                    }
+                },
+                "stream-iterate": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "^2.1.5",
+                        "stream-shift": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "stream-shift": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "strict-uri-encode": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "stringify-package": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "tar": {
+                    "version": "4.4.10",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "chownr": "^1.1.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.3.5",
+                        "minizlib": "^1.2.1",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.3"
+                    },
+                    "dependencies": {
+                        "minipass": {
+                            "version": "2.3.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
+                            }
+                        },
+                        "yallist": {
+                            "version": "3.0.3",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "term-size": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "execa": "^0.7.0"
+                    }
+                },
+                "text-table": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "through": {
+                    "version": "2.3.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "timed-out": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "tiny-relative-date": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "typedarray": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "umask": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "unique-filename": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "unique-slug": "^2.0.0"
+                    }
+                },
+                "unique-slug": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "imurmurhash": "^0.1.4"
+                    }
+                },
+                "unique-string": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "crypto-random-string": "^1.0.0"
+                    }
+                },
+                "unpipe": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "unzip-response": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "update-notifier": {
+                    "version": "2.5.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boxen": "^1.2.1",
+                        "chalk": "^2.0.1",
+                        "configstore": "^3.0.0",
+                        "import-lazy": "^2.1.0",
+                        "is-ci": "^1.0.10",
+                        "is-installed-globally": "^0.1.0",
+                        "is-npm": "^1.0.0",
+                        "latest-version": "^3.0.0",
+                        "semver-diff": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
+                    }
+                },
+                "url-parse-lax": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "prepend-http": "^1.0.1"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "util-extend": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "util-promisify": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "object.getownpropertydescriptors": "^2.0.3"
+                    }
+                },
+                "uuid": {
+                    "version": "3.3.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "validate-npm-package-license": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-correct": "^3.0.0",
+                        "spdx-expression-parse": "^3.0.0"
+                    }
+                },
+                "validate-npm-package-name": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "builtins": "^1.0.3"
+                    }
+                },
+                "verror": {
+                    "version": "1.10.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "^1.2.0"
+                    }
+                },
+                "wcwidth": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "defaults": "^1.0.3"
+                    }
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^1.0.2"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "widest-line": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1"
+                    }
+                },
+                "worker-farm": {
+                    "version": "1.7.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "errno": "~0.1.7"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "write-file-atomic": {
+                    "version": "2.4.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "xdg-basedir": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "xtend": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "11.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
+                    },
+                    "dependencies": {
+                        "y18n": {
+                            "version": "3.2.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "yargs-parser": {
+                    "version": "9.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^4.1.0"
+                    }
+                }
+            }
+        },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -6656,6 +12156,12 @@
                 "isobject": "^3.0.1"
             }
         },
+        "octokit-pagination-methods": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+            "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+            "dev": true
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6737,6 +12243,22 @@
                 "mem": "^4.0.0"
             }
         },
+        "os-name": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+            "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+            "dev": true,
+            "requires": {
+                "macos-release": "^2.2.0",
+                "windows-release": "^3.1.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
         "p-defer": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -6750,6 +12272,23 @@
             "dev": true,
             "requires": {
                 "p-reduce": "^1.0.0"
+            }
+        },
+        "p-filter": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+            "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+            "dev": true,
+            "requires": {
+                "p-map": "^2.0.0"
+            },
+            "dependencies": {
+                "p-map": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+                    "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+                    "dev": true
+                }
             }
         },
         "p-finally": {
@@ -6797,6 +12336,16 @@
             "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
             "dev": true
         },
+        "p-retry": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.1.0.tgz",
+            "integrity": "sha512-oepllyG9gX1qH4Sm20YAKxg1GA7L7puhvGnTfimi31P07zSIj7SDV6YtuAx9nbJF51DES+2CIIRkXs8GKqWJxA==",
+            "dev": true,
+            "requires": {
+                "@types/retry": "^0.12.0",
+                "retry": "^0.12.0"
+            }
+        },
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -6818,6 +12367,23 @@
                 "cyclist": "^1.0.1",
                 "inherits": "^2.0.3",
                 "readable-stream": "^2.1.5"
+            }
+        },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            },
+            "dependencies": {
+                "callsites": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+                    "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+                    "dev": true
+                }
             }
         },
         "parse-asn1": {
@@ -6847,6 +12413,12 @@
                 "is-decimal": "^1.0.0",
                 "is-hexadecimal": "^1.0.0"
             }
+        },
+        "parse-github-url": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+            "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
+            "dev": true
         },
         "parse-json": {
             "version": "4.0.0",
@@ -6980,6 +12552,67 @@
             "dev": true,
             "requires": {
                 "node-modules-regexp": "^1.0.0"
+            }
+        },
+        "pkg-conf": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+            "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+            "dev": true,
+            "requires": {
+                "find-up": "^2.0.0",
+                "load-json-file": "^4.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                }
             }
         },
         "pkg-dir": {
@@ -7305,6 +12938,12 @@
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
             "dev": true
         },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -7346,6 +12985,18 @@
             "requires": {
                 "randombytes": "^2.0.5",
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             }
         },
         "react-is": {
@@ -7472,6 +13123,15 @@
                 "util.promisify": "^1.0.0"
             }
         },
+        "rechoir": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true,
+            "requires": {
+                "resolve": "^1.1.6"
+            }
+        },
         "redent": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -7482,6 +13142,21 @@
                 "strip-indent": "^2.0.0"
             }
         },
+        "redeyed": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+            "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+            "dev": true,
+            "requires": {
+                "esprima": "~4.0.0"
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+            "dev": true
+        },
         "regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -7490,6 +13165,16 @@
             "requires": {
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
+            }
+        },
+        "registry-auth-token": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+            "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+            "dev": true,
+            "requires": {
+                "rc": "^1.2.8",
+                "safe-buffer": "^5.0.1"
             }
         },
         "remark": {
@@ -7710,6 +13395,15 @@
             "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
             "dev": true
         },
+        "resolve-global": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+            "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+            "dev": true,
+            "requires": {
+                "global-dirs": "^0.1.1"
+            }
+        },
         "resolve-url": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -7749,10 +13443,22 @@
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "dev": true
         },
+        "retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+            "dev": true
+        },
         "reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
+        },
+        "right-pad": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
+            "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
             "dev": true
         },
         "rimraf": {
@@ -7779,6 +13485,15 @@
             "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
             "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
             "dev": true
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
+            "requires": {
+                "is-promise": "^2.1.0"
+            }
         },
         "run-node": {
             "version": "1.0.0",
@@ -7865,6 +13580,191 @@
                 "ajv-keywords": "^3.1.0"
             }
         },
+        "semantic-release": {
+            "version": "15.13.24",
+            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.13.24.tgz",
+            "integrity": "sha512-OPshm6HSp+KmZP9dUv1o3MRILDgOeHYWPI+XSpQRERMri7QkaEiIPkZzoNm2d6KDeFDnp03GphQQS4+Zfo+x/Q==",
+            "dev": true,
+            "requires": {
+                "@semantic-release/commit-analyzer": "^6.1.0",
+                "@semantic-release/error": "^2.2.0",
+                "@semantic-release/github": "^5.1.0",
+                "@semantic-release/npm": "^5.0.5",
+                "@semantic-release/release-notes-generator": "^7.1.2",
+                "aggregate-error": "^3.0.0",
+                "cosmiconfig": "^5.0.1",
+                "debug": "^4.0.0",
+                "env-ci": "^4.0.0",
+                "execa": "^1.0.0",
+                "figures": "^3.0.0",
+                "find-versions": "^3.0.0",
+                "get-stream": "^5.0.0",
+                "git-log-parser": "^1.2.0",
+                "hook-std": "^2.0.0",
+                "hosted-git-info": "^3.0.0",
+                "lodash": "^4.17.15",
+                "marked": "^0.7.0",
+                "marked-terminal": "^3.2.0",
+                "p-locate": "^4.0.0",
+                "p-reduce": "^2.0.0",
+                "read-pkg-up": "^6.0.0",
+                "resolve-from": "^5.0.0",
+                "semver": "^6.0.0",
+                "signale": "^1.2.1",
+                "yargs": "^14.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "figures": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+                    "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "hosted-git-info": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.0.tgz",
+                    "integrity": "sha512-zYSx1cP4MLsvKtTg8DF/PI6e6FHZ3wcawcTGsrLU2TM+UfD4jmSrn2wdQT16TFbH3lO4PIdjLG0E+cuYDgFD9g==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^5.1.1"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "p-locate": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                            "dev": true,
+                            "requires": {
+                                "p-limit": "^2.0.0"
+                            }
+                        }
+                    }
+                },
+                "lru-cache": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "p-reduce": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+                    "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "read-pkg-up": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-6.0.0.tgz",
+                    "integrity": "sha512-odtTvLl+EXo1eTsMnoUHRmg/XmXdTkwXVxy4VFE9Kp6cCq7b3l7QMdBndND3eAFzrbSAXC/WCUOQQ9rLjifKZw==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^4.0.0",
+                        "read-pkg": "^5.1.1",
+                        "type-fest": "^0.5.0"
+                    }
+                },
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "type-fest": {
+                    "version": "0.5.2",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+                    "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "14.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.0.0.tgz",
+                    "integrity": "sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.1"
+                    },
+                    "dependencies": {
+                        "find-up": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                            "dev": true,
+                            "requires": {
+                                "locate-path": "^3.0.0"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "semver": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -7875,6 +13775,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+            "dev": true
+        },
+        "semver-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+            "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
             "dev": true
         },
         "serialize-javascript": {
@@ -7943,6 +13849,17 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
+        "shelljs": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
+            "integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
+            }
+        },
         "shellwords": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -7960,6 +13877,28 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
+        },
+        "signale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+            "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.3.2",
+                "figures": "^2.0.0",
+                "pkg-conf": "^2.1.0"
+            },
+            "dependencies": {
+                "figures": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+                    "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5"
+                    }
+                }
+            }
         },
         "sisteransi": {
             "version": "1.0.3",
@@ -8133,6 +14072,12 @@
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
             "dev": true
         },
+        "spawn-error-forwarder": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+            "integrity": "sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk=",
+            "dev": true
+        },
         "spdx-correct": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -8171,6 +14116,15 @@
             "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
             "dev": true
         },
+        "split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "dev": true,
+            "requires": {
+                "through": "2"
+            }
+        },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -8178,6 +14132,15 @@
             "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
+            }
+        },
+        "split2": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+            "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+            "dev": true,
+            "requires": {
+                "through2": "^2.0.2"
             }
         },
         "sprintf-js": {
@@ -8258,6 +14221,16 @@
             "dev": true,
             "requires": {
                 "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "stream-combiner2": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "~0.1.0",
                 "readable-stream": "^2.0.2"
             }
         },
@@ -8417,6 +14390,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
             "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true
         },
         "style-search": {
@@ -8698,6 +14677,24 @@
                 "has-flag": "^3.0.0"
             }
         },
+        "supports-hyperlinks": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+            "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^2.0.0",
+                "supports-color": "^5.0.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                    "dev": true
+                }
+            }
+        },
         "svg-tags": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
@@ -8787,10 +14784,22 @@
                 "require-main-filename": "^2.0.0"
             }
         },
+        "text-extensions": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+            "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+            "dev": true
+        },
         "throat": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
             "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
         "through2": {
@@ -8810,6 +14819,15 @@
             "dev": true,
             "requires": {
                 "setimmediate": "^1.0.4"
+            }
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "~1.0.2"
             }
         },
         "tmpl": {
@@ -8891,6 +14909,12 @@
                 "punycode": "^2.1.0"
             }
         },
+        "traverse": {
+            "version": "0.6.6",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+            "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+            "dev": true
+        },
         "trim": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -8901,6 +14925,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
             "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+            "dev": true
+        },
+        "trim-off-newlines": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+            "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
             "dev": true
         },
         "trim-right": {
@@ -9458,6 +15488,21 @@
                 "unist-util-is": "^3.0.0"
             }
         },
+        "universal-user-agent": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
+            "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+            "dev": true,
+            "requires": {
+                "os-name": "^3.1.0"
+            }
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
+        },
         "unset-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -9536,6 +15581,12 @@
                     "dev": true
                 }
             }
+        },
+        "url-join": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+            "dev": true
         },
         "use": {
             "version": "3.1.1",
@@ -9862,6 +15913,21 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "windows-release": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+            "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+            "dev": true,
+            "requires": {
+                "execa": "^1.0.0"
+            }
+        },
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true
         },
         "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@coveord/platform-client",
-    "version": "0.0.0",
+    "version": "0.0.0-development",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/definitions/CoveoPlatform.d.ts",
@@ -9,16 +9,22 @@
         "build": "webpack --mode production",
         "test": "jest",
         "test:changed": "jest --watch",
-        "test:watch": "jest --watchAll"
+        "test:watch": "jest --watchAll",
+        "release": "semantic-release"
     },
     "devDependencies": {
+        "@commitlint/cli": "^8.2.0",
+        "@commitlint/config-conventional": "^8.2.0",
+        "@commitlint/travis-cli": "^8.2.0",
         "@types/jest": "^24.0.18",
         "clean-webpack-plugin": "^3.0.0",
+        "cz-conventional-changelog": "^3.0.2",
         "husky": "^3.0.5",
         "jest": "^24.9.0",
         "jest-fetch-mock": "^2.1.2",
         "lint-staged": "^9.2.5",
         "prettier": "^1.18.2",
+        "semantic-release": "^15.13.24",
         "ts-jest": "^24.0.2",
         "ts-loader": "^6.0.4",
         "tsjs": "^1.0.1",
@@ -30,7 +36,9 @@
     "prettier": "tsjs/prettier-config",
     "husky": {
         "hooks": {
-            "pre-commit": "lint-staged"
+            "pre-commit": "lint-staged",
+            "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+            "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true"
         }
     },
     "lint-staged": {
@@ -46,12 +54,17 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/coveo/platform-client.git"
+        "url": "https://github.com/coveo/platform-client.git"
     },
     "author": "Coveo",
     "license": "Apache-2.0",
     "homepage": "https://github.com/coveo/platform-client#readme",
     "files": [
         "/dist"
-    ]
+    ],
+    "config": {
+        "commitizen": {
+            "path": "./node_modules/cz-conventional-changelog"
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
             "tslint -c ./tslint.json -p ./tsconfig.json --fix",
             "git add"
         ],
-        "**/*.{js,jsx,json,md,yml}": [
+        "**/*.{js,jsx,json}": [
             "prettier --write",
             "git add"
         ]


### PR DESCRIPTION
Configured the [semantic-release package](https://github.com/semantic-release/semantic-release).

### Changes
- Travis CI will now automatically release in npm, create tags in github and generate changelogs based on the commit messages.
- The [conventional commit messages format](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) will be enforced by [commitlint](https://github.com/conventional-changelog/commitlint)
- To facilitate writing commit messages that follow the required format, I added [commitzen](https://github.com/commitizen/cz-cli)

### What will it change in the development workflow?
- Commitzen is configured to hook onto the `git commit` command so if you were working with the command line, it changes nothing in your workflow other than the new CLI asking you questions.
- If you were using any GUI based tool to write you commit messages such as Sourcetree, VSCode, GitKraken, Github Desktop, etc., there is no guarantee that Commitzen will work out of the box. You will either have to find an extension for it or write manually commit messages that respects the format.