### PR TITLE
feat(getsnapshotcontent): use fetch directly in resource snapshot method

### DIFF
--- a/src/APICore.ts
+++ b/src/APICore.ts
@@ -20,10 +20,10 @@ export default class API implements IAPI {
         return this.config.organizationIdRetriever?.() || this.config.organizationId;
     }
 
-    async get<T = {}>(url: string, args: RequestInit = {method: 'get'}, isCustomUrl: boolean = false): Promise<T> {
+    async get<T = {}>(url: string, args: RequestInit = {method: 'get'}): Promise<T> {
         args.signal = args.signal || this.getRequestsController.signal;
         try {
-            return await this.request<T>(url, args, isCustomUrl);
+            return await this.request<T>(url, args);
         } catch (error) {
             if (error.name === 'AbortError') {
                 return; // We don't want to resolve or reject the promise
@@ -33,10 +33,10 @@ export default class API implements IAPI {
         }
     }
 
-    async getFile(url: string, args: RequestInit = {method: 'get'}, isCustomUrl: boolean = false): Promise<Blob> {
+    async getFile(url: string, args: RequestInit = {method: 'get'}): Promise<Blob> {
         args.signal = args.signal || this.getRequestsController.signal;
         try {
-            return await this.requestFile(url, args, isCustomUrl);
+            return await this.requestFile(url, args);
         } catch (error) {
             if (error.name === 'AbortError') {
                 return; // We don't want to resolve or reject the promise
@@ -102,7 +102,7 @@ export default class API implements IAPI {
         return `${this.config.host}${route}`.replace(API.orgPlaceholder, this.organizationId);
     }
 
-    private async request<T>(route: string, args: RequestInit, isCustomUrl: boolean = false): Promise<T> {
+    private async request<T>(route: string, args: RequestInit): Promise<T> {
         const init: RequestInit = {
             ...args,
             headers: {
@@ -112,11 +112,11 @@ export default class API implements IAPI {
             },
         };
 
-        const response = await fetch(isCustomUrl ? route : this.getUrlFromRoute(route), init);
+        const response = await fetch(this.getUrlFromRoute(route), init);
         return handleResponse<T>(response, this.handlers);
     }
 
-    private async requestFile(route: string, args: RequestInit, isCustomUrl: boolean = false): Promise<Blob> {
+    private async requestFile(route: string, args: RequestInit): Promise<Blob> {
         const init: RequestInit = {
             ...args,
             headers: {
@@ -124,7 +124,7 @@ export default class API implements IAPI {
                 ...(args.headers || {}),
             },
         };
-        const response = await fetch(isCustomUrl ? route : this.getUrlFromRoute(route), init);
+        const response = await fetch(this.getUrlFromRoute(route), init);
         return handleResponse<Blob>(response, [
             ResponseHandlers.noContent,
             ResponseHandlers.successBlob,

--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -15,8 +15,7 @@ export default class ResourceSnapshots extends Resource {
 
     async getContent(snapshotId: string) {
         const {url} = await this.generateUrl(snapshotId);
-
-        return this.api.get<string>(url, undefined, true);
+        return await fetch(url, {method: 'get'});
     }
 
     generateUrl(snapshotId: string) {

--- a/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
+++ b/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
@@ -41,11 +41,12 @@ describe('ResourceSnapshots', () => {
             };
 
             jest.spyOn(resourceSnapshots, 'generateUrl').mockResolvedValue(urlReturned);
+            const fetchMock = global.fetch.mockResponseOnce(JSON.stringify({test: 'hello'}));
 
             await resourceSnapshots.getContent(snapshotToGetId);
 
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(urlReturned.url, undefined, true);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(fetchMock).toHaveBeenCalledWith(urlReturned.url, {method: 'get'});
         });
     });
 

--- a/src/tests/APICore.spec.ts
+++ b/src/tests/APICore.spec.ts
@@ -37,18 +37,6 @@ describe('APICore', () => {
                 expect(response).toEqual(testData.response);
             });
 
-            it('should do a simple GET request to a custom url', async () => {
-                const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-                const response = await api.get<typeof testData.response>(customUrl, undefined, true);
-
-                expect(fetchMock).toHaveBeenCalledTimes(1);
-                const [url, options] = fetchMock.mock.calls[0];
-
-                expect(url).toBe(customUrl);
-                expect(options.method).toBe('get');
-                expect(response).toEqual(testData.response);
-            });
-
             it('should make the promise fail on a failed request', async () => {
                 const error = new Error('the request has failed');
                 global.fetch.mockRejectedValue(error);
@@ -80,19 +68,6 @@ describe('APICore', () => {
                 const [url, options] = fetchMock.mock.calls[0];
 
                 expect(url).toBe(`${testConfig.host}${testData.route}`);
-                expect(options.method).toBe('get');
-                expect(response).toEqual(expectedResponse);
-            });
-
-            it('should do a GET request to the specified custom url and resolve with a blob', async () => {
-                const fetchMock = global.fetch.mockResponseOnce(JSON.stringify(testData.response));
-                const expectedResponse = await new Response(JSON.stringify(testData.response)).blob();
-                const response = await api.getFile(customUrl, undefined, true);
-
-                expect(fetchMock).toHaveBeenCalledTimes(1);
-                const [url, options] = fetchMock.mock.calls[0];
-
-                expect(url).toBe(customUrl);
                 expect(options.method).toBe('get');
                 expect(response).toEqual(expectedResponse);
             });


### PR DESCRIPTION
This allows a request without bearer token