### PR TITLE
feat(ua): add dimensions resource for model testing additional parameters

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -661,3 +661,23 @@ export enum StatementGroupType {
     campaign = 'campaign',
     permanent = 'permanent',
 }
+
+export enum DimensionType {
+    TEXT = 'TEXT',
+    NUMBER = 'NUMBER',
+    SHORT = 'SHORT',
+    BOOLEAN = 'BOOLEAN',
+    DATE = 'DATE',
+    DATETIME = 'DATETIME',
+}
+
+export enum DimensionStatus {
+    AVAILABLE = 'AVAILABLE',
+    UPDATING = 'UPDATING',
+}
+
+export enum DimensionEventTypes {
+    searches = 'searches',
+    clicks = 'clicks',
+    custom_events = 'custom_events',
+}

--- a/src/resources/UsageAnalytics/Read/Dimensions/Dimensions.ts
+++ b/src/resources/UsageAnalytics/Read/Dimensions/Dimensions.ts
@@ -1,0 +1,106 @@
+import {DimensionEventTypes} from '../../../Enums';
+import Resource from '../../../Resource';
+import {
+    CreateCustomDimensionParams,
+    CustomDimensionModel,
+    CustomDimensionSuggestionModel,
+    DimensionModel,
+    DimensionValuesModel,
+    GetDimensionValuesParams,
+    ListDimensionsParams,
+    ListUncreatedDimensionsParams,
+} from './DimensionsInterfaces';
+
+export default class Dimensions extends Resource {
+    static baseUrl = '/rest/ua/v15/dimensions';
+
+    list(params?: ListDimensionsParams) {
+        return this.api.get<DimensionModel[]>(
+            this.buildPath(Dimensions.baseUrl, {...params, org: this.api.organizationId})
+        );
+    }
+
+    listExportableDimensions(params?: ListDimensionsParams) {
+        return this.api.get<DimensionModel[]>(
+            this.buildPath(`${Dimensions.baseUrl}/exportables`, {...params, org: this.api.organizationId})
+        );
+    }
+
+    get(apiName: string) {
+        return this.api.get<DimensionModel>(
+            this.buildPath(`${Dimensions.baseUrl}/${apiName}`, {org: this.api.organizationId})
+        );
+    }
+
+    getValues(dimension: string, params?: GetDimensionValuesParams) {
+        return this.api.get<DimensionValuesModel>(
+            this.buildPath(`${Dimensions.baseUrl}/${dimension}/values`, {...params, org: this.api.organizationId})
+        );
+    }
+
+    getStatus() {
+        return this.api.get<Record<string, string>>(`${Dimensions.baseUrl}/status`);
+    }
+
+    checkHealth() {
+        return this.api.get<Record<string, string>>(`${Dimensions.baseUrl}/monitoring/health`);
+    }
+
+    listCustomDimensions(includeOnlyParents = false) {
+        return this.api.get<DimensionModel[]>(
+            this.buildPath(`${Dimensions.baseUrl}/custom`, {includeOnlyParents, org: this.api.organizationId})
+        );
+    }
+
+    createCustomDimension(model: CustomDimensionModel, params?: CreateCustomDimensionParams) {
+        return this.api.post<DimensionModel>(
+            this.buildPath(`${Dimensions.baseUrl}/custom`, {...params, org: this.api.organizationId}),
+            model
+        );
+    }
+
+    getCustomDimension(apiName: string) {
+        return this.api.get<DimensionModel>(
+            this.buildPath(`${Dimensions.baseUrl}/custom/${apiName}`, {org: this.api.organizationId})
+        );
+    }
+
+    getCustomDimensionValues(dimension: string, params?: GetDimensionValuesParams) {
+        return this.api.get<DimensionValuesModel>(
+            this.buildPath(`${Dimensions.baseUrl}/custom/${dimension}/values`, {
+                ...params,
+                org: this.api.organizationId,
+            })
+        );
+    }
+
+    updateCustomDimension(apiName: string, model: CustomDimensionModel, updatePastEvents = false) {
+        return this.api.put<DimensionModel>(
+            this.buildPath(`${Dimensions.baseUrl}/custom/${apiName}`, {updatePastEvents, org: this.api.organizationId}),
+            model
+        );
+    }
+
+    deleteCustomDimension(apiName: string) {
+        return this.api.delete<void>(
+            this.buildPath(`${Dimensions.baseUrl}/custom/${apiName}`, {org: this.api.organizationId})
+        );
+    }
+
+    getCustomDimensionStatus() {
+        return this.api.get<Record<string, string>>(`${Dimensions.baseUrl}/custom/status`);
+    }
+
+    checkCustomDimensionHealth() {
+        return this.api.get<Record<string, string>>(`${Dimensions.baseUrl}/custom/monitoring/health`);
+    }
+
+    listUncreatedDimensions(event: DimensionEventTypes, params?: ListUncreatedDimensionsParams) {
+        return this.api.get<CustomDimensionSuggestionModel[]>(
+            this.buildPath(`${Dimensions.baseUrl}/custom/${event}/suggestions`, {
+                ...params,
+                org: this.api.organizationId,
+            })
+        );
+    }
+}

