### PR TITLE
feat(pipeline): add pipeline resource for ml test

### DIFF
--- a/src/resources/Pipelines/Pipelines.ts
+++ b/src/resources/Pipelines/Pipelines.ts
@@ -4,8 +4,8 @@ import MLAssociations from './MLAssociations/MLAssociations';
 import {PipelineBackendVersion, PipelineModel} from './PipelinesInterfaces';
 
 export default class Pipelines extends Resource {
-    static baseUrl = '/rest/search/v2/admin/pipelines';
-    static v1Url = '/rest/search/v1/admin/pipelines';
+    static searchUrlVersion2 = '/rest/search/v2/admin/pipelines';
+    static searchUrlVersion1 = '/rest/search/v1/admin/pipelines';
     static searchUrl = '/rest/search/admin/pipelines';
 
     associations: MLAssociations;
@@ -24,7 +24,7 @@ export default class Pipelines extends Resource {
 
     getBackendVersion() {
         return this.api.get<PipelineBackendVersion>(
-            this.buildPath(`${Pipelines.baseUrl}/ml/version`, {organizationId: this.api.organizationId})
+            this.buildPath(`${Pipelines.searchUrlVersion2}/ml/version`, {organizationId: this.api.organizationId})
         );
     }
 }

--- a/src/resources/Pipelines/Pipelines.ts
+++ b/src/resources/Pipelines/Pipelines.ts
@@ -1,10 +1,18 @@
 import API from '../../APICore';
 import Resource from '../Resource';
 import MLAssociations from './MLAssociations/MLAssociations';
-import {PipelineBackendVersion} from './PipelinesInterfaces';
+import {PipelineBackendVersion, PipelineModel} from './PipelinesInterfaces';
 
 export default class Pipelines extends Resource {
-    static baseUrl = '/rest/search/v2/admin/pipelines';
+    static getBaseUrl = (version?: 1 | 2) => {
+        if (version === 1) {
+            return '/rest/search/v1/admin/pipelines';
+        }
+        if (version === 2) {
+            return '/rest/search/v2/admin/pipelines';
+        }
+        return '/rest/search/admin/pipelines';
+    };
 
     associations: MLAssociations;
 
@@ -14,9 +22,15 @@ export default class Pipelines extends Resource {
         this.associations = new MLAssociations(api);
     }
 
+    listBasicInfo() {
+        return this.api.get<PipelineModel[]>(
+            this.buildPath(Pipelines.getBaseUrl(), {organizationId: this.api.organizationId})
+        );
+    }
+
     getBackendVersion() {
         return this.api.get<PipelineBackendVersion>(
-            this.buildPath(`${Pipelines.baseUrl}/ml/version`, {organizationId: this.api.organizationId})
+            this.buildPath(`${Pipelines.getBaseUrl(2)}/ml/version`, {organizationId: this.api.organizationId})
         );
     }
 }

--- a/src/resources/Pipelines/Pipelines.ts
+++ b/src/resources/Pipelines/Pipelines.ts
@@ -4,15 +4,9 @@ import MLAssociations from './MLAssociations/MLAssociations';
 import {PipelineBackendVersion, PipelineModel} from './PipelinesInterfaces';
 
 export default class Pipelines extends Resource {
-    static getBaseUrl = (version?: 1 | 2) => {
-        if (version === 1) {
-            return '/rest/search/v1/admin/pipelines';
-        }
-        if (version === 2) {
-            return '/rest/search/v2/admin/pipelines';
-        }
-        return '/rest/search/admin/pipelines';
-    };
+    static baseUrl = '/rest/search/v2/admin/pipelines';
+    static v1Url = '/rest/search/v1/admin/pipelines';
+    static searchUrl = '/rest/search/admin/pipelines';
 
     associations: MLAssociations;
 
@@ -24,13 +18,13 @@ export default class Pipelines extends Resource {
 
     listBasicInfo() {
         return this.api.get<PipelineModel[]>(
-            this.buildPath(Pipelines.getBaseUrl(), {organizationId: this.api.organizationId})
+            this.buildPath(Pipelines.searchUrl, {organizationId: this.api.organizationId})
         );
     }
 
     getBackendVersion() {
         return this.api.get<PipelineBackendVersion>(
-            this.buildPath(`${Pipelines.getBaseUrl(2)}/ml/version`, {organizationId: this.api.organizationId})
+            this.buildPath(`${Pipelines.baseUrl}/ml/version`, {organizationId: this.api.organizationId})
         );
     }
 }

--- a/src/resources/Pipelines/PipelinesInterfaces.ts
+++ b/src/resources/Pipelines/PipelinesInterfaces.ts
@@ -1,3 +1,19 @@
 export interface PipelineBackendVersion {
     version: '1' | '2';
 }
+
+export interface PipelineModel {
+    id: string;
+    name: string;
+    isDefault?: boolean;
+    condition?: any;
+    created_by?: string;
+    description?: string;
+    filter?: any;
+    last_modified_by?: string;
+    position?: number;
+    splitTestEnabled?: boolean;
+    splitTestName?: string;
+    splitTestRatio?: number;
+    splitTestTarget?: string;
+}

--- a/src/resources/Pipelines/tests/Pipelines.spec.ts
+++ b/src/resources/Pipelines/tests/Pipelines.spec.ts
@@ -18,7 +18,7 @@ describe('Pipelines', () => {
         it('should make a GET call to the specific Pipelines url', () => {
             pipelines.listBasicInfo();
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Pipelines.getBaseUrl()}`);
+            expect(api.get).toHaveBeenCalledWith(`${Pipelines.searchUrl}`);
         });
     });
 
@@ -26,7 +26,7 @@ describe('Pipelines', () => {
         it('should make a GET call to the specific Pipelines url', () => {
             pipelines.getBackendVersion();
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Pipelines.getBaseUrl(2)}/ml/version`);
+            expect(api.get).toHaveBeenCalledWith(`${Pipelines.baseUrl}/ml/version`);
         });
     });
 });

