### PR TITLE
fix(saml): change "identityProvider" path for "identityprovider"

### DIFF
--- a/src/resources/Saml/Saml.ts
+++ b/src/resources/Saml/Saml.ts
@@ -16,22 +16,22 @@ export default class Saml extends Resource {
     }
 
     deleteProvider() {
-        return this.api.delete(`${Saml.baseUrl}/identityProvider`);
+        return this.api.delete(`${Saml.baseUrl}/identityprovider`);
     }
 
     getProvider() {
-        return this.api.get<SamlIdentityProviderModel>(`${Saml.baseUrl}/identityProvider`);
+        return this.api.get<SamlIdentityProviderModel>(`${Saml.baseUrl}/identityprovider`);
     }
 
     create(identityProvider: New<SamlIdentityProviderModel>) {
-        return this.api.post<SamlIdentityProviderModel>(`${Saml.baseUrl}/identityProvider`, identityProvider);
+        return this.api.post<SamlIdentityProviderModel>(`${Saml.baseUrl}/identityprovider`, identityProvider);
     }
 
     update(identityProvider: SamlIdentityProviderModel) {
-        return this.api.put<SamlIdentityProviderModel>(`${Saml.baseUrl}/identityProvider`, identityProvider);
+        return this.api.put<SamlIdentityProviderModel>(`${Saml.baseUrl}/identityprovider`, identityProvider);
     }
 
     listRealms() {
-        return this.api.get<RealmModel[]>(`${Saml.baseUrl}/identityProvider/realms`);
+        return this.api.get<RealmModel[]>(`${Saml.baseUrl}/identityprovider/realms`);
     }
 }

--- a/src/resources/Saml/tests/Saml.spec.ts
+++ b/src/resources/Saml/tests/Saml.spec.ts
@@ -33,31 +33,31 @@ describe('Saml', () => {
     });
 
     describe('getProvider', () => {
-        it('should make a GET call to "/saml/identityProvider"', () => {
+        it('should make a GET call to "/saml/identityprovider"', () => {
             saml.getProvider();
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith('/rest/organizations/{organizationName}/saml/identityProvider');
+            expect(api.get).toHaveBeenCalledWith('/rest/organizations/{organizationName}/saml/identityprovider');
         });
     });
 
     describe('listRealms', () => {
-        it('should make a GET call to "/saml/identityProvider/realms"', () => {
+        it('should make a GET call to "/saml/identityprovider/realms"', () => {
             saml.listRealms();
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith('/rest/organizations/{organizationName}/saml/identityProvider/realms');
+            expect(api.get).toHaveBeenCalledWith('/rest/organizations/{organizationName}/saml/identityprovider/realms');
         });
     });
 
     describe('deleteProvdier', () => {
-        it('should make a DELETE call to "/saml/identityProvider"', () => {
+        it('should make a DELETE call to "/saml/identityprovider"', () => {
             saml.deleteProvider();
             expect(api.delete).toHaveBeenCalledTimes(1);
-            expect(api.delete).toHaveBeenCalledWith('/rest/organizations/{organizationName}/saml/identityProvider');
+            expect(api.delete).toHaveBeenCalledWith('/rest/organizations/{organizationName}/saml/identityprovider');
         });
     });
 
     describe('create', () => {
-        it('should make a POST call to "/saml/identityProvider"', () => {
+        it('should make a POST call to "/saml/identityprovider"', () => {
             const provider: New<SamlIdentityProviderModel> = {
                 displayName: 'My SAML SSO',
                 entityId: 'whatever',
@@ -69,14 +69,14 @@ describe('Saml', () => {
             saml.create(provider);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(
-                '/rest/organizations/{organizationName}/saml/identityProvider',
+                '/rest/organizations/{organizationName}/saml/identityprovider',
                 provider
             );
         });
     });
 
     describe('update', () => {
-        it('should make a PUT call to "/saml/identityProvider"', () => {
+        it('should make a PUT call to "/saml/identityprovider"', () => {
             const provider: SamlIdentityProviderModel = {
                 id: '123-abc',
                 displayName: 'My SAML SSO',
@@ -89,7 +89,7 @@ describe('Saml', () => {
             saml.update(provider);
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(
-                '/rest/organizations/{organizationName}/saml/identityProvider',
+                '/rest/organizations/{organizationName}/saml/identityprovider',
                 provider
             );
         });


### PR DESCRIPTION
I did a typo when implementing the saml identity provider calls. The correct path is `identityprovider` and not `identityProvider` (see https://platformdev.cloud.coveo.com/docs/?api=AuthorizationServer#/Saml32Identity32Providers).