### PR TITLE
feat(catalog): require availability.idField

### DIFF
--- a/src/resources/Catalogs/Catalog.ts
+++ b/src/resources/Catalogs/Catalog.ts
@@ -1,7 +1,7 @@
 import API from '../../APICore';
 import {New, PageModel} from '../BaseInterfaces';
 import Resource from '../Resource';
-import {CatalogModel, CatalogsListOptions} from './CatalogInterfaces';
+import {CatalogModel, CatalogsListOptions, CreateCatalogModel} from './CatalogInterfaces';
 
 export default class Catalog extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/catalogs`;
@@ -10,8 +10,8 @@ export default class Catalog extends Resource {
         return this.api.get<PageModel<CatalogModel>>(this.buildPath(Catalog.baseUrl, options));
     }
 
-    create(catalog: New<CatalogModel>) {
-        return this.api.post<CatalogModel>(Catalog.baseUrl, catalog);
+    create(catalog: New<CreateCatalogModel>) {
+        return this.api.post<CreateCatalogModel>(Catalog.baseUrl, catalog);
     }
 
     delete(catalogId: string) {

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -13,6 +13,10 @@ export interface CatalogModel {
     variant?: VariantHierarchyModel;
 }
 
+export interface CreateCatalogModel extends CatalogModel {
+    availability?: CreateAvailabilityHierarchyModel;
+}
+
 export interface VariantHierarchyModel {
     fields: string[];
     idField: string;
@@ -27,7 +31,12 @@ export interface ProductHierarchyModel {
 export interface AvailabilityHierarchyModel {
     availableSkusField: string;
     fields: string[];
+    idField?: string;
     objectType: string;
+}
+
+export interface CreateAvailabilityHierarchyModel extends AvailabilityHierarchyModel {
+    idField: string;
 }
 
 export interface ScopeModel {

--- a/src/resources/Catalogs/tests/Catalog.spec.ts
+++ b/src/resources/Catalogs/tests/Catalog.spec.ts
@@ -1,7 +1,7 @@
 import API from '../../../APICore';
 import {New} from '../../BaseInterfaces';
 import Catalog from '../Catalog';
-import {CatalogModel} from '../CatalogInterfaces';
+import {CatalogModel, CreateCatalogModel} from '../CatalogInterfaces';
 
 jest.mock('../../../APICore');
 
@@ -26,7 +26,7 @@ describe('Catalog', () => {
 
     describe('create', () => {
         it('should make a POST call to the catalogs base url', () => {
-            const catalogModel: New<CatalogModel> = {
+            const catalogModel: New<CreateCatalogModel> = {
                 name: 'New catalog',
                 product: {
                     idField: '@uri',


### PR DESCRIPTION
Require the new `availability.idField` in new catalogs.

So it is still optional when you _get_ one, and you can still _save_ one if the original doesn't have it set yet.

At some point, when all catalogs are migrated in prod, we will flip the switch to make it mandatory everywhere and we will be able to remove both `Create` models!