### PR TITLE
fix(modelConfig): change content-type of update

### DIFF
--- a/src/resources/MachineLearning/ModelConfiguration/ModelConfiguration.ts
+++ b/src/resources/MachineLearning/ModelConfiguration/ModelConfiguration.ts
@@ -24,7 +24,8 @@ export default class ModelConfiguration extends Resource {
     ) {
         return this.api.put<AdvancedRegistrationConfigFileCreationResponse>(
             this.buildPath(ModelConfiguration.getBaseUrl(modelId, modelConfigFileType), {languageCode}),
-            modelConfigFileContents
+            modelConfigFileContents,
+            {method: 'put', body: modelConfigFileContents, headers: {'Content-Type': 'text/plain'}}
         );
     }
 }

--- a/src/resources/MachineLearning/ModelConfiguration/tests/ModelConfiguration.spec.ts
+++ b/src/resources/MachineLearning/ModelConfiguration/tests/ModelConfiguration.spec.ts
@@ -36,7 +36,8 @@ describe('ModelConfiguration', () => {
             expect(api.put).toBeCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(
                 ModelConfiguration.getBaseUrl(modelId, modelConfigFileType),
-                modelConfigFileContents
+                modelConfigFileContents,
+                {method: 'put', body: modelConfigFileContents, headers: {'Content-Type': 'text/plain'}}
             );
         });
     });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52677246/73665596-5cc5c300-466f-11ea-95f3-fb4774504468.png)
Currently, we have `headers: {'Content-Type': 'application/json'}` for PUT method by default, however, for the update request to advanced model configuration we will need the Content-Type of `'text/plain'`.