--- a/src/resources/UsageAnalytics/Read/Dimensions/DimensionsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Dimensions/DimensionsInterfaces.ts
@@ -1,0 +1,58 @@
+import {DimensionStatus, DimensionType} from '../../../Enums';
+
+export interface DimensionModel {
+    apiNames: string[];
+    availableInVisit?: boolean;
+    custom: boolean;
+    displayName: string;
+    eventTypes: string[];
+    returnName: string;
+    status: DimensionStatus;
+    type: DimensionType;
+}
+
+export interface DimensionValuesModel {
+    values: Array<Record<string, string | number>>;
+}
+
+export interface CustomDimensionSuggestionModel {
+    eventName?: string;
+    apiName?: string;
+    values?: string[];
+}
+
+export interface CustomDimensionModel {
+    type: DimensionType;
+    displayName: string;
+}
+
+export interface ListDimensionsParams {
+    org?: string;
+    includeOnlyParents?: boolean;
+    includeCustom?: boolean;
+}
+
+export interface GetDimensionValuesParams {
+    from: string;
+    to: string;
+    tz?: string;
+    org?: string;
+    f?: string[];
+    p?: number;
+    n?: number;
+}
+
+export interface CreateCustomDimensionParams {
+    org?: string;
+    name?: string;
+    event?: string[];
+    updatePastEvents?: boolean;
+}
+
+export interface ListUncreatedDimensionsParams {
+    org?: string;
+    from?: string;
+    to?: string;
+    includeValueSamples?: boolean;
+    depth?: number;
+}

--- a/src/resources/UsageAnalytics/Read/Dimensions/index.ts
+++ b/src/resources/UsageAnalytics/Read/Dimensions/index.ts
@@ -1,0 +1,2 @@
+export * from './Dimensions';
+export * from './DimensionsInterfaces';

