### PR TITLE
feat(catalog): add source scope to catalog

### DIFF
--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -39,6 +39,11 @@ export interface CreateAvailabilityHierarchyModel extends AvailabilityHierarchyM
     idField: string;
 }
 
-export interface ScopeModel {
-    query: string;
-}
+export type ScopeModel =
+    | {
+          query: string;
+      }
+    | {
+          query?: string;
+          sourceIds: string[];
+      };


### PR DESCRIPTION
[COM-396]: https://coveord.atlassian.net/browse/COM-396

This is to reflect the current state of our service. We will be migrating everyone to `sourceIds`, eventually.

So you can have `{ sourceIds: []}`, `{ sourceIds: [], query: '' }` or the legacy `{ query: '' }`