### PR TITLE
Add organization status call and options for GET organization

### DIFF
--- a/src/resources/Organizations/Organization.ts
+++ b/src/resources/Organizations/Organization.ts
@@ -1,7 +1,13 @@
 import API from '../../APICore';
 import {PageModel, PrivilegeModel} from '../BaseInterfaces';
 import Resource from '../Resource';
-import {CreateOrganizationOptions, ListOrganizationOptions, OrganizationModel} from './OrganizationInterfaces';
+import {
+    CreateOrganizationOptions,
+    GetOrganizationOptions,
+    ListOrganizationOptions,
+    OrganizationModel,
+    OrganizationsStatusModel,
+} from './OrganizationInterfaces';
 
 export default class Organization extends Resource {
     static baseUrl = '/rest/organizations';
@@ -18,12 +24,16 @@ export default class Organization extends Resource {
         return this.api.delete(`${Organization.baseUrl}/${organizationId}`);
     }
 
-    get(organizationId: string) {
-        return this.api.get<OrganizationModel>(`${Organization.baseUrl}/${organizationId}`);
+    get(organizationId: string, options?: GetOrganizationOptions) {
+        return this.api.get<OrganizationModel>(this.buildPath(`${Organization.baseUrl}/${organizationId}`, options));
     }
 
     update(organization: Partial<OrganizationModel>) {
         return this.api.put<OrganizationModel>(`${Organization.baseUrl}/${organization.id}`, organization);
+    }
+
+    status(organizationId: string = API.orgPlaceholder) {
+        return this.api.get<OrganizationsStatusModel>(`${Organization.baseUrl}/${organizationId}/status`);
     }
 
     listPrivileges() {

--- a/src/resources/Organizations/OrganizationInterfaces.ts
+++ b/src/resources/Organizations/OrganizationInterfaces.ts
@@ -20,18 +20,24 @@ export interface OrganizationModel {
     id: string;
     displayName: string;
     createdDate: number;
-    license: LicenseModel;
-    organizationStatusModel: OrganizationsStatusModel;
     publicContentOnly: boolean;
     type: string;
     owner: {
         email: string;
     };
     readOnly: boolean;
+    license?: LicenseModel;
+    organizationStatusModel?: OrganizationsStatusModel;
+}
+
+export type AdditionalOrganizationField = 'status' | 'license' | string;
+
+export interface GetOrganizationOptions {
+    additionalFields?: AdditionalOrganizationField | AdditionalOrganizationField[];
 }
 
 export interface ListOrganizationOptions {
-    additionalFields?: string | string[];
+    additionalFields?: AdditionalOrganizationField | AdditionalOrganizationField[];
     filter?: string;
     order?: string;
     page?: number;

--- a/src/resources/Organizations/tests/Organizations.spec.ts
+++ b/src/resources/Organizations/tests/Organizations.spec.ts
@@ -48,6 +48,28 @@ describe('Organization', () => {
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Organization.baseUrl}/${organizationToGetId}`);
         });
+
+        it('should make a GET call with the specified options', () => {
+            const organizationToGetId = 'Organization-to-be-fetched';
+            organization.get(organizationToGetId, {
+                additionalFields: 'status',
+            });
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Organization.baseUrl}/${organizationToGetId}?additionalFields=status`
+            );
+        });
+
+        it('should make a GET call with the multiple additional fields', () => {
+            const organizationToGetId = 'Organization-to-be-fetched';
+            organization.get(organizationToGetId, {
+                additionalFields: ['status', 'license'],
+            });
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Organization.baseUrl}/${organizationToGetId}?additionalFields=status%2Clicense`
+            );
+        });
     });
 
     describe('update', () => {
@@ -60,6 +82,21 @@ describe('Organization', () => {
             organization.update(organizationModel);
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(`${Organization.baseUrl}/${organizationModel.id}`, organizationModel);
+        });
+    });
+
+    describe('status', () => {
+        it('should make a GET call to the specific Organization status url', () => {
+            const organizationToGetId = 'Organization-to-be-fetched';
+            organization.status(organizationToGetId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Organization.baseUrl}/${organizationToGetId}/status`);
+        });
+
+        it('should make a GET call to /rest/organizations/{organizationName}/status if the orgId is not specified', () => {
+            organization.status();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`/rest/organizations/{organizationName}/status`);
         });
     });
 


### PR DESCRIPTION
I tried to use `Platform.organization.get` and noticed there were some missing fields in the response.

In the Swagger call, it mentions the `additionalFields` which was not fronted, so I added that as an option to the GET call.

I then adapted the response model to assume that those fields might be null.

I then added known values for `AdditionalFields`, it doesn't look like it actually works for auto-completion though 🤔

And then I added the `status` call, because, in fact, this is what I needed in the first place 😄 