### PR TITLE
Add the `user` resource

### DIFF
--- a/src/PlatformClient.ts
+++ b/src/PlatformClient.ts
@@ -25,7 +25,6 @@ export class PlatformClient extends PlatformResources {
     };
 
     private options: PlatformClientOptions;
-    private tokenInfo: Record<string, any>; // define a better type
 
     constructor(options: PlatformClientOptions) {
         super();
@@ -55,11 +54,7 @@ export class PlatformClient extends PlatformResources {
     }
 
     async initialize() {
-        try {
-            this.tokenInfo = await this.checkToken();
-        } catch (err) {
-            throw new Error(err.message);
-        }
+        return this.API.checkToken();
     }
 
     abortPendingGetRequests() {
@@ -76,12 +71,6 @@ export class PlatformClient extends PlatformResources {
 
     private get host(): string {
         return this.options.host || PlatformClient.Hosts[this.options.environment];
-    }
-
-    private async checkToken() {
-        const formData = new FormData();
-        formData.set('token', this.options.accessTokenRetriever());
-        return this.API.postForm<any>('/oauth/check_token', formData);
     }
 }
 

--- a/src/features/APIWithHooks.ts
+++ b/src/features/APIWithHooks.ts
@@ -1,4 +1,5 @@
 import {IAPI} from '../APICore';
+import {UserModel} from '../resources/Users';
 
 export interface IAPIHooks {
     beforeRequest?: (url: string, args: RequestInit) => void;
@@ -43,6 +44,14 @@ export class APIWithHooks<TAPI extends IAPI = IAPI> implements IAPI {
 
     abortGetRequests(): void {
         this.api.abortGetRequests();
+    }
+
+    async checkToken() {
+        return this.api.checkToken();
+    }
+
+    get currentUser(): UserModel {
+        return this.api.currentUser;
     }
 
     private async wrapInGenericHandler<T>(url: string, args: RequestInit, request: () => Promise<T>) {

--- a/src/features/tests/APIWithHooks.spec.ts
+++ b/src/features/tests/APIWithHooks.spec.ts
@@ -1,4 +1,5 @@
 import {IAPI} from '../../APICore';
+import {UserModel} from '../../resources/Users';
 import {APIWithHooks} from '../APIWithHooks';
 
 jest.mock('../../APICore');
@@ -11,6 +12,8 @@ const mockApi = (): jest.Mocked<IAPI> => ({
     delete: jest.fn().mockImplementation(() => Promise.resolve({})),
     put: jest.fn().mockImplementation(() => Promise.resolve({})),
     abortGetRequests: jest.fn(),
+    checkToken: jest.fn().mockImplementation(() => Promise.resolve()),
+    currentUser: {} as UserModel,
 });
 
 describe('APIWithHooks', () => {

--- a/src/resources/PlatformResources.ts
+++ b/src/resources/PlatformResources.ts
@@ -14,6 +14,7 @@ import Resource from './Resource';
 import Saml from './Saml/Saml';
 import SecurityCache from './SecurityCache/SecurityCache';
 import Sources from './Sources/Sources';
+import User from './Users/User';
 
 const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'aws', resource: AWS},
@@ -30,6 +31,7 @@ const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'source', resource: Sources},
     {key: 'field', resource: Field},
     {key: 'saml', resource: Saml},
+    {key: 'user', resource: User},
 ];
 
 class PlatformResources {
@@ -49,6 +51,7 @@ class PlatformResources {
     source: Sources;
     field: Field;
     saml: Saml;
+    user: User;
 
     registerAll() {
         resourcesMap.forEach(({key, resource}) => {

--- a/src/resources/Users/User.ts
+++ b/src/resources/Users/User.ts
@@ -1,0 +1,19 @@
+import {RealmModel} from '../Groups';
+import Resource from '../Resource';
+import {UserModel} from './UserInterfaces';
+
+export default class User extends Resource {
+    static baseUrl = '/rest/users';
+
+    get(username: string) {
+        return this.api.get<UserModel>(`${User.baseUrl}/${username}`);
+    }
+
+    update(username: string, user: UserModel) {
+        return this.api.put(`${User.baseUrl}/${username}`, user);
+    }
+
+    listRealms(username: string) {
+        return this.api.get<RealmModel[]>(`${User.baseUrl}/${username}/realms`);
+    }
+}

--- a/src/resources/Users/User.ts
+++ b/src/resources/Users/User.ts
@@ -5,12 +5,12 @@ import {UserModel} from './UserInterfaces';
 export default class User extends Resource {
     static baseUrl = '/rest/users';
 
-    get(username: string) {
+    get(username: string = this.api.currentUser?.username) {
         return this.api.get<UserModel>(`${User.baseUrl}/${username}`);
     }
 
-    update(username: string, user: UserModel) {
-        return this.api.put(`${User.baseUrl}/${username}`, user);
+    update(user: Partial<UserModel>) {
+        return this.api.put(`${User.baseUrl}/${this.api.currentUser?.username}`, {...this.api.currentUser, ...user});
     }
 
     listRealms(username: string) {

--- a/src/resources/Users/UserInterfaces.ts
+++ b/src/resources/Users/UserInterfaces.ts
@@ -1,0 +1,31 @@
+import {AuthProvider} from '../Enums';
+import {RealmModel} from '../Groups';
+
+export interface UserModel {
+    additionalInformation: Record<string, any>;
+    country: string;
+    credentialsExpired: boolean;
+    displayName: string;
+    email: string;
+    emailAliases: string[];
+    emailConfirmed: boolean;
+    enabled: boolean;
+    expired: boolean;
+    firstName: string;
+    lastLogin: number;
+    lastName: string;
+    locked: boolean;
+    name: string;
+    provider: AuthProvider;
+    providerUserId: string;
+    providerUsername: string;
+    realms: UserRealmModel[];
+    samlIdentityProviderId: string;
+    socialUser: boolean;
+    username: string;
+}
+
+export interface UserRealmModel {
+    member: boolean;
+    realm: RealmModel;
+}

--- a/src/resources/Users/index.ts
+++ b/src/resources/Users/index.ts
@@ -1,0 +1,2 @@
+export * from './User';
+export * from './UserInterfaces';

--- a/src/resources/Users/tests/User.spec.ts
+++ b/src/resources/Users/tests/User.spec.ts
@@ -24,21 +24,38 @@ describe('User', () => {
     });
 
     describe('update', () => {
-        it('should make a PUT call to the specific Organization url', () => {
-            const userModel = {
-                additionalInformation: {},
-                username: '🥕',
-                displayName: 'carrot',
-            } as UserModel;
+        const currentUser: UserModel = {
+            additionalInformation: {},
+            username: '🥕',
+        } as UserModel;
 
-            user.update('🥕', userModel);
+        beforeEach(() => {
+            Object.defineProperty(api, 'currentUser', {
+                get: jest.fn(() => currentUser),
+            });
+        });
+
+        it('should make a PUT call to the specific user url and extend existing current user attributes', () => {
+            const userModel: Partial<UserModel> = {
+                additionalInformation: {happy: true},
+                displayName: 'carrot',
+            };
+
+            user.update(userModel);
             expect(api.put).toHaveBeenCalledTimes(1);
-            expect(api.put).toHaveBeenCalledWith('/rest/users/🥕', userModel);
+            expect(api.put).toHaveBeenCalledWith(
+                '/rest/users/🥕',
+                expect.objectContaining({
+                    additionalInformation: {happy: true},
+                    displayName: 'carrot',
+                    username: '🥕',
+                })
+            );
         });
     });
 
     describe('listRealms', () => {
-        it('should make a GET call /rest/organizations/{organizationName}/privileges', () => {
+        it('should make a GET call /rest/users/{username}/realms', () => {
             user.listRealms('🍪');
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith('/rest/users/🍪/realms');

--- a/src/resources/Users/tests/User.spec.ts
+++ b/src/resources/Users/tests/User.spec.ts
@@ -1,0 +1,47 @@
+import API from '../../../APICore';
+import User from '../User';
+import {UserModel} from '../UserInterfaces';
+
+jest.mock('../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('User', () => {
+    let user: User;
+    const api = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        user = new User(api);
+    });
+
+    describe('get', () => {
+        it('should make a GET call to the User base url', () => {
+            user.get('💎');
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith('/rest/users/💎');
+        });
+    });
+
+    describe('update', () => {
+        it('should make a PUT call to the specific Organization url', () => {
+            const userModel = {
+                additionalInformation: {},
+                username: '🥕',
+                displayName: 'carrot',
+            } as UserModel;
+
+            user.update('🥕', userModel);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith('/rest/users/🥕', userModel);
+        });
+    });
+
+    describe('listRealms', () => {
+        it('should make a GET call /rest/organizations/{organizationName}/privileges', () => {
+            user.listRealms('🍪');
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith('/rest/users/🍪/realms');
+        });
+    });
+});

--- a/src/resources/tests/PlatformResources.spec.ts
+++ b/src/resources/tests/PlatformResources.spec.ts
@@ -12,6 +12,7 @@ import PlatformResources from '../PlatformResources';
 import Saml from '../Saml/Saml';
 import SecurityCache from '../SecurityCache/SecurityCache';
 import Sources from '../Sources/Sources';
+import User from '../Users/User';
 
 describe('PlatformResources', () => {
     describe('registerAll', () => {
@@ -117,6 +118,14 @@ describe('PlatformResources', () => {
 
             expect(platformResources.saml).toBeDefined();
             expect(platformResources.saml).toBeInstanceOf(Saml);
+        });
+
+        it('should register the user resource on the platform instance', () => {
+            const platformResources = new PlatformResources();
+            platformResources.registerAll();
+
+            expect(platformResources.user).toBeDefined();
+            expect(platformResources.user).toBeInstanceOf(User);
         });
     });
 });

--- a/src/tests/PlatformClient.spec.ts
+++ b/src/tests/PlatformClient.spec.ts
@@ -82,43 +82,6 @@ describe('PlatformClient', () => {
         expect(registerAllSpy).toHaveBeenCalledTimes(1);
     });
 
-    describe('initialize', () => {
-        const mockedFormData = {
-            set: jest.fn(),
-        };
-
-        beforeEach(() => {
-            (global as any).FormData = jest.fn(() => mockedFormData);
-        });
-
-        it('should check if the retrieved token is valid', async () => {
-            const platform = new PlatformClient(baseOptions);
-            const APIMockInstance = APIMock.mock.instances[0];
-
-            await platform.initialize();
-
-            expect(APIMockInstance.postForm).toHaveBeenCalledTimes(1);
-            expect(APIMockInstance.postForm).toHaveBeenCalledWith('/oauth/check_token', mockedFormData);
-            expect(mockedFormData.set).toHaveBeenCalledTimes(1);
-            expect(mockedFormData.set).toHaveBeenCalledWith('token', baseOptions.accessTokenRetriever());
-        });
-
-        it('should throw an error if the check token call fails', async () => {
-            const platform = new PlatformClient(baseOptions);
-            const APIPostFormMock: jest.Mock<ReturnType<typeof API.prototype.postForm>> = APIMock.mock.instances[0]
-                .postForm as any;
-            APIPostFormMock.mockRejectedValue(new Error('invalid token'));
-
-            try {
-                await platform.initialize();
-            } catch (err) {
-                expect(err.message).toBe('invalid token');
-            }
-
-            expect.assertions(1);
-        });
-    });
-
     it('should abort get requests on the API instance', () => {
         const platform = new PlatformClient(baseOptions);
         const abortGetRequestsSpy = APIMock.mock.instances[0].abortGetRequests as jest.Mock<
@@ -128,6 +91,15 @@ describe('PlatformClient', () => {
         platform.abortPendingGetRequests();
 
         expect(abortGetRequestsSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should check the validity of the access token when initializing the platform client', () => {
+        const checkTokenSpy = jest.spyOn(API.prototype, 'checkToken');
+        const platform = new PlatformClient(baseOptions);
+
+        platform.initialize();
+
+        expect(checkTokenSpy).toHaveBeenCalledTimes(1);
     });
 
     describe('withFeatures', () => {


### PR DESCRIPTION
https://platformdev.cloud.coveo.com/docs/?api=AuthorizationServer#!/Users/rest_users_paramId_get

Added some logic to reuse the `UserModel` (current user) coming from the token information. We already fetch to check the token when initializing the platform client instance anyway.