### PR TITLE
fix(securitycache): now return arrays when fetching lists

### DIFF
--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -44,10 +44,10 @@ export default class SecurityCache extends Ressource {
     }
 
     listProviders() {
-        return this.api.get<SecurityProviderModelWithStatus>(SecurityCache.providersUrl);
+        return this.api.get<SecurityProviderModelWithStatus[]>(SecurityCache.providersUrl);
     }
 
     providerSchedules() {
-        return this.api.get<ScheduleModel>(`${SecurityCache.providersUrl}/schedules`);
+        return this.api.get<ScheduleModel[]>(`${SecurityCache.providersUrl}/schedules`);
     }
 }


### PR DESCRIPTION
Call type for list was not returning an array.