### PR TITLE
fix(types): output enums in the minified bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
         "commitizen": {
             "path": "./node_modules/cz-conventional-changelog"
         }
-    }
+    },
+    "sideEffects": [
+        "./src/resources/Enums.ts"
+    ]
 }

--- a/src/PlatformClient.ts
+++ b/src/PlatformClient.ts
@@ -1,3 +1,5 @@
+import './resources/Enums';
+
 import API from './APICore';
 import {APIConfiguration, PlatformClientOptions} from './ConfigurationInterfaces';
 import {HostUndefinedError} from './Errors';

--- a/src/resources/BaseInterfaces.ts
+++ b/src/resources/BaseInterfaces.ts
@@ -6,15 +6,6 @@ export interface PageModel<T = any> {
 
 export type New<T, K extends string | number | symbol = null> = Omit<T, 'id' | K>;
 
-export enum AuthProvider {
-    SALESFORCE = 'SALESFORCE',
-    SALESFORCE_SANDBOX = 'SALESFORCE_SANDBOX',
-    GOOGLE = 'GOOGLE',
-    OFFICE365 = 'OFFICE365',
-    SAML = 'SAML',
-    EMAIL = 'EMAIL',
-}
-
 export interface IdAndDisplayNameModel {
     id: string;
     displayName?: string;

--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -1,0 +1,33 @@
+export enum AuthProvider {
+    SALESFORCE = 'SALESFORCE',
+    SALESFORCE_SANDBOX = 'SALESFORCE_SANDBOX',
+    GOOGLE = 'GOOGLE',
+    OFFICE365 = 'OFFICE365',
+    SAML = 'SAML',
+    EMAIL = 'EMAIL',
+}
+
+export enum SecurityCacheStateOptions {
+    Unknown = 'UNKNOWN',
+    UpToDate = 'UP_TO_DATE',
+    NotUpdated = 'NOT_UPDATED',
+    OutOfDate = 'OUT_OF_DATE',
+    InError = 'IN_ERROR',
+    Disabled = 'DISABLED',
+}
+
+export enum ScheduleType {
+    Minutely = 'MINUTELY',
+    Hourly = 'HOURLY',
+    Daily = 'DAILY',
+    Weekly = 'WEEKLY',
+    Monthly = 'MONTHLY',
+}
+
+export enum FieldTypes {
+    LONG = 'LONG',
+    LONG_64 = 'LONG_64',
+    DOUBLE = 'DOUBLE',
+    DATE = 'DATE',
+    STRING = 'STRING',
+}

--- a/src/resources/Fields/FieldsInterfaces.ts
+++ b/src/resources/Fields/FieldsInterfaces.ts
@@ -1,3 +1,5 @@
+import {FieldTypes} from '../Enums';
+
 export interface FieldModel {
     dateFormat?: string;
     description?: string;
@@ -19,14 +21,6 @@ export interface FieldModel {
     useCacheForNestedQuery?: boolean;
     useCacheForNumericQuery?: boolean;
     useCacheForSort?: boolean;
-}
-
-export enum FieldTypes {
-    LONG = 'LONG',
-    LONG_64 = 'LONG_64',
-    DOUBLE = 'DOUBLE',
-    DATE = 'DATE',
-    STRING = 'STRING',
 }
 
 export interface ListFieldsParams {

--- a/src/resources/Groups/GroupsInterfaces.ts
+++ b/src/resources/Groups/GroupsInterfaces.ts
@@ -1,4 +1,5 @@
-import {AuthProvider, IdAndDisplayNameModel, PrivilegeModel} from '../BaseInterfaces';
+import {IdAndDisplayNameModel, PrivilegeModel} from '../BaseInterfaces';
+import {AuthProvider} from '../Enums';
 import {RealmModel} from './Realms/GroupRealmInterfaces';
 
 export interface GroupModel {

--- a/src/resources/Groups/Realms/GroupRealmInterfaces.ts
+++ b/src/resources/Groups/Realms/GroupRealmInterfaces.ts
@@ -1,4 +1,4 @@
-import {AuthProvider} from '../../BaseInterfaces';
+import {AuthProvider} from '../../Enums';
 
 export interface RealmModel {
     id: string;

--- a/src/resources/Groups/Realms/tests/GroupRealm.spec.ts
+++ b/src/resources/Groups/Realms/tests/GroupRealm.spec.ts
@@ -1,5 +1,5 @@
 import API from '../../../../APICore';
-import {AuthProvider} from '../../../BaseInterfaces';
+import {AuthProvider} from '../../../Enums';
 import GroupRealm from '../GroupRealm';
 import {RealmModel} from '../GroupRealmInterfaces';
 

--- a/src/resources/SecurityCache/SecurityCacheInterfaces.ts
+++ b/src/resources/SecurityCache/SecurityCacheInterfaces.ts
@@ -1,3 +1,5 @@
+import {ScheduleType, SecurityCacheStateOptions} from '../Enums';
+
 export interface ScheduleModel {
     enabled: boolean;
     frequency?: ScheduleFrequency;
@@ -135,21 +137,4 @@ export interface SecurityCacheListOptions {
 export interface SecurityCacheMemberInfoModel {
     key: string;
     value: string;
-}
-
-export enum SecurityCacheStateOptions {
-    Unknown = 'UNKNOWN',
-    UpToDate = 'UP_TO_DATE',
-    NotUpdated = 'NOT_UPDATED',
-    OutOfDate = 'OUT_OF_DATE',
-    InError = 'IN_ERROR',
-    Disabled = 'DISABLED',
-}
-
-export enum ScheduleType {
-    Minutely = 'MINUTELY',
-    Hourly = 'HOURLY',
-    Daily = 'DAILY',
-    Weekly = 'WEEKLY',
-    Monthly = 'MONTHLY',
 }


### PR DESCRIPTION
Enums were not outputted in the minified bundle. Thats because they were not imported anywhere and webpack was identifying them as dead code.

I moved all enums in a single file, imported that file somewhere and identified it as having side effects to accelerate compilation.