### PR TITLE
ci(travis): prevent builds on other branches than master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: node_js
 node_js:
   - lts/*
 
+branches:
+    only:
+        - master
+
 stages:
   - analyse commits
   - test


### PR DESCRIPTION
Travis was running builds for all branches (even if no PRs are opened on the branch).
With this change TravisCI will still trigger builds for PRs, but will not build other branches than master.