### PR TITLE
Add a way to abort pending get requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ platform.catalog.list({page: 0, pageSize: 10}).then((res) => {
 });
 ```
 
+### Compatibility
+
+The `platform-client` package is built on top of the `fetch` API and some related features such as the `AbortController` which are not entirely supported by all JavaScript runtime environments. Consequently, we recommend including the following list of polyfills to your project before using it in production.
+
+* [Polyfill for `fetch`](https://github.com/github/fetch)
+* [Polyfill for `AbortController`](https://github.com/mo/abortcontroller-polyfill)
+
+
 ## Documentation
 
 This project is built using TypeScript and automatically generates relevant type declarations. Most IDEs with TypeScript integration will display those type declarations as autocompletions, so that you typically will not need to refer to external documentation. Hence, the decision has been made not to document any option, resource, or action, except for the main configuration options. For in-depth documentation on the APIs exposed by this package, please consult our [official documentation portal](https://docs.coveo.com/en/151/cloud-v2-developers/coveo-cloud-v2-for-developers).

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,5 @@
 import {GlobalWithFetchMock} from 'jest-fetch-mock';
+import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 
 const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
 customGlobal.fetch = require('jest-fetch-mock');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1799,6 +1799,12 @@
             "integrity": "sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==",
             "dev": true
         },
+        "abortcontroller-polyfill": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz",
+            "integrity": "sha512-3ZFfCRfDzx3GFjO6RAkYx81lPGpUS20ISxux9gLxuKnqafNcFQo59+IoZqpO2WvQlyc287B62HDnDdNYRmlvWA==",
+            "dev": true
+        },
         "acorn": {
             "version": "5.7.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@commitlint/config-conventional": "^8.2.0",
         "@commitlint/travis-cli": "^8.2.0",
         "@types/jest": "^24.0.18",
+        "abortcontroller-polyfill": "^1.4.0",
         "clean-webpack-plugin": "^3.0.0",
         "cz-conventional-changelog": "^3.0.2",
         "husky": "^3.0.5",

--- a/src/Entry.ts
+++ b/src/Entry.ts
@@ -1,5 +1,6 @@
 export * from './PlatformClient';
 export * from './ConfigurationInterfaces';
 export * from './APICore';
+export * from './Errors';
 export * from './handlers';
 export * from './resources';

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -1,0 +1,6 @@
+export class HostUndefinedError extends Error {
+    name = 'HostUndefinedError';
+    constructor() {
+        super(`The CoveoPlatform's host is undefined.`);
+    }
+}

--- a/src/PlatformClient.ts
+++ b/src/PlatformClient.ts
@@ -50,6 +50,10 @@ export class PlatformClient extends PlatformResources {
         }
     }
 
