### PR TITLE
feat(enum): add en and fr to languagecode

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -399,3 +399,8 @@ export enum ProductName {
     SITECORE = 'SITECORE',
     USAGE_ANALYTICS = 'USAGE_ANALYTICS',
 }
+
+export enum LanguageCode {
+    English = 'en',
+    French = 'fr',
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52677246/74376013-5d690280-4daf-11ea-9618-5ea26c9775b7.png)
https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
We need _en_ and _fr_ for now, but all the languages in the list of ISO 639-1 should be added at the end of the day (**not today**)