### PR TITLE
fix(typings): export all types from the package root

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.0-development",
     "description": "",
     "main": "dist/index.js",
-    "types": "dist/definitions/PlatformClient.d.ts",
+    "types": "dist/definitions/Entry.d.ts",
     "keywords": [
         "coveo",
         "api",

--- a/src/Entry.ts
+++ b/src/Entry.ts
@@ -1,0 +1,5 @@
+export * from './PlatformClient';
+export * from './ConfigurationInterfaces';
+export * from './APICore';
+export * from './handlers';
+export * from './resources';

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,0 +1,2 @@
+export * from './ResponseHandlers';
+export * from './ResponseHandlerInterfaces';

--- a/src/resources/Catalogs/index.ts
+++ b/src/resources/Catalogs/index.ts
@@ -1,0 +1,2 @@
+export * from './Catalog';
+export * from './CatalogInterfaces';

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,0 +1,3 @@
+export * from './Resources';
+export * from './BaseInterfaces';
+export * from './Catalogs';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
     "extends": "./tsconfig",
-    "include": ["src/PlatformClient.ts"]
+    "include": ["src/Entry.ts"]
 }


### PR DESCRIPTION
When consuming the `platform-client` package, importing interfaces becomes a real pain.

Before the fix:
```ts
import {GroupModel} from '@coveord/platform-client/dist/definitions/resources/Groups/GroupsInterfaces';
```

After the fix:
```ts
import {GroupModel} from '@coveord/platform-client';
```
