### PR TITLE
fix(apihooks): expose apiwithhooks

### DIFF
--- a/src/Entry.ts
+++ b/src/Entry.ts
@@ -2,5 +2,6 @@ export * from './PlatformClient';
 export * from './ConfigurationInterfaces';
 export * from './APICore';
 export * from './Errors';
+export * from './features';
 export * from './handlers';
 export * from './resources';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,0 +1,2 @@
+export * from './APIFeature';
+export * from './APIWithHooks';


### PR DESCRIPTION
I wanted to use `APIWithHooks` but it was not exposed 🤦‍♂ 