--- a/src/resources/UsageAnalytics/Read/Dimensions/tests/Dimensions.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Dimensions/tests/Dimensions.spec.ts
@@ -1,0 +1,171 @@
+import API from '../../../../../APICore';
+import {DimensionEventTypes, DimensionType} from '../../../../Enums';
+import Dimensions from '../Dimensions';
+import {CustomDimensionModel} from '../DimensionsInterfaces';
+
+jest.mock('../../../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('Dimensions', () => {
+    let dimensions: Dimensions;
+    const api = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        dimensions = new Dimensions(api);
+    });
+
+    describe('list', () => {
+        it('should make a GET call to the Dimensions base url', () => {
+            dimensions.list();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(Dimensions.baseUrl);
+        });
+    });
+
+    describe('listExportableDimensions', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            dimensions.listExportableDimensions();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/exportables`);
+        });
+    });
+
+    describe('get', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            const apiName = '🌞';
+            dimensions.get(apiName);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/${apiName}`);
+        });
+    });
+
+    describe('getValues', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            const dimension = '😎';
+            dimensions.getValues(dimension);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/${dimension}/values`);
+        });
+    });
+
+    describe('getStatus', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            dimensions.getStatus();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/status`);
+        });
+    });
+
+    describe('checkHealth', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            dimensions.checkHealth();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/monitoring/health`);
+        });
+    });
+
+    describe('listCustomDimensions', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            dimensions.listCustomDimensions(true);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/custom?includeOnlyParents=true`);
+        });
+    });
+
+    describe('createCustomDimension', () => {
+        it('should make a POST call to the specific Dimensions url', () => {
+            const model: CustomDimensionModel = {
+                displayName: '🆒',
+                type: DimensionType.TEXT,
+            };
+            dimensions.createCustomDimension(model);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Dimensions.baseUrl}/custom`, model);
+        });
+    });
+
+    describe('getCustomDimension', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            const apiName = '🥵';
+            dimensions.getCustomDimension(apiName);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/custom/${apiName}`);
+        });
+    });
+
+    describe('getCustomDimensionValues', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            const dimension = '🕶️';
+            dimensions.getCustomDimensionValues(dimension);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/custom/${dimension}/values`);
+        });
+    });
+
+    describe('updateCustomDimension', () => {
+        it('should make a PUT call to the specific Dimensions url', () => {
+            const apiName = '🏖️';
+            const model: CustomDimensionModel = {
+                displayName: '🦈',
+                type: DimensionType.TEXT,
+            };
+            dimensions.updateCustomDimension(apiName, model);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `${Dimensions.baseUrl}/custom/${apiName}?updatePastEvents=false`,
+                model
+            );
+        });
+    });
+
+    describe('deleteCustomDimension', () => {
+        it('should make a DELETE call to the specific Dimensions url', () => {
+            const apiName = '🌊';
+            dimensions.deleteCustomDimension(apiName);
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${Dimensions.baseUrl}/custom/${apiName}`);
+        });
+    });
+
+    describe('getCustomDimensionStatus', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            dimensions.getCustomDimensionStatus();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/custom/status`);
+        });
+    });
+
+    describe('checkCustomDimensionHealth', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            dimensions.checkCustomDimensionHealth();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/custom/monitoring/health`);
+        });
+    });
+
+    describe('listUncreatedDimensions', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            const event: DimensionEventTypes = DimensionEventTypes.searches;
+            dimensions.listUncreatedDimensions(event);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/custom/${event}/suggestions`);
+        });
+    });
+});

--- a/src/resources/UsageAnalytics/UsageAnalytics.ts
+++ b/src/resources/UsageAnalytics/UsageAnalytics.ts
@@ -1,13 +1,16 @@
 import API from '../../APICore';
 import Resource from '../Resource';
+import Dimensions from './Read/Dimensions/Dimensions';
 import Statistics from './Read/Statistics/Statistics';
 
 export default class UsageAnalytics extends Resource {
     statistics: Statistics;
+    dimensions: Dimensions;
 
     constructor(protected api: API) {
         super(api);
 
+        this.dimensions = new Dimensions(api);
         this.statistics = new Statistics(api);
     }
 }

--- a/src/resources/UsageAnalytics/index.ts
+++ b/src/resources/UsageAnalytics/index.ts
@@ -1,2 +1,3 @@
+export * from './Read/Dimensions';
 export * from './Read/Statistics';
 export * from './UsageAnalytics';


### PR DESCRIPTION
In order to fetch option values for `Language`, `Origin 1` and `Origin 2` in Model Testing additional parameters, we'd need the same call that the UA UI is doing to provide auto complete in the Visit Browser.
![image](https://user-images.githubusercontent.com/52677246/85306765-f6eea200-b47c-11ea-8a23-87197e5c164c.png)
 
![image](https://user-images.githubusercontent.com/52677246/85306850-11c11680-b47d-11ea-91a4-1c9d6caa1e6a.png)
