### PR TITLE
refactor(ml-model): added get call renamed former get for getDetails

### DIFF
--- a/src/resources/MachineLearning/Models/Models.ts
+++ b/src/resources/MachineLearning/Models/Models.ts
@@ -14,8 +14,12 @@ export default class Models extends Resource {
         return this.api.get<MLModel[]>(`${Models.baseUrl}/details`);
     }
 
-    get(modelId: string) {
+    getDetails(modelId: string) {
         return this.api.get<MLModelInfo>(`${Models.baseUrl}/${modelId}/details`);
+    }
+
+    get(modelId: string) {
+        return this.api.get<MLModelInfo>(`${Models.baseUrl}/${modelId}`);
     }
 
     delete(modelId: string) {

--- a/src/resources/MachineLearning/Models/tests/Models.spec.ts
+++ b/src/resources/MachineLearning/Models/tests/Models.spec.ts
@@ -31,10 +31,20 @@ describe('Models', () => {
     });
 
     describe('get', () => {
-        it('should make a GET call to the specific Models url', () => {
+        it('should make a GET call to the specific Model', () => {
             const modelId = 'O. O';
 
             models.get(modelId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Models.baseUrl}/${modelId}`);
+        });
+    });
+
+    describe('getDetails', () => {
+        it("should make a GET call to the specific Model's Details", () => {
+            const modelId = 'O. O';
+
+            models.getDetails(modelId);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Models.baseUrl}/${modelId}/details`);
         });


### PR DESCRIPTION
used the former get call for the simpler get and moved the get call to the more apropriate
getDetails

BREAKING CHANGE: the get call will not get the same response (it is not used in the admin yet
though)