### PR TITLE
build(webpack): use the Entry.ts file as webpack entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,5 @@
         "commitizen": {
             "path": "./node_modules/cz-conventional-changelog"
         }
-    },
-    "sideEffects": [
-        "./src/resources/Enums.ts"
-    ]
+    }
 }

--- a/src/PlatformClient.ts
+++ b/src/PlatformClient.ts
@@ -1,5 +1,3 @@
-import './resources/Enums';
-
 import API from './APICore';
 import {APIConfiguration, PlatformClientOptions} from './ConfigurationInterfaces';
 import {HostUndefinedError} from './Errors';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = (env, argv) => {
     const production = argv.mode === 'production';
 
     return {
-        entry: './src/PlatformClient.ts',
+        entry: './src/Entry.ts',
         devtool: production ? 'source-map' : 'inline-source-map',
         output: {
             filename: 'index.js',


### PR DESCRIPTION
My fix from yesterday wasn't working after all. Found out the real cause :crossed_fingers:. Our webpack config wasn't using our `Entry.ts` file as actual entry :open_mouth: 