### PR TITLE
feat(modelinfo): update modelinfo interfaces

### DIFF
--- a/src/resources/ApiKeys/ApiKeysInterfaces.ts
+++ b/src/resources/ApiKeys/ApiKeysInterfaces.ts
@@ -7,7 +7,7 @@ export interface ApiKeyModel {
     value?: string;
     displayName?: string;
     description?: string;
-    createdBy?: object;
+    createdBy?: any;
     createdDate?: number;
     allowedIps?: string[];
     apiKeysThatCanEdit?: IdAndDisplayNameModel[];

--- a/src/resources/ApiKeys/ApiKeysInterfaces.ts
+++ b/src/resources/ApiKeys/ApiKeysInterfaces.ts
@@ -7,7 +7,7 @@ export interface ApiKeyModel {
     value?: string;
     displayName?: string;
     description?: string;
-    createdBy?: {};
+    createdBy?: any;
     createdDate?: number;
     allowedIps?: string[];
     apiKeysThatCanEdit?: IdAndDisplayNameModel[];

--- a/src/resources/ApiKeys/ApiKeysInterfaces.ts
+++ b/src/resources/ApiKeys/ApiKeysInterfaces.ts
@@ -7,7 +7,7 @@ export interface ApiKeyModel {
     value?: string;
     displayName?: string;
     description?: string;
-    createdBy?: any;
+    createdBy?: object;
     createdDate?: number;
     allowedIps?: string[];
     apiKeysThatCanEdit?: IdAndDisplayNameModel[];

--- a/src/resources/BaseInterfaces.ts
+++ b/src/resources/BaseInterfaces.ts
@@ -26,3 +26,5 @@ export interface PrivilegeModel {
     targetId: string;
     type?: string;
 }
+
+export type KeyValue<T> = {[key: string]: T};

--- a/src/resources/BaseInterfaces.ts
+++ b/src/resources/BaseInterfaces.ts
@@ -26,5 +26,3 @@ export interface PrivilegeModel {
     targetId: string;
     type?: string;
 }
-
-export type KeyValue<T> = {[key: string]: T};

--- a/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
+++ b/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
@@ -145,18 +145,18 @@ export interface ModelInformationPR {
         version: string;
     };
 
-    itemBasedNamesAndNumOfRecordedItems: object;
-    itemBasedNamesWithCandidateItems: object;
-    numOfEventsPerEventType: object;
-    userBasedCandidates: object;
-    userBasedNumOfItems: object;
-    userBasedNumOfUsers: object;
+    itemBasedNamesAndNumOfRecordedItems: any;
+    itemBasedNamesWithCandidateItems: any;
+    numOfEventsPerEventType: any;
+    userBasedCandidates: any;
+    userBasedNumOfItems: any;
+    userBasedNumOfUsers: any;
 
     contentIDKeys: string[];
     parentIDKeys: [];
 
-    modelBuildingStats?: object;
-    languages?: object;
+    modelBuildingStats?: any;
+    languages?: any;
 }
 
 export interface ModelInformationQS {

--- a/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
+++ b/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
@@ -1,4 +1,207 @@
+import {KeyValue} from '../../BaseInterfaces';
+
 export interface MLModelInfo {
     id: string;
-    info?: {};
+    info?: ModelInformationART | ModelInformationDNE | ModelInformationER | ModelInformationPR | ModelInformationQS;
+}
+
+export interface ModelInformationART {
+    metaInfo: {
+        modelName: string;
+        version: string;
+        environment: string;
+        org: string;
+        modelVersion: string;
+        createdDate: string;
+    };
+    modelBuildingStats: {
+        searchEventCount: number;
+        clickEventCount: number;
+        customEventCount: number;
+        segmentedVisitsCount: number;
+    };
+    totalQueries: number;
+    wordSelectionModels: KeyValue<KeyValue<number>>;
+    candidateExamples: KeyValue<string[]>;
+    languages: {
+        [languageKey: string]: {
+            contextKeysToDocuments: any;
+            queries: number;
+            documents: number;
+            filters: any;
+            words: number;
+            stopwords: number;
+            [otherKeys: string]: number;
+        };
+    };
+    contentIDKeys: string[];
+    params: {
+        version: string;
+        maxBins: number;
+        topClicksTakeBins: number[];
+        topClicksMultBins: number[];
+        intersectMultBins: number[];
+        originalMultBins: number[];
+        stemmedMultBins: number[];
+        userContextMultBins: number[];
+        subqueryMultBins: number[];
+        subqueryLenThr: number;
+        clicksDecayParams: KeyValue<number>;
+    };
+    featureSelectLog: FeatureSelectLog;
+    [key: string]: any;
+}
+
+export interface FeatureSelectLog {
+    [contextKey: string]: {
+        eventType: {name: string};
+        statusMessage: string;
+    };
+}
+
+export interface ModelInformationDNE {
+    modelBuildingStats: {
+        visitsCount: number;
+        totalQueries: number;
+        searchEventCount: number;
+        clickEventCount: number;
+        facetSelectEventCount: number;
+    };
+    params: {
+        version: string;
+    };
+    totalQueries: number;
+    contentIDKeys?: string[];
+    languages: {
+        [languageKey: string]: {
+            topFacets: string[];
+            docPerFilters: Record<string, number>;
+            queries: number;
+        };
+    };
+    metaInfo: {
+        modelName: string;
+        version: string;
+        environment: string;
+        org: string;
+        modelVersion: string;
+        createdDate: string;
+    };
+}
+
+export interface ModelInformationER {
+    indicatorsModifier: KeyValue<number>;
+    deprecatedUrlToFieldValueSize: number;
+    candidateExamples: KeyValue<string[]>;
+    primaryIdToValue: number;
+    eventGroups: string[];
+    primaryEventType: string;
+    params: {
+        languages: string[];
+        eventConfigs: any;
+        eventsToCombineMapping: any;
+        normalizeUrl: any;
+        querySplit: {
+            maxNgram: number;
+            keepOrigQuery: boolean;
+            keepStemQuery: boolean;
+            keepOrigNGramQuery: boolean;
+            keepStemNGramQuery: boolean;
+        };
+    };
+    contentIDKeys: string[];
+    primaryEventGroupName: string;
+    eventGroupValuesExamplesInHistory: any;
+    indicatorsMap: any;
+    metaInfo: {
+        modelName: string;
+        version: string;
+        environment: string;
+        org: string;
+        modelVersion: string;
+        createdDate: string;
+    };
+    modelBuildingStats: {
+        viewCount: number;
+        PageViewCount: number;
+        Query_stem1Count: number;
+        searchCount: number;
+        Query_stemCount: number;
+        clickCount: number;
+        [key: string]: number;
+    };
+    'Possible recommendations: ': number;
+    eventGroupsFields: KeyValue<string[]>;
+    primaryEventName: string;
+    'Recommendations per language: ': KeyValue<number>;
+    [key: string]: any;
+}
+
+export interface ModelInformationPR {
+    metaInfo: {
+        createdDate: string;
+        environment: string;
+        modelName: string;
+        modelVersion: string;
+        org: string;
+        version: string;
+    };
+
+    itemBasedNamesAndNumOfRecordedItems: any;
+    itemBasedNamesWithCandidateItems: any;
+    numOfEventsPerEventType: any;
+    userBasedCandidates: any;
+    userBasedNumOfItems: any;
+    userBasedNumOfUsers: any;
+
+    contentIDKeys: string[];
+    parentIDKeys: [];
+
+    modelBuildingStats?: any;
+    languages?: any;
+}
+
+export interface ModelInformationQS {
+    numContextValues: number;
+    lastQueriesPerUser: number;
+    userContextPrefix: string;
+    knownPartialsWithSuggestions: number;
+    candidateExamples: KeyValue<string[]>;
+    languages: string[];
+    minClickCountByLang: KeyValue<number>;
+    userClusterMap: number;
+    candidatesPerLanguages: KeyValue<number>;
+    filterFields: string[];
+    params: {
+        version: string;
+        contextBoost: number;
+        cooccurrenceBoost: number;
+        userClusterBoost: number;
+        partialQueryBoost: number;
+    };
+    candidates: number;
+    numUserClusters: number;
+    metaInfo: {
+        modelName: string;
+        version: string;
+        environment: string;
+        org: string;
+        modelVersion: string;
+        createdDate: string;
+    };
+    modelBuildingStats: {
+        searchEventCount: number;
+        clickEventCount: number;
+        filteredSearches: number;
+        customEventCount: number;
+    };
+    minCandWithContextBoost: number;
+    topCooccurrences: number;
+    ratioCandWithContextBoost: number;
+    userContextFields: string[];
+    maxQueryLength: number;
+    candidatesPerFilters: KeyValue<number>;
+    topCooccurrencesExamples: KeyValue<string[]>;
+    stopwords: KeyValue<number>;
+    [key: string]: any;
 }

--- a/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
+++ b/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
@@ -1,5 +1,3 @@
-import {KeyValue} from '../../BaseInterfaces';
-
 export interface MLModelInfo {
     id: string;
     info?: ModelInformationART | ModelInformationDNE | ModelInformationER | ModelInformationPR | ModelInformationQS;
@@ -21,8 +19,8 @@ export interface ModelInformationART {
         segmentedVisitsCount: number;
     };
     totalQueries: number;
-    wordSelectionModels: KeyValue<KeyValue<number>>;
-    candidateExamples: KeyValue<string[]>;
+    wordSelectionModels: Record<string, Record<string, number>>;
+    candidateExamples: Record<string, string[]>;
     languages: {
         [languageKey: string]: {
             contextKeysToDocuments: any;
@@ -46,7 +44,7 @@ export interface ModelInformationART {
         userContextMultBins: number[];
         subqueryMultBins: number[];
         subqueryLenThr: number;
-        clicksDecayParams: KeyValue<number>;
+        clicksDecayParams: Record<string, number>;
     };
     featureSelectLog: FeatureSelectLog;
     [key: string]: any;
@@ -90,9 +88,9 @@ export interface ModelInformationDNE {
 }
 
 export interface ModelInformationER {
-    indicatorsModifier: KeyValue<number>;
+    indicatorsModifier: Record<string, number>;
     deprecatedUrlToFieldValueSize: number;
-    candidateExamples: KeyValue<string[]>;
+    candidateExamples: Record<string, string[]>;
     primaryIdToValue: number;
     eventGroups: string[];
     primaryEventType: string;
@@ -131,9 +129,9 @@ export interface ModelInformationER {
         [key: string]: number;
     };
     'Possible recommendations: ': number;
-    eventGroupsFields: KeyValue<string[]>;
+    eventGroupsFields: Record<string, string[]>;
     primaryEventName: string;
-    'Recommendations per language: ': KeyValue<number>;
+    'Recommendations per language: ': Record<string, number>;
     [key: string]: any;
 }
 
@@ -147,18 +145,18 @@ export interface ModelInformationPR {
         version: string;
     };
 
-    itemBasedNamesAndNumOfRecordedItems: any;
-    itemBasedNamesWithCandidateItems: any;
-    numOfEventsPerEventType: any;
-    userBasedCandidates: any;
-    userBasedNumOfItems: any;
-    userBasedNumOfUsers: any;
+    itemBasedNamesAndNumOfRecordedItems: object;
+    itemBasedNamesWithCandidateItems: object;
+    numOfEventsPerEventType: object;
+    userBasedCandidates: object;
+    userBasedNumOfItems: object;
+    userBasedNumOfUsers: object;
 
     contentIDKeys: string[];
     parentIDKeys: [];
 
-    modelBuildingStats?: any;
-    languages?: any;
+    modelBuildingStats?: object;
+    languages?: object;
 }
 
 export interface ModelInformationQS {
@@ -166,11 +164,11 @@ export interface ModelInformationQS {
     lastQueriesPerUser: number;
     userContextPrefix: string;
     knownPartialsWithSuggestions: number;
-    candidateExamples: KeyValue<string[]>;
+    candidateExamples: Record<string, string[]>;
     languages: string[];
-    minClickCountByLang: KeyValue<number>;
+    minClickCountByLang: Record<string, number>;
     userClusterMap: number;
-    candidatesPerLanguages: KeyValue<number>;
+    candidatesPerLanguages: Record<string, number>;
     filterFields: string[];
     params: {
         version: string;
@@ -200,8 +198,8 @@ export interface ModelInformationQS {
     ratioCandWithContextBoost: number;
     userContextFields: string[];
     maxQueryLength: number;
-    candidatesPerFilters: KeyValue<number>;
-    topCooccurrencesExamples: KeyValue<string[]>;
-    stopwords: KeyValue<number>;
+    candidatesPerFilters: Record<string, number>;
+    topCooccurrencesExamples: Record<string, string[]>;
+    stopwords: Record<string, number>;
     [key: string]: any;
 }

--- a/src/resources/Pipelines/MLAssociations/MLAssociationsInterfaces.ts
+++ b/src/resources/Pipelines/MLAssociations/MLAssociationsInterfaces.ts
@@ -12,7 +12,7 @@ export interface MLAssociationModel {
     cacheMaximumAge: string;
     condition?: string;
     conditionDefinition?: string;
-    customQueryParameters?: any;
+    customQueryParameters?: object;
     enableWordCompletion?: boolean;
     exclusive?: boolean;
     intelligentTermDetection?: boolean;
@@ -35,7 +35,7 @@ export interface CreateAssociation extends EditAssociation {
 export interface EditAssociation {
     cacheMaximumAge?: string;
     condition?: string;
-    customQueryParameters?: any;
+    customQueryParameters?: object;
     description?: string;
     enableWordCompletion?: boolean;
     exclusive?: boolean;

--- a/src/resources/Pipelines/MLAssociations/MLAssociationsInterfaces.ts
+++ b/src/resources/Pipelines/MLAssociations/MLAssociationsInterfaces.ts
@@ -12,7 +12,7 @@ export interface MLAssociationModel {
     cacheMaximumAge: string;
     condition?: string;
     conditionDefinition?: string;
-    customQueryParameters?: object;
+    customQueryParameters?: any;
     enableWordCompletion?: boolean;
     exclusive?: boolean;
     intelligentTermDetection?: boolean;
@@ -35,7 +35,7 @@ export interface CreateAssociation extends EditAssociation {
 export interface EditAssociation {
     cacheMaximumAge?: string;
     condition?: string;
-    customQueryParameters?: object;
+    customQueryParameters?: any;
     description?: string;
     enableWordCompletion?: boolean;
     exclusive?: boolean;

--- a/src/resources/Pipelines/MLAssociations/MLAssociationsInterfaces.ts
+++ b/src/resources/Pipelines/MLAssociations/MLAssociationsInterfaces.ts
@@ -12,7 +12,7 @@ export interface MLAssociationModel {
     cacheMaximumAge: string;
     condition?: string;
     conditionDefinition?: string;
-    customQueryParameters?: {};
+    customQueryParameters?: any;
     enableWordCompletion?: boolean;
     exclusive?: boolean;
     intelligentTermDetection?: boolean;
@@ -35,7 +35,7 @@ export interface CreateAssociation extends EditAssociation {
 export interface EditAssociation {
     cacheMaximumAge?: string;
     condition?: string;
-    customQueryParameters?: {};
+    customQueryParameters?: any;
     description?: string;
     enableWordCompletion?: boolean;
     exclusive?: boolean;


### PR DESCRIPTION
I've moved model info interfaces to Machine Learning resource, however, all the information are not documented in Swagger yet, some change may occur in the future. 
Also, I've replaced all the empty object type `{}` with `any`, because empty object could be limited in some occasion and does not have special meaning. 