### PR TITLE
feat(security): add on-premises enabled to interface

### DIFF
--- a/src/resources/SecurityCache/SecurityCacheInterfaces.ts
+++ b/src/resources/SecurityCache/SecurityCacheInterfaces.ts
@@ -43,6 +43,7 @@ export interface SecurityProviderModelWithStatus {
     name: string;
     nodeRequired?: boolean;
     nodeTypeName?: string;
+    onPremisesEnabled?: boolean;
     organizationId?: string;
     parameters?: ParameterModel;
     referencedBy?: SecurityProviderReferenceModel[];


### PR DESCRIPTION
This changeset adds the onPremisesEnabled parameter to Security Providers, which reflects the platform's json. It would be used to differentiate on-premises security providers from cloud providers in the UI.

![image](https://user-images.githubusercontent.com/13049746/76319236-4d144c80-62b5-11ea-9359-44daa5269a4b.png)

[CTINFRA-795]

[CTINFRA-795]: https://coveord.atlassian.net/browse/CTINFRA-795