### PR TITLE
fix(groups): create and update methods wrong return types

### DIFF
--- a/src/APICore.ts
+++ b/src/APICore.ts
@@ -2,32 +2,16 @@ import {APIConfiguration} from './ConfigurationInterfaces';
 import {ResponseHandler} from './handlers/ResponseHandlerInterfaces';
 import handleResponse, {defaultResponseHandlers} from './handlers/ResponseHandlers';
 
-function removeEmptyEntries(obj) {
-    return Object.keys(obj).reduce((memo, key) => {
-        const val = obj[key];
-        if (val && typeof val === 'object') {
-            memo[key] = removeEmptyEntries(obj);
-        } else if (val != null || val !== '') {
-            memo[key] = obj[key];
-        }
-        return memo;
-    }, {});
-}
-
-function convertToQueryString(parameters: any) {
-    return parameters ? `?${new URLSearchParams(Object.entries(removeEmptyEntries(parameters))).toString()}` : '';
-}
-
 export default class API {
     static orgPlaceholder = '{organizationName}';
 
     constructor(private config: APIConfiguration) {}
 
-    async get<T>(url: string, args: RequestInit = {method: 'get'}): Promise<T> {
+    async get<T = {}>(url: string, args: RequestInit = {method: 'get'}): Promise<T> {
         return await this.request<T>(url, args);
     }
 
-    async post<T>(
+    async post<T = {}>(
         url: string,
         body: any,
         args: RequestInit = {method: 'post', body: JSON.stringify(body), headers: {'Content-Type': 'application/json'}}
@@ -35,11 +19,11 @@ export default class API {
         return await this.request<T>(url, args);
     }
 
-    async postForm<T>(url: string, form: FormData, args: RequestInit = {method: 'post', body: form}): Promise<T> {
+    async postForm<T = {}>(url: string, form: FormData, args: RequestInit = {method: 'post', body: form}): Promise<T> {
         return await this.request<T>(url, args);
     }
 
-    async put<T>(
+    async put<T = {}>(
         url: string,
         body: any,
         args: RequestInit = {method: 'put', body: JSON.stringify(body), headers: {'Content-Type': 'application/json'}}
@@ -47,7 +31,7 @@ export default class API {
         return await this.request<T>(url, args);
     }
 
-    async delete<T = void>(url: string, args: RequestInit = {method: 'delete'}): Promise<T> {
+    async delete<T = {}>(url: string, args: RequestInit = {method: 'delete'}): Promise<T> {
         return await this.request<T>(url, args);
     }
 

--- a/src/resources/Groups/Groups.ts
+++ b/src/resources/Groups/Groups.ts
@@ -11,7 +11,7 @@ export default class Group extends Resource {
     }
 
     create(group: New<GroupModel, 'resourceId'>, options?: CreateGroupOptions) {
-        return this.api.post<GroupModel>(this.buildPath(Group.baseUrl, options), group);
+        return this.api.post<{id: string}>(this.buildPath(Group.baseUrl, options), group);
     }
 
     delete(groupId: string) {
@@ -23,6 +23,6 @@ export default class Group extends Resource {
     }
 
     update(group: GroupModel, options?: UpdateGroupOptions) {
-        return this.api.put<GroupModel>(this.buildPath(`${Group.baseUrl}/${group.id}`, options), group);
+        return this.api.put(this.buildPath(`${Group.baseUrl}/${group.id}`, options), group);
     }
 }


### PR DESCRIPTION
Return types of the `create` and `update` methods of the group resource were wrong. Those methods don't return the `GroupModel`. 

- `create` actually returns `{id: string}`
- `update` actually returns no content.