### PR TITLE
fix(statements): allow additional statement fields

### DIFF
--- a/src/resources/Pipelines/Statements/StatementsInterfaces.ts
+++ b/src/resources/Pipelines/Statements/StatementsInterfaces.ts
@@ -13,6 +13,7 @@ export interface StatementModel {
     detailed: any;
     warnings?: string[];
     displayName?: string; // The display name for this Machine Learning model.This property only has a meaning with recommendation, topClicks, and querySuggest statements. ,
+    [key: string]: any;
 }
 
 export interface CreateStatementModel {


### PR DESCRIPTION
Some features (such as the query parameters overrides) will have additional fields not listed in the generic StatementModel interface.