### PR TITLE
Add some calls to the pipeline resource

### DIFF
--- a/src/resources/Pipelines/Pipelines.ts
+++ b/src/resources/Pipelines/Pipelines.ts
@@ -1,12 +1,18 @@
 import API from '../../APICore';
+import {PrivilegeModel} from '../BaseInterfaces';
 import Resource from '../Resource';
 import MLAssociations from './MLAssociations/MLAssociations';
-import {PipelineBackendVersion, PipelineModel} from './PipelinesInterfaces';
+import {
+    ListPipelinesOptions,
+    NewPipelineModel,
+    PipelineBackendVersion,
+    PipelineModel,
+    UpdatePipelineModel,
+} from './PipelinesInterfaces';
 
 export default class Pipelines extends Resource {
     static searchUrlVersion2 = '/rest/search/v2/admin/pipelines';
     static searchUrlVersion1 = '/rest/search/v1/admin/pipelines';
-    static searchUrl = '/rest/search/admin/pipelines';
 
     associations: MLAssociations;
 
@@ -16,15 +22,57 @@ export default class Pipelines extends Resource {
         this.associations = new MLAssociations(api);
     }
 
-    listBasicInfo() {
-        return this.api.get<PipelineModel[]>(
-            this.buildPath(Pipelines.searchUrl, {organizationId: this.api.organizationId})
+    getMLVersion() {
+        return this.api.get<PipelineBackendVersion>(
+            this.buildPath(`${Pipelines.searchUrlVersion2}/ml/version`, {organizationId: this.api.organizationId})
         );
     }
 
-    getBackendVersion() {
-        return this.api.get<PipelineBackendVersion>(
-            this.buildPath(`${Pipelines.searchUrlVersion2}/ml/version`, {organizationId: this.api.organizationId})
+    list(options?: ListPipelinesOptions) {
+        return this.api.get<PipelineModel[]>(
+            this.buildPath(Pipelines.searchUrlVersion1, {organizationId: this.api.organizationId, ...options})
+        );
+    }
+
+    get(pipelineId: string) {
+        return this.api.get<PipelineModel>(
+            this.buildPath(`${Pipelines.searchUrlVersion1}/${pipelineId}`, {
+                organizationId: this.api.organizationId,
+            })
+        );
+    }
+
+    delete(pipelineId: string) {
+        return this.api.delete(
+            this.buildPath(`${Pipelines.searchUrlVersion1}/${pipelineId}`, {
+                organizationId: this.api.organizationId,
+            })
+        );
+    }
+
+    update(pipeline: UpdatePipelineModel) {
+        return this.api.put<PrivilegeModel>(
+            this.buildPath(`${Pipelines.searchUrlVersion1}/${pipeline.id}`, {
+                organizationId: this.api.organizationId,
+            }),
+            pipeline
+        );
+    }
+
+    duplicate(pipelineId: string) {
+        return this.api.post<PipelineModel>(
+            this.buildPath(`${Pipelines.searchUrlVersion1}/${pipelineId}/duplicate`, {
+                organizationId: this.api.organizationId,
+            })
+        );
+    }
+
+    create(pipeline: NewPipelineModel) {
+        return this.api.post<PipelineModel>(
+            this.buildPath(Pipelines.searchUrlVersion1, {
+                organizationId: this.api.organizationId,
+            }),
+            pipeline
         );
     }
 }

--- a/src/resources/Pipelines/PipelinesInterfaces.ts
+++ b/src/resources/Pipelines/PipelinesInterfaces.ts
@@ -1,19 +1,50 @@
+import {GranularResource} from '../BaseInterfaces';
+
 export interface PipelineBackendVersion {
     version: '1' | '2';
 }
 
-export interface PipelineModel {
-    id: string;
+interface PipelineShared {
     name: string;
-    isDefault?: boolean;
-    condition?: any;
-    created_by?: string;
     description?: string;
-    filter?: any;
-    last_modified_by?: string;
-    position?: number;
+    isDefault?: boolean;
+    condition?: ConditionModel;
     splitTestEnabled?: boolean;
     splitTestName?: string;
     splitTestRatio?: number;
     splitTestTarget?: string;
+    filter?: string;
+}
+
+export interface PipelineModel extends PipelineShared {
+    id: string;
+    position?: number;
+    created_by?: string;
+    last_modified_by?: string;
+}
+
+export interface NewPipelineModel extends PipelineShared, GranularResource {}
+export interface UpdatePipelineModel extends PipelineModel, GranularResource {}
+
+export interface ConditionModel {
+    id: string;
+    description: string;
+    definition: string;
+    detailed: any;
+    childrenCount?: number;
+    feature?: string;
+    parent?: string;
+    condition?: string;
+    position?: number;
+    ready?: boolean;
+}
+
+export interface ListPipelinesOptions {
+    isOrderAscending?: boolean;
+    filter?: string;
+    sortby?: string;
+    page?: number;
+    perPage?: number;
+    feature?: string;
+    organizationId?: string;
 }

--- a/src/resources/Pipelines/tests/Pipelines.spec.ts
+++ b/src/resources/Pipelines/tests/Pipelines.spec.ts
@@ -1,5 +1,6 @@
 import API from '../../../APICore';
 import Pipelines from '../Pipelines';
+import {NewPipelineModel, UpdatePipelineModel} from '../PipelinesInterfaces';
 
 jest.mock('../../../APICore');
 
@@ -14,19 +15,72 @@ describe('Pipelines', () => {
         pipelines = new Pipelines(api);
     });
 
-    describe('listBasicInfo', () => {
-        it('should make a GET call to the specific Pipelines url', () => {
-            pipelines.listBasicInfo();
+    describe('list', () => {
+        it('should make a GET call to the Pipelines v1 url', () => {
+            pipelines.list();
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(Pipelines.searchUrl);
+            expect(api.get).toHaveBeenCalledWith(Pipelines.searchUrlVersion1);
         });
     });
 
     describe('getBackendVersion', () => {
         it('should make a GET call to the specific Pipelines url', () => {
-            pipelines.getBackendVersion();
+            pipelines.getMLVersion();
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Pipelines.searchUrlVersion2}/ml/version`);
+        });
+    });
+
+    describe('get', () => {
+        it('should make a GET call to /rest/searc/v1/admin/pipelines/:id', () => {
+            pipelines.get('🔥');
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith('/rest/search/v1/admin/pipelines/🔥');
+        });
+    });
+
+    describe('delete', () => {
+        it('should make a DELETE call to /rest/searc/v1/admin/pipelines/:id', () => {
+            pipelines.delete('🔥');
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith('/rest/search/v1/admin/pipelines/🔥');
+        });
+    });
+
+    describe('update', () => {
+        it('should make a PUT call to /rest/searc/v1/admin/pipelines/:id', () => {
+            const pipelineToUpdate: UpdatePipelineModel = {
+                id: '🔥',
+                name: 'fire',
+            };
+            pipelines.update(pipelineToUpdate);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith('/rest/search/v1/admin/pipelines/🔥', pipelineToUpdate);
+        });
+    });
+
+    describe('duplicate', () => {
+        it('should make a POST call to /rest/searc/v1/admin/pipelines/:id/duplicate', () => {
+            pipelines.duplicate('🔥');
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith('/rest/search/v1/admin/pipelines/🔥/duplicate');
+        });
+    });
+
+    describe('create', () => {
+        it('should make a POST call to /rest/searc/v1/admin/pipelines', () => {
+            const newPipeline: NewPipelineModel = {
+                name: 'fire',
+                description: 'this-is-lit',
+            };
+            pipelines.create(newPipeline);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith('/rest/search/v1/admin/pipelines', newPipeline);
         });
     });
 });


### PR DESCRIPTION
Added the following calls on the `pipeline` resource:
- `list`
- `get`
- `delete`
- `update`
- `duplicate`
- `create`

BREAKING CHANGE: `pipeline.listBasicInfo` has been replaced by `pipeline.list`
BREAKING CHANGE: `pipeline.getBackendVersion` renamed to `getMLVersion`