+    abortPendingGetRequests() {
+        this.API.abortGetRequests();
+    }
+
     private get apiConfiguration(): APIConfiguration {
         const {environment, ...apiConfig} = this.options;
         return {

--- a/src/PlatformClient.ts
+++ b/src/PlatformClient.ts
@@ -1,5 +1,6 @@
 import API from './APICore';
 import {APIConfiguration, PlatformClientOptions} from './ConfigurationInterfaces';
+import {HostUndefinedError} from './Errors';
 import {ResponseHandlers} from './handlers/ResponseHandlers';
 import PlatformResources from './resources/PlatformResources';
 
@@ -34,7 +35,7 @@ export class PlatformClient extends PlatformResources {
         };
 
         if (!this.host) {
-            throw new Error(`CoveoPlatform's host is undefined.`);
+            throw new HostUndefinedError();
         }
 
         this.API = new API(this.apiConfiguration);

--- a/src/tests/APICore.spec.ts
+++ b/src/tests/APICore.spec.ts
@@ -13,14 +13,23 @@ describe('APICore', () => {
         response: {nuggets: 12345},
         body: {q: 'how many nuggets'},
     };
-    const api = new API(testConfig);
+    let api: API;
 
     beforeEach(() => {
+        api = new API(testConfig);
         jest.clearAllMocks();
     });
 
+    describe('when creating a new API instance', () => {
+        it('should not throw errors', () => {
+            expect(() => {
+                new API(testConfig);
+            }).not.toThrow();
+        });
+    });
+
     describe('get', () => {
-        test('simple request', async () => {
+        it('should do a simple GET request', async () => {
             const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
             const response = await api.get<typeof testData.response>(testData.route);
 
@@ -32,7 +41,7 @@ describe('APICore', () => {
             expect(response).toEqual(testData.response);
         });
 
-        test('failed request', async () => {
+        it('should make the promise fail on a failed request', async () => {
             const error = new Error('the request has failed');
             global.fetch.mockRejectedValue(error);
 
@@ -42,10 +51,17 @@ describe('APICore', () => {
                 expect(e).toEqual(error);
             }
         });
+
+        it('should bind GET requests to an abort signal', () => {
+            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+            api.get(testData.route);
+            expect(global.fetch.mock.calls[0][1].signal).toBeDefined();
+            expect(global.fetch.mock.calls[0][1].signal instanceof AbortSignal).toBe(true);
+        });
     });
 
     describe('post', () => {
-        test('simple request', async () => {
+        it('should do a simple POST request', async () => {
             const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
             const response = await api.post(testData.route, testData.body);
 
@@ -58,11 +74,18 @@ describe('APICore', () => {
             expect(options.headers).toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
             expect(response).toEqual(testData.response);
         });
+
+        it('should not bind POST requests to an abort signal', () => {
+            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+            api.post(testData.route, testData.body);
+            expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
+        });
     });
 
     describe('postForm', () => {
-        test('simple request', async () => {
-            const formMock: jest.Mocked<FormData> = jest.fn() as any;
+        const formMock: jest.Mocked<FormData> = jest.fn() as any;
+
+        it('should do a simple POST request using form data', async () => {
             const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
             const response = await api.postForm(testData.route, formMock);
 
@@ -75,10 +98,16 @@ describe('APICore', () => {
             expect(options.headers).not.toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
             expect(response).toEqual(testData.response);
         });
+
+        it('should not bind POST requests to an abort signal', () => {
+            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+            api.postForm(testData.route, formMock);
+            expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
+        });
     });
 
     describe('put', () => {
-        test('simple request', async () => {
+        it('should do a simple PUT request', async () => {
             const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
             const response = await api.put(testData.route, testData.body);
 
@@ -91,10 +120,16 @@ describe('APICore', () => {
             expect(options.headers).toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
             expect(response).toEqual(testData.response);
         });
+
+        it('should not bind PUT requests to an abort signal', () => {
+            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+            api.put(testData.route, testData.body);
+            expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
+        });
     });
 
     describe('delete', () => {
-        test('simple request', async () => {
+        it('should do a simple DELETE request', async () => {
             const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
             const response = await api.delete(testData.route);
 
@@ -104,6 +139,12 @@ describe('APICore', () => {
             expect(url).toBe(`${testConfig.host}${testData.route}`);
             expect(options.method).toBe('delete');
             expect(response).toEqual(testData.response);
+        });
+
+        it('should not bind DELETE requests to an abort signal', () => {
+            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+            api.delete(testData.route);
+            expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
         });
     });
 
@@ -117,5 +158,47 @@ describe('APICore', () => {
         await apiWithCustomResponseHandler.get('some/resource');
 
         expect(CustomResponseHandler.process).toHaveBeenCalledTimes(1);
+    });
+
+    describe('when calling abortGetRequests', () => {
+        it('should abort pending get requests', () => {
+            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+            api.get(testData.route);
+            expect(global.fetch.mock.calls[0][1].signal.aborted).toBe(false);
+            api.abortGetRequests();
+            expect(global.fetch.mock.calls[0][1].signal.aborted).toBe(true);
+        });
+
+        it('should not abort get requests that are being sent after the abort signal', () => {
+            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+            api.abortGetRequests();
+            api.get(testData.route);
+            expect(global.fetch.mock.calls[0][1].signal.aborted).toBe(false);
+        });
+
+        it('should not resolve nor reject the fetch promise', () => {
+            jest.useFakeTimers();
+            const resolvedPromiseSpy = jest.fn().mockName('resolvedPromiseSpy');
+            const rejectedPromiseSpy = jest.fn().mockName('rejectedPromiseSpy');
+
+            global.fetch.mockImplementationOnce(() => {
+                return new Promise((resolve) => {
+                    setTimeout(() => {
+                        resolve(new Response(JSON.stringify(testData.response), {status: 200}));
+                    }, 1000);
+                });
+            });
+
+            api.get(testData.route)
+                .then(resolvedPromiseSpy)
+                .catch(rejectedPromiseSpy);
+
+            jest.advanceTimersByTime(500);
+            api.abortGetRequests();
+            jest.advanceTimersByTime(2000);
+
+            expect(resolvedPromiseSpy).not.toHaveBeenCalled();
+            expect(rejectedPromiseSpy).not.toHaveBeenCalled();
+        });
     });
 });

--- a/src/tests/PlatformClient.spec.ts
+++ b/src/tests/PlatformClient.spec.ts
@@ -117,4 +117,15 @@ describe('PlatformClient', () => {
             expect.assertions(1);
         });
     });
+
+    it('should abort get requests on the API instance', () => {
+        const platform = new PlatformClient(baseOptions);
+        const abortGetRequestsSpy = APIMock.mock.instances[0].abortGetRequests as jest.Mock<
+            ReturnType<typeof API.prototype.abortGetRequests>
+        >;
+
+        platform.abortPendingGetRequests();
+
+        expect(abortGetRequestsSpy).toHaveBeenCalledTimes(1);
+    });
 });


### PR DESCRIPTION
#### Usage
```ts
// Supposing we have a platform-client instance named "Platform"
Platform.abortPendingGetRequests();
```
Aborted promises won't resolve and won't reject, they will simply remain pending. However those requests will be identified as "cancelled" by the browser if you use the platform-client in such environment.