### PR TITLE
feat: custom response handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,30 @@ This project is built using TypeScript and automatically generates relevant type
 | `organizationId`       | yes      | undefined                            | The unique identifier of the target organization.                                                                                                |
 | `environment`          | optional | `'production'`                       | The target environment. If one of following: `'development'`, `'staging'`, `'production'`, `'hipaa'`; automatically targets the associated host. |
 | `host`                 | optional | `'https://platform.cloud.coveo.com'` | The target host. Useful to target local hosts when testing.                                                                                      |
+| `responseHandlers`     | optional | []                                   | Custom server response handlers. See [error handling section](#error-handling) for detailed explanation.                                         |
+
+### Error handling
+
+Each request made by the `platform-client`, once resolved or rejected, gets processed by one (and only one) of the response handlers. Some very basic response handlers are used by default, but you can override their behavior by specifying your own in the `responseHandlers` [configuration option](#configuration-option). The order in which they are specified defines their priority. Meaning that the first handler of the array that can process the response is used to do so.
+
+A response handler is defined as such:
+
+```ts
+interface IRestResponseHandler {
+    canProcess(response: Response): boolean; // whether the handler should be used to process the response
+    process<T>(response: Response): Promise<IRestResponse<T>>; // defines how the handler processes the response
+}
+```
+
+Example
+
+```ts
+const MySuccessResponseHandler: IRestResponseHandler = {
+    canProcess: (response: Response): boolean => response.ok;
+    process: async <T>(response: Response): Promise<IRestResponse<T>> => {
+        const data = await response.json();
+        console.log(data);
+        return data;
+    };
+}
+```

--- a/src/tests/CoveoPlatform.spec.ts
+++ b/src/tests/CoveoPlatform.spec.ts
@@ -7,16 +7,13 @@ jest.mock('../APICore');
 const APIMock: jest.Mock<API> = API as any;
 
 describe('CoveoPlatform', () => {
-    const tokenRetriever = jest.fn(() => 'my-token');
-
     const baseOptions: CoveoPlatformOptions = {
-        accessTokenRetriever: tokenRetriever,
+        accessTokenRetriever: jest.fn(() => 'my-token'),
         organizationId: 'some-org',
     };
 
     beforeEach(() => {
-        global.fetch.resetMocks();
-        tokenRetriever.mockClear();
+        jest.clearAllMocks();
         APIMock.mockClear();
     });
 
@@ -34,35 +31,47 @@ describe('CoveoPlatform', () => {
     test('the API uses the production host if no environment option is provided', () => {
         new CoveoPlatform(baseOptions);
         expect(APIMock).toHaveBeenCalledWith(
-            CoveoPlatform.Hosts[CoveoPlatform.Environments.prod],
-            expect.anything(),
-            expect.anything()
+            expect.objectContaining({
+                host: CoveoPlatform.Hosts[CoveoPlatform.Environments.prod],
+            })
         );
     });
 
     test('the API uses the host associated with the environment specified in the options', () => {
         new CoveoPlatform({...baseOptions, environment: CoveoPlatform.Environments.dev});
         expect(APIMock).toHaveBeenCalledWith(
-            CoveoPlatform.Hosts[CoveoPlatform.Environments.dev],
-            expect.anything(),
-            expect.anything()
+            expect.objectContaining({
+                host: CoveoPlatform.Hosts[CoveoPlatform.Environments.dev],
+            })
         );
     });
 
     test('the API uses the custom host specified in the options if any', () => {
         const myCustomHost = 'localhost:9999/my-api-running-locally';
         new CoveoPlatform({...baseOptions, host: myCustomHost});
-        expect(APIMock).toHaveBeenCalledWith(myCustomHost, expect.anything(), expect.anything());
+        expect(APIMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                host: myCustomHost,
+            })
+        );
     });
 
     test('the API uses the organization id specified in the options', () => {
         new CoveoPlatform(baseOptions);
-        expect(APIMock).toHaveBeenCalledWith(expect.anything(), baseOptions.organizationId, expect.anything());
+        expect(APIMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                organizationId: baseOptions.organizationId,
+            })
+        );
     });
 
     test('the API uses the accessTokenRetriever function specified in the options', () => {
         new CoveoPlatform(baseOptions);
-        expect(APIMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), tokenRetriever);
+        expect(APIMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                accessTokenRetriever: baseOptions.accessTokenRetriever,
+            })
+        );
     });
 
     it('should register all the resources on the platform instance', () => {


### PR DESCRIPTION
Added the possibility to configure custom response handlers. I updated the [README](https://github.com/coveo/platform-client/blob/enable-custom-response-handlers/README.md#error-handling) to describe their usage.