### PR TITLE
fix(modelconfiguration): update content-type

### DIFF
--- a/src/resources/MachineLearning/ModelConfiguration/ModelConfiguration.ts
+++ b/src/resources/MachineLearning/ModelConfiguration/ModelConfiguration.ts
@@ -24,7 +24,8 @@ export default class ModelConfiguration extends Resource {
     ) {
         return this.api.put<AdvancedRegistrationConfigFileCreationResponse>(
             this.buildPath(ModelConfiguration.getBaseUrl(modelId, modelConfigFileType), {languageCode}),
-            modelConfigFileContents
+            modelConfigFileContents,
+            {method: 'put', body: modelConfigFileContents, headers: {'Content-Type': 'text/plain'}}
         );
     }
 }

--- a/src/resources/MachineLearning/ModelConfiguration/tests/ModelConfiguration.spec.ts
+++ b/src/resources/MachineLearning/ModelConfiguration/tests/ModelConfiguration.spec.ts
@@ -36,7 +36,8 @@ describe('ModelConfiguration', () => {
             expect(api.put).toBeCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(
                 ModelConfiguration.getBaseUrl(modelId, modelConfigFileType),
-                modelConfigFileContents
+                modelConfigFileContents,
+                {method: 'put', body: modelConfigFileContents, headers: {'Content-Type': 'text/plain'}}
             );
         });
     });


### PR DESCRIPTION
Currently, we have `headers: {'Content-Type': 'application/json'}` for PUT method by default, however, we will need the Content-Type to be 'text/plain' for the update request of advanced model configuration.
![image](https://user-images.githubusercontent.com/52677246/73674959-96062f00-467f-11ea-9e85-c4f0f61d8b6d.png)
