### PR TITLE
Remove commitizen hook on `git commit` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "test": "jest --clearCache && jest",
         "test:changed": "jest --watch",
         "test:watch": "jest --watchAll",
-        "release": "semantic-release"
+        "release": "semantic-release",
+        "commit-cli": "git-cz"
     },
     "devDependencies": {
         "@commitlint/cli": "^8.3.5",
@@ -46,8 +47,7 @@
     "husky": {
         "hooks": {
             "pre-commit": "lint-staged",
-            "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-            "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true"
+            "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
         }
     },
     "lint-staged": {

--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -375,3 +375,27 @@ export enum ModelConfigFileType {
     FACET_ID_MAPPING = 'FACET_ID_MAPPING',
     DEFAULT_QUERIES = 'DEFAULT_QUERIES',
 }
+
+export enum ProductType {
+    INTERNAL = 'INTERNAL',
+    SALES = 'SALES',
+    ALLIANCE = 'ALLIANCE',
+    SANDBOX = 'SANDBOX',
+    STANDARD = 'STANDARD',
+    TRIAL = 'TRIAL',
+}
+
+export enum ProductEdition {
+    ENTERPRISE = 'ENTERPRISE',
+    FREE = 'FREE',
+    PRO = 'PRO',
+}
+
+export enum ProductName {
+    COVEO_CLOUD = 'COVEO_CLOUD',
+    DYNAMICS = 'DYNAMICS',
+    SALESFORCE = 'SALESFORCE',
+    SERVICENOW = 'SERVICENOW',
+    SITECORE = 'SITECORE',
+    USAGE_ANALYTICS = 'USAGE_ANALYTICS',
+}


### PR DESCRIPTION
The commitizen cli was being prompted whenever we would commit something, even if we were already providing a valid commit message, which was quite a bit annoying. 

I removed the commitzen cli hook on the `git commit` command and added a npm script to prompt the commit helper cli when needed. The cli tool will now be used more as an opt-in feature rather than an obligation.

To commit changes, you will now have 2 options:
- run `npm run commit-cli`: the commitizen cli will be prompted and will ask you questions in order to generate a proper commit message.
- commit normally using your preferred method (you still need to write a commit message that follows the conventional commit pattern or it won't let you commit)