### PR TITLE
fix(platformclient): provide an organization id retriever function

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ platform.catalog.list({page: 0, pageSize: 10}).then((res) => {
 
 The `platform-client` package is built on top of the `fetch` API and some related features such as the `AbortController` which are not entirely supported by all JavaScript runtime environments. Consequently, we recommend including the following list of polyfills to your project before using it in production.
 
-* [Polyfill for `fetch`](https://github.com/github/fetch)
-* [Polyfill for `AbortController`](https://github.com/mo/abortcontroller-polyfill)
-
+-   [Polyfill for `fetch`](https://github.com/github/fetch)
+-   [Polyfill for `AbortController`](https://github.com/mo/abortcontroller-polyfill)
 
 ## Documentation
 
@@ -63,13 +62,14 @@ This project is built using TypeScript and automatically generates relevant type
 
 ### Configuration Options
 
-| Option                 | Required | Default Value                        | Description                                                                                                                                      |
-| ---------------------- | -------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `accessTokenRetriever` | yes      | undefined                            | A function that provides the access token or API key. Executed before every call to ensure token freshness.                                      |
-| `organizationId`       | yes      | undefined                            | The unique identifier of the target organization.                                                                                                |
-| `environment`          | optional | `'production'`                       | The target environment. If one of following: `'development'`, `'staging'`, `'production'`, `'hipaa'`; automatically targets the associated host. |
-| `host`                 | optional | `'https://platform.cloud.coveo.com'` | The target host. Useful to target local hosts when testing.                                                                                      |
-| `responseHandlers`     | optional | []                                   | Custom server response handlers. See [error handling section](#error-handling) for detailed explanation.                                         |
+| Option                        | Required                                                  | Default Value                        | Description                                                                                                                                      |
+| ----------------------------- | --------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `accessTokenRetriever`        | yes                                                       | undefined                            | A function that provides the access token or API key. Executed before every call to ensure token freshness.                                      |
+| `organizationIdRetriever`     | must supply `organizationId` or `organizationIdRetriever` | undefined                            | A function that provides the organization ID. Executed before every call to ensure the most up-to-date value.                                    |
+| `organizationId` *(deprecated)* | must supply `organizationId` or `organizationIdRetriever` | undefined                            | The unique identifier of the target organization.                                                                                                |
+| `environment`                 | optional                                                  | `'production'`                       | The target environment. If one of following: `'development'`, `'staging'`, `'production'`, `'hipaa'`; automatically targets the associated host. |
+| `host`                        | optional                                                  | `'https://platform.cloud.coveo.com'` | The target host. Useful to target local hosts when testing.                                                                                      |
+| `responseHandlers`            | optional                                                  | []                                   | Custom server response handlers. See [error handling section](#error-handling) for detailed explanation.                                         |
 
 ### Error handling
 

--- a/src/APICore.ts
+++ b/src/APICore.ts
@@ -12,7 +12,7 @@ export default class API {
     }
 
     get organizationId() {
-        return this.config.organizationId;
+        return this.config.organizationIdRetriever?.() || this.config.organizationId;
     }
 
     async get<T = {}>(url: string, args: RequestInit = {method: 'get'}): Promise<T> {
@@ -63,7 +63,7 @@ export default class API {
     }
 
     private getUrlFromRoute(route: string): string {
-        return `${this.config.host}${route}`.replace(API.orgPlaceholder, this.config.organizationId);
+        return `${this.config.host}${route}`.replace(API.orgPlaceholder, this.organizationId);
     }
 
     private async request<T>(route: string, args: RequestInit): Promise<T> {

--- a/src/ConfigurationInterfaces.ts
+++ b/src/ConfigurationInterfaces.ts
@@ -1,7 +1,11 @@
 import {ResponseHandler} from './handlers/ResponseHandlerInterfaces';
 
 export interface APIConfiguration {
-    organizationId: string;
+    /**
+     * @deprecated Use the organizationIdRetriever instead
+     */
+    organizationId?: string;
+    organizationIdRetriever?: () => string;
     accessTokenRetriever: () => string;
     host?: string;
     responseHandlers?: ResponseHandler[];

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,4 +1,5 @@
 export * from './BaseInterfaces';
+export * from './Enums';
 export * from './PlatformResources';
 export * from './AWS';
 export * from './Catalogs';

--- a/src/tests/APICore.spec.ts
+++ b/src/tests/APICore.spec.ts
@@ -13,139 +13,182 @@ describe('APICore', () => {
         response: {nuggets: 12345},
         body: {q: 'how many nuggets'},
     };
-    let api: API;
 
-    beforeEach(() => {
-        api = new API(testConfig);
-        jest.clearAllMocks();
-    });
+    describe('when making requests', () => {
+        let api: API;
 
-    describe('when creating a new API instance', () => {
-        it('should not throw errors', () => {
-            expect(() => {
-                new API(testConfig);
-            }).not.toThrow();
+        beforeEach(() => {
+            api = new API(testConfig);
+            jest.clearAllMocks();
+        });
+
+        describe('get', () => {
+            it('should do a simple GET request', async () => {
+                const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                const response = await api.get<typeof testData.response>(testData.route);
+
+                expect(fetchMock).toHaveBeenCalledTimes(1);
+                const [url, options] = fetchMock.mock.calls[0];
+
+                expect(url).toBe(`${testConfig.host}${testData.route}`);
+                expect(options.method).toBe('get');
+                expect(response).toEqual(testData.response);
+            });
+
+            it('should make the promise fail on a failed request', async () => {
+                const error = new Error('the request has failed');
+                global.fetch.mockRejectedValue(error);
+
+                try {
+                    await api.get(testData.route);
+                } catch (e) {
+                    expect(e).toEqual(error);
+                }
+            });
+
+            it('should bind GET requests to an abort signal', () => {
+                global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                api.get(testData.route);
+                expect(global.fetch.mock.calls[0][1].signal).toBeDefined();
+                expect(global.fetch.mock.calls[0][1].signal instanceof AbortSignal).toBe(true);
+            });
+        });
+
+        describe('post', () => {
+            it('should do a simple POST request', async () => {
+                const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                const response = await api.post(testData.route, testData.body);
+
+                expect(fetchMock).toHaveBeenCalledTimes(1);
+                const [url, options] = fetchMock.mock.calls[0];
+
+                expect(url).toBe(`${testConfig.host}${testData.route}`);
+                expect(options.method).toBe('post');
+                expect(options.body).toBe(JSON.stringify(testData.body));
+                expect(options.headers).toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
+                expect(response).toEqual(testData.response);
+            });
+
+            it('should not bind POST requests to an abort signal', () => {
+                global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                api.post(testData.route, testData.body);
+                expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
+            });
+        });
+
+        describe('postForm', () => {
+            const formMock: jest.Mocked<FormData> = jest.fn() as any;
+
+            it('should do a simple POST request using form data', async () => {
+                const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                const response = await api.postForm(testData.route, formMock);
+
+                expect(fetchMock).toHaveBeenCalledTimes(1);
+                const [url, options] = fetchMock.mock.calls[0];
+
+                expect(url).toBe(`${testConfig.host}${testData.route}`);
+                expect(options.method).toBe('post');
+                expect(options.body).toBe(formMock);
+                expect(options.headers).not.toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
+                expect(response).toEqual(testData.response);
+            });
+
+            it('should not bind POST requests to an abort signal', () => {
+                global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                api.postForm(testData.route, formMock);
+                expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
+            });
+        });
+
+        describe('put', () => {
+            it('should do a simple PUT request', async () => {
+                const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                const response = await api.put(testData.route, testData.body);
+
+                expect(fetchMock).toHaveBeenCalledTimes(1);
+                const [url, options] = fetchMock.mock.calls[0];
+
+                expect(url).toBe(`${testConfig.host}${testData.route}`);
+                expect(options.method).toBe('put');
+                expect(options.body).toBe(JSON.stringify(testData.body));
+                expect(options.headers).toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
+                expect(response).toEqual(testData.response);
+            });
+
+            it('should not bind PUT requests to an abort signal', () => {
+                global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                api.put(testData.route, testData.body);
+                expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
+            });
+        });
+
+        describe('delete', () => {
+            it('should do a simple DELETE request', async () => {
+                const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                const response = await api.delete(testData.route);
+
+                expect(fetchMock).toHaveBeenCalledTimes(1);
+                const [url, options] = fetchMock.mock.calls[0];
+
+                expect(url).toBe(`${testConfig.host}${testData.route}`);
+                expect(options.method).toBe('delete');
+                expect(response).toEqual(testData.response);
+            });
+
+            it('should not bind DELETE requests to an abort signal', () => {
+                global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                api.delete(testData.route);
+                expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
+            });
+        });
+
+        describe('when calling abortGetRequests', () => {
+            it('should abort pending get requests', () => {
+                global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                api.get(testData.route);
+                expect(global.fetch.mock.calls[0][1].signal.aborted).toBe(false);
+                api.abortGetRequests();
+                expect(global.fetch.mock.calls[0][1].signal.aborted).toBe(true);
+            });
+
+            it('should not abort get requests that are being sent after the abort signal', () => {
+                global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                api.abortGetRequests();
+                api.get(testData.route);
+                expect(global.fetch.mock.calls[0][1].signal.aborted).toBe(false);
+            });
+
+            it('should not resolve nor reject the fetch promise', () => {
+                jest.useFakeTimers();
+                const resolvedPromiseSpy = jest.fn().mockName('resolvedPromiseSpy');
+                const rejectedPromiseSpy = jest.fn().mockName('rejectedPromiseSpy');
+
+                global.fetch.mockImplementationOnce(() => {
+                    return new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve(new Response(JSON.stringify(testData.response), {status: 200}));
+                        }, 1000);
+                    });
+                });
+
+                api.get(testData.route)
+                    .then(resolvedPromiseSpy)
+                    .catch(rejectedPromiseSpy);
+
+                jest.advanceTimersByTime(500);
+                api.abortGetRequests();
+                jest.advanceTimersByTime(2000);
+
+                expect(resolvedPromiseSpy).not.toHaveBeenCalled();
+                expect(rejectedPromiseSpy).not.toHaveBeenCalled();
+            });
         });
     });
 
-    describe('get', () => {
-        it('should do a simple GET request', async () => {
-            const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            const response = await api.get<typeof testData.response>(testData.route);
-
-            expect(fetchMock).toHaveBeenCalledTimes(1);
-            const [url, options] = fetchMock.mock.calls[0];
-
-            expect(url).toBe(`${testConfig.host}${testData.route}`);
-            expect(options.method).toBe('get');
-            expect(response).toEqual(testData.response);
-        });
-
-        it('should make the promise fail on a failed request', async () => {
-            const error = new Error('the request has failed');
-            global.fetch.mockRejectedValue(error);
-
-            try {
-                await api.get(testData.route);
-            } catch (e) {
-                expect(e).toEqual(error);
-            }
-        });
-
-        it('should bind GET requests to an abort signal', () => {
-            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            api.get(testData.route);
-            expect(global.fetch.mock.calls[0][1].signal).toBeDefined();
-            expect(global.fetch.mock.calls[0][1].signal instanceof AbortSignal).toBe(true);
-        });
-    });
-
-    describe('post', () => {
-        it('should do a simple POST request', async () => {
-            const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            const response = await api.post(testData.route, testData.body);
-
-            expect(fetchMock).toHaveBeenCalledTimes(1);
-            const [url, options] = fetchMock.mock.calls[0];
-
-            expect(url).toBe(`${testConfig.host}${testData.route}`);
-            expect(options.method).toBe('post');
-            expect(options.body).toBe(JSON.stringify(testData.body));
-            expect(options.headers).toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
-            expect(response).toEqual(testData.response);
-        });
-
-        it('should not bind POST requests to an abort signal', () => {
-            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            api.post(testData.route, testData.body);
-            expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
-        });
-    });
-
-    describe('postForm', () => {
-        const formMock: jest.Mocked<FormData> = jest.fn() as any;
-
-        it('should do a simple POST request using form data', async () => {
-            const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            const response = await api.postForm(testData.route, formMock);
-
-            expect(fetchMock).toHaveBeenCalledTimes(1);
-            const [url, options] = fetchMock.mock.calls[0];
-
-            expect(url).toBe(`${testConfig.host}${testData.route}`);
-            expect(options.method).toBe('post');
-            expect(options.body).toBe(formMock);
-            expect(options.headers).not.toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
-            expect(response).toEqual(testData.response);
-        });
-
-        it('should not bind POST requests to an abort signal', () => {
-            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            api.postForm(testData.route, formMock);
-            expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
-        });
-    });
-
-    describe('put', () => {
-        it('should do a simple PUT request', async () => {
-            const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            const response = await api.put(testData.route, testData.body);
-
-            expect(fetchMock).toHaveBeenCalledTimes(1);
-            const [url, options] = fetchMock.mock.calls[0];
-
-            expect(url).toBe(`${testConfig.host}${testData.route}`);
-            expect(options.method).toBe('put');
-            expect(options.body).toBe(JSON.stringify(testData.body));
-            expect(options.headers).toEqual(expect.objectContaining({'Content-Type': 'application/json'}));
-            expect(response).toEqual(testData.response);
-        });
-
-        it('should not bind PUT requests to an abort signal', () => {
-            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            api.put(testData.route, testData.body);
-            expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
-        });
-    });
-
-    describe('delete', () => {
-        it('should do a simple DELETE request', async () => {
-            const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            const response = await api.delete(testData.route);
-
-            expect(fetchMock).toHaveBeenCalledTimes(1);
-            const [url, options] = fetchMock.mock.calls[0];
-
-            expect(url).toBe(`${testConfig.host}${testData.route}`);
-            expect(options.method).toBe('delete');
-            expect(response).toEqual(testData.response);
-        });
-
-        it('should not bind DELETE requests to an abort signal', () => {
-            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            api.delete(testData.route);
-            expect(global.fetch.mock.calls[0][1].signal).toBeUndefined();
-        });
+    it('should not throw errors when instanciating a new API', () => {
+        expect(() => {
+            new API(testConfig);
+        }).not.toThrow();
     });
 
     it('should give priority to custom response handlers when specified', async () => {
@@ -160,45 +203,16 @@ describe('APICore', () => {
         expect(CustomResponseHandler.process).toHaveBeenCalledTimes(1);
     });
 
-    describe('when calling abortGetRequests', () => {
-        it('should abort pending get requests', () => {
-            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            api.get(testData.route);
-            expect(global.fetch.mock.calls[0][1].signal.aborted).toBe(false);
-            api.abortGetRequests();
-            expect(global.fetch.mock.calls[0][1].signal.aborted).toBe(true);
+    describe('organizationId', () => {
+        it('should return the organization id option if no organizationIdRetriever is set', () => {
+            const api = new API(testConfig);
+            expect(api.organizationId).toBe(testConfig.organizationId);
         });
 
-        it('should not abort get requests that are being sent after the abort signal', () => {
-            global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-            api.abortGetRequests();
-            api.get(testData.route);
-            expect(global.fetch.mock.calls[0][1].signal.aborted).toBe(false);
-        });
-
-        it('should not resolve nor reject the fetch promise', () => {
-            jest.useFakeTimers();
-            const resolvedPromiseSpy = jest.fn().mockName('resolvedPromiseSpy');
-            const rejectedPromiseSpy = jest.fn().mockName('rejectedPromiseSpy');
-
-            global.fetch.mockImplementationOnce(() => {
-                return new Promise((resolve) => {
-                    setTimeout(() => {
-                        resolve(new Response(JSON.stringify(testData.response), {status: 200}));
-                    }, 1000);
-                });
-            });
-
-            api.get(testData.route)
-                .then(resolvedPromiseSpy)
-                .catch(rejectedPromiseSpy);
-
-            jest.advanceTimersByTime(500);
-            api.abortGetRequests();
-            jest.advanceTimersByTime(2000);
-
-            expect(resolvedPromiseSpy).not.toHaveBeenCalled();
-            expect(rejectedPromiseSpy).not.toHaveBeenCalled();
+        it('should return call the organization id retriver function to get the organization id', () => {
+            const api = new API({...testConfig, organizationIdRetriever: () => 'another-org-id'});
+            expect(api.organizationId).not.toBe(testConfig.organizationId);
+            expect(api.organizationId).toBe('another-org-id');
         });
     });
 });


### PR DESCRIPTION
This way we'll ensure the org is always the right one at the time of making the calls.