### PR TITLE
fix(sources): fix wrong pagemodel for sources

### DIFF
--- a/src/resources/BaseInterfaces.ts
+++ b/src/resources/BaseInterfaces.ts
@@ -1,8 +1,9 @@
-export interface PageModel<T = any> {
-    items: T[];
+export type PageModel<T = any, TItemsKey extends string = 'items'> = {
+    [key in TItemsKey]: T[];
+} & {
     totalEntries: number;
     totalPages: number;
-}
+};
 
 export type New<T, K extends string | number | symbol = null> = Omit<T, 'id' | K>;
 

--- a/src/resources/Sources/Sources.ts
+++ b/src/resources/Sources/Sources.ts
@@ -28,7 +28,7 @@ export default class Sources extends Resource {
     }
 
     list(params?: ListSourcesParams) {
-        return this.api.get<PageModel<SourceModel>>(this.buildPath(`${Sources.baseUrl}/pages`, params));
+        return this.api.get<PageModel<SourceModel, 'sourceModels'>>(this.buildPath(`${Sources.baseUrl}/pages`, params));
     }
 
     createFromRaw(rawSourceConfig: RawSourceConfig, options?: CreateSourceOptions) {


### PR DESCRIPTION
I tried using `Platform.source.list()` and shit went wrong because the actual returned data is not contained in `items`, but in `sourceModels`.

Let me know if you'd rather just have a different `PageModel` implementation instead of the generic one here (I was on the fence between those two ideas)