### PR TITLE
Fix PlatformClient.initialize method

### DIFF
--- a/src/APICore.ts
+++ b/src/APICore.ts
@@ -30,12 +30,20 @@ export default class API {
     async post<T>(
         url: string,
         body: any,
-        args: RequestInit = {method: 'post', body: JSON.stringify(body)}
+        args: RequestInit = {method: 'post', body: JSON.stringify(body), headers: {'Content-Type': 'application/json'}}
     ): Promise<T> {
         return await this.request<T>(url, args);
     }
 
-    async put<T>(url: string, body: any, args: RequestInit = {method: 'put', body: JSON.stringify(body)}): Promise<T> {
+    async postForm<T>(url: string, form: FormData, args: RequestInit = {method: 'post', body: form}): Promise<T> {
+        return await this.request<T>(url, args);
+    }
+
+    async put<T>(
+        url: string,
+        body: any,
+        args: RequestInit = {method: 'put', body: JSON.stringify(body), headers: {'Content-Type': 'application/json'}}
+    ): Promise<T> {
         return await this.request<T>(url, args);
     }
 
@@ -56,8 +64,8 @@ export default class API {
         const init: RequestInit = {
             ...args,
             headers: {
-                'Content-Type': 'application/json',
-                authorization: `Bearer ${this.config.accessTokenRetriever()}`,
+                Authorization: `Bearer ${this.config.accessTokenRetriever()}`,
+                Accept: 'application/json',
                 ...(args.headers || {}),
             },
         };

--- a/src/PlatformClient.ts
+++ b/src/PlatformClient.ts
@@ -63,7 +63,9 @@ export class PlatformClient extends PlatformResources {
     }
 
     private async checkToken() {
-        return this.API.post('/oauth/check_token', {token: this.options.accessTokenRetriever()});
+        const formData = new FormData();
+        formData.set('token', this.options.accessTokenRetriever());
+        return this.API.postForm<any>('/oauth/check_token', formData);
     }
 }
 

--- a/src/tests/APICore.spec.ts
+++ b/src/tests/APICore.spec.ts
@@ -63,6 +63,24 @@ describe('APICore', () => {
             expect(url).toBe(`${testConfig.host}${testData.route}`);
             expect(options.method).toBe('post');
             expect(options.body).toBe(JSON.stringify(testData.body));
+            expect(options.headers).toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
+            expect(response).toEqual(testData.response);
+        });
+    });
+
+    describe('postForm', () => {
+        test('simple request', async () => {
+            const formMock: jest.Mocked<FormData> = jest.fn() as any;
+            const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+            const response = await api.postForm(testData.route, formMock);
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            const [url, options] = fetchMock.mock.calls[0];
+
+            expect(url).toBe(`${testConfig.host}${testData.route}`);
+            expect(options.method).toBe('post');
+            expect(options.body).toBe(formMock);
+            expect(options.headers).not.toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
             expect(response).toEqual(testData.response);
         });
     });
@@ -78,6 +96,7 @@ describe('APICore', () => {
             expect(url).toBe(`${testConfig.host}${testData.route}`);
             expect(options.method).toBe('put');
             expect(options.body).toBe(JSON.stringify(testData.body));
+            expect(options.headers).toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
             expect(response).toEqual(testData.response);
         });
     });

--- a/src/tests/PlatformClient.spec.ts
+++ b/src/tests/PlatformClient.spec.ts
@@ -82,23 +82,31 @@ describe('PlatformClient', () => {
     });
 
     describe('initialize', () => {
+        const mockedFormData = {
+            set: jest.fn(),
+        };
+
+        beforeEach(() => {
+            (global as any).FormData = jest.fn(() => mockedFormData);
+        });
+
         it('should check if the retrieved token is valid', async () => {
             const platform = new PlatformClient(baseOptions);
             const APIMockInstance = APIMock.mock.instances[0];
 
             await platform.initialize();
 
-            expect(APIMockInstance.post).toHaveBeenCalledTimes(1);
-            expect(APIMockInstance.post).toHaveBeenCalledWith(
-                '/oauth/check_token',
-                expect.objectContaining({token: baseOptions.accessTokenRetriever()})
-            );
+            expect(APIMockInstance.postForm).toHaveBeenCalledTimes(1);
+            expect(APIMockInstance.postForm).toHaveBeenCalledWith('/oauth/check_token', mockedFormData);
+            expect(mockedFormData.set).toHaveBeenCalledTimes(1);
+            expect(mockedFormData.set).toHaveBeenCalledWith('token', baseOptions.accessTokenRetriever());
         });
 
         it('should throw an error if the check token call fails', async () => {
             const platform = new PlatformClient(baseOptions);
-            const APIPostMock: jest.Mock<ReturnType<typeof API.prototype.post>> = APIMock.mock.instances[0].post as any;
-            APIPostMock.mockRejectedValue(new Error('invalid token'));
+            const APIPostFormMock: jest.Mock<ReturnType<typeof API.prototype.postForm>> = APIMock.mock.instances[0]
+                .postForm as any;
+            APIPostFormMock.mockRejectedValue(new Error('invalid token'));
 
             try {
                 await platform.initialize();


### PR DESCRIPTION
`PlatformClient.initialize` method makes POST request to `/oauth/check_token` on the coveo platform in order to ensure the validity of the provided access token. The service behind that call only accepts a [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object as request body. Currently the request body is sent as JSON string which results in `invalid token error` (I guess the server ends up checking a null token).