### PR TITLE
fix(pipeline-statements): make exportCSV resolve with a blob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8279,6 +8279,12 @@
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
         },
+        "node-blob": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/node-blob/-/node-blob-0.0.2.tgz",
+            "integrity": "sha512-82wiGzMht96gPQDUYaZBdZEVvYD9aEhU6Bt9KLCr4rADZPRd7dQVY2Yj0ZG/1vp4DhVkL49nJT/M3CiMTAt3ag==",
+            "dev": true
+        },
         "node-emoji": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "jest": "^24.9.0",
         "jest-fetch-mock": "^2.1.2",
         "lint-staged": "^9.5.0",
+        "node-blob": "0.0.2",
         "prettier": "^1.19.1",
         "semantic-release": "^16.0.2",
         "ts-jest": "^24.3.0",

--- a/src/features/APIWithHooks.ts
+++ b/src/features/APIWithHooks.ts
@@ -18,6 +18,10 @@ export class APIWithHooks<TAPI extends IAPI = IAPI> implements IAPI {
         return this.wrapInGenericHandler(url, args, () => this.api.get<T>(url, args));
     }
 
+    async getFile(url: string, args: RequestInit = {method: 'get'}): Promise<Blob> {
+        return this.wrapInGenericHandler(url, args, () => this.api.getFile(url, args));
+    }
+
     async post<T = {}>(
         url: string,
         body: any = {},

--- a/src/features/tests/APIWithHooks.spec.ts
+++ b/src/features/tests/APIWithHooks.spec.ts
@@ -1,3 +1,5 @@
+import Blob from 'node-blob';
+
 import {IAPI} from '../../APICore';
 import {UserModel} from '../../resources/Users';
 import {APIWithHooks} from '../APIWithHooks';
@@ -7,6 +9,7 @@ jest.mock('../../APICore');
 const mockApi = (): jest.Mocked<IAPI> => ({
     organizationId: '🐟',
     get: jest.fn().mockImplementation(() => Promise.resolve({})),
+    getFile: jest.fn().mockImplementation(() => Promise.resolve(new Blob(['test test'], {type: 'text/plain'}))),
     post: jest.fn().mockImplementation(() => Promise.resolve({})),
     postForm: jest.fn().mockImplementation(() => Promise.resolve({})),
     delete: jest.fn().mockImplementation(() => Promise.resolve({})),
@@ -20,6 +23,7 @@ describe('APIWithHooks', () => {
     let api: jest.Mocked<IAPI>;
     const urls = {
         get: 'get',
+        getFile: 'getFile',
         post: 'post',
         postForm: 'postForm',
         delete: 'delete',
@@ -48,6 +52,13 @@ describe('APIWithHooks', () => {
 
             assertInvocationWasBefore(beforeMock, api.get as jest.Mock);
             expect(api.get).toHaveBeenCalledWith(urls.get, someGenericArgs);
+        });
+
+        it('should trigger the hook on a get', async () => {
+            await apiWithHooks.getFile(urls.getFile, someGenericArgs);
+
+            assertInvocationWasBefore(beforeMock, api.getFile as jest.Mock);
+            expect(api.getFile).toHaveBeenCalledWith(urls.getFile, someGenericArgs);
         });
 
         it('should trigger the hook on a post', async () => {
@@ -94,6 +105,13 @@ describe('APIWithHooks', () => {
 
             assertInvocationWasBefore(api.get as jest.Mock, afterMock);
             expect(api.get).toHaveBeenCalledWith(urls.get, someGenericArgs);
+        });
+
+        it('should trigger the hook on a getFile', async () => {
+            await apiWithHooks.getFile(urls.getFile, someGenericArgs);
+
+            assertInvocationWasBefore(api.getFile as jest.Mock, afterMock);
+            expect(api.getFile).toHaveBeenCalledWith(urls.getFile, someGenericArgs);
         });
 
         it('should trigger the hook on a post', async () => {
@@ -152,6 +170,15 @@ describe('APIWithHooks', () => {
 
             assertInvocationWasBefore(api.get as jest.Mock, afterExceptionMock);
             expect(afterExceptionMock).toHaveBeenCalledWith(urls.get, someGenericArgs, someError);
+        });
+
+        it('should trigger the hook on a get exception', async () => {
+            api.getFile.mockRejectedValue(someError);
+
+            await apiWithHooks.getFile(urls.getFile, someGenericArgs);
+
+            assertInvocationWasBefore(api.getFile as jest.Mock, afterExceptionMock);
+            expect(afterExceptionMock).toHaveBeenCalledWith(urls.getFile, someGenericArgs, someError);
         });
 
         it('should not trigger the hook on a get success', async () => {

--- a/src/handlers/ResponseHandlers.ts
+++ b/src/handlers/ResponseHandlers.ts
@@ -10,6 +10,11 @@ const success: ResponseHandler = {
     process: async <T>(response: Response): Promise<T> => await response.json(),
 };
 
+const successBlob: ResponseHandler = {
+    canProcess: (response: Response): boolean => response.ok,
+    process: async <T>(response: Response): Promise<T> => await (response.blob() as any),
+};
+
 const error: ResponseHandler = {
     canProcess: () => true,
     process: async <T>(response: Response): Promise<T> => {
@@ -18,7 +23,7 @@ const error: ResponseHandler = {
 };
 
 export const defaultResponseHandlers = [noContent, success, error];
-export const ResponseHandlers = {noContent, success, error};
+export const ResponseHandlers = {noContent, success, successBlob, error};
 
 export default function<T>(response: Response, handlers = defaultResponseHandlers) {
     return handlers.filter((handler) => handler.canProcess(response))[0].process<T>(response);

--- a/src/handlers/tests/ResponseHandlers.spec.ts
+++ b/src/handlers/tests/ResponseHandlers.spec.ts
@@ -1,4 +1,4 @@
-import handleResponse from '../ResponseHandlers';
+import handleResponse, {ResponseHandlers} from '../ResponseHandlers';
 
 describe('ResponseHandlers', () => {
     it('should return a promise resolved with an empty object when the response status code is 204', async () => {
@@ -14,8 +14,8 @@ describe('ResponseHandlers', () => {
         const ret1 = await handleResponse(okResponse);
         expect(ret1).toEqual(data);
 
-        const stilOkResponse = new Response(JSON.stringify(data), {status: 299});
-        const ret2 = await handleResponse(stilOkResponse);
+        const stillOkResponse = new Response(JSON.stringify(data), {status: 299});
+        const ret2 = await handleResponse(stillOkResponse);
         expect(ret2).toEqual(data);
     });
 
@@ -30,5 +30,14 @@ describe('ResponseHandlers', () => {
         }
 
         expect.assertions(1);
+    });
+
+    it('should return a promise resolved with the response body as blob when using the successBlob handler and the status is between 200 and 299', async () => {
+        const data = {someData: 'thank you!'};
+        const expectedBlob = await new Response(JSON.stringify(data)).blob();
+
+        const okResponse = new Response(JSON.stringify(data), {status: 200});
+        const ret1 = await handleResponse(okResponse, [ResponseHandlers.successBlob]);
+        expect(ret1).toEqual(expectedBlob);
     });
 });

--- a/src/resources/Pipelines/Statements/Statements.ts
+++ b/src/resources/Pipelines/Statements/Statements.ts
@@ -21,7 +21,7 @@ export default class Statements extends Resource {
     }
 
     exportCSV(pipelineId: string, options?: ExportStatementParams) {
-        return this.api.get<string>(
+        return this.api.getFile(
             this.buildPath(`${Statements.getBaseUrl(pipelineId)}/export`, {
                 organizationId: this.api.organizationId,
                 ...options,

--- a/src/resources/Pipelines/Statements/tests/Statements.spec.ts
+++ b/src/resources/Pipelines/Statements/tests/Statements.spec.ts
@@ -39,8 +39,8 @@ describe('Statements', () => {
             };
 
             statements.exportCSV(pipelineId, options);
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(
+            expect(api.getFile).toHaveBeenCalledTimes(1);
+            expect(api.getFile).toHaveBeenCalledWith(
                 `${Statements.getBaseUrl(pipelineId)}/export?feature=${options.feature}`
             );
         });

--- a/src/tests/APICore.spec.ts
+++ b/src/tests/APICore.spec.ts
@@ -56,6 +56,41 @@ describe('APICore', () => {
             });
         });
 
+        describe('getFile', () => {
+            it('should do a GET request to the specified url and resolve with a blob', async () => {
+                const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                const expectedResponse = await new Response(JSON.stringify(testData.response)).blob();
+                const response = await api.getFile(testData.route);
+
+                expect(fetchMock).toHaveBeenCalledTimes(1);
+                const [url, options] = fetchMock.mock.calls[0];
+
+                expect(url).toBe(`${testConfig.host}${testData.route}`);
+                expect(options.method).toBe('get');
+                expect(response).toEqual(expectedResponse);
+            });
+
+            it('should make the promise fail on a failed request', async () => {
+                const error = new Error('the request has failed');
+                global.fetch.mockRejectedValue(error);
+
+                try {
+                    await api.getFile(testData.route);
+                } catch (e) {
+                    expect(e).toEqual(error);
+                } finally {
+                    expect.assertions(1);
+                }
+            });
+
+            it('should bind GET requests to an abort signal', () => {
+                global.fetch.mockResponseOnce(JSON.stringify(testData.response));
+                api.getFile(testData.route);
+                expect(global.fetch.mock.calls[0][1].signal).toBeDefined();
+                expect(global.fetch.mock.calls[0][1].signal instanceof AbortSignal).toBe(true);
+            });
+        });
+
         describe('post', () => {
             it('should do a simple POST request', async () => {
                 const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));


### PR DESCRIPTION
Added the `api.getFile` method on the api core that handles the response by returning a blob instead of parsing the response into a JSON object. 

When fetching a file, we don't want to parse the response into a JSON object because it is not necessarily a json file (in the case of the exportCSV, it is a `.csv` file obviously).