--- a/src/resources/Pipelines/tests/Pipelines.spec.ts
+++ b/src/resources/Pipelines/tests/Pipelines.spec.ts
@@ -14,11 +14,19 @@ describe('Pipelines', () => {
         pipelines = new Pipelines(api);
     });
 
+    describe('listBasicInfo', () => {
+        it('should make a GET call to the specific Pipelines url', () => {
+            pipelines.listBasicInfo();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Pipelines.getBaseUrl()}`);
+        });
+    });
+
     describe('getBackendVersion', () => {
         it('should make a GET call to the specific Pipelines url', () => {
             pipelines.getBackendVersion();
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Pipelines.baseUrl}/ml/version`);
+            expect(api.get).toHaveBeenCalledWith(`${Pipelines.getBaseUrl(2)}/ml/version`);
         });
     });
 });

--- a/src/resources/Pipelines/tests/Pipelines.spec.ts
+++ b/src/resources/Pipelines/tests/Pipelines.spec.ts
@@ -18,7 +18,7 @@ describe('Pipelines', () => {
         it('should make a GET call to the specific Pipelines url', () => {
             pipelines.listBasicInfo();
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Pipelines.searchUrl}`);
+            expect(api.get).toHaveBeenCalledWith(Pipelines.searchUrl);
         });
     });
 

--- a/src/resources/Pipelines/tests/Pipelines.spec.ts
+++ b/src/resources/Pipelines/tests/Pipelines.spec.ts
@@ -26,7 +26,7 @@ describe('Pipelines', () => {
         it('should make a GET call to the specific Pipelines url', () => {
             pipelines.getBackendVersion();
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Pipelines.baseUrl}/ml/version`);
+            expect(api.get).toHaveBeenCalledWith(`${Pipelines.searchUrlVersion2}/ml/version`);
         });
     });
 });


### PR DESCRIPTION
This API endpoint is used for fetching available pipelines in ML model tester and content browser, not documented in swagger yet.