### PR TITLE
feat(ml): add dne configuration resource

### DIFF
--- a/src/resources/MachineLearning/DNEConfiguration/DNEConfiguration.ts
+++ b/src/resources/MachineLearning/DNEConfiguration/DNEConfiguration.ts
@@ -1,0 +1,59 @@
+import API from '../../../APICore';
+import Resource from '../../Resource';
+import {
+    AutoSelectionFieldCandidateModel,
+    ListCandidateFieldsParams,
+    DocumentExtractionPreviewParams,
+    DocumentExtractionPreviewModel,
+    DocumentExtractionQueryModel,
+    DNENewConfigurationModel,
+    DNEConfigurationModel,
+} from './DNEConfigurationInterfaces';
+
+export default class DNEConfiguration extends Resource {
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/dne`;
+
+    listFields(params?: ListCandidateFieldsParams) {
+        return this.api.get<AutoSelectionFieldCandidateModel[]>(
+            this.buildPath(`${DNEConfiguration.baseUrl}/autoselectionfieldcandidates`, params)
+        );
+    }
+
+    getDocumentExtractionPreview(params?: DocumentExtractionPreviewParams) {
+        return this.api.get<DocumentExtractionPreviewModel>(
+            this.buildPath(`${DNEConfiguration.baseUrl}/documentextractionpreview`, params)
+        );
+    }
+
+    getDocumentExtractionQuery(model: DocumentExtractionQueryModel) {
+        return this.api.post<string>(`${DNEConfiguration.baseUrl}/documentextractionquery`, model);
+    }
+
+    async createWithoutQuery(
+        newModel: DNENewConfigurationModel,
+        documentExtractionQueryModel: DocumentExtractionQueryModel
+    ) {
+        const documentExtractionQuery = await this.getDocumentExtractionQuery(documentExtractionQueryModel);
+
+        return this.api.post<DNEConfigurationModel>(`${DNEConfiguration.baseUrl}/model`, {
+            ...newModel,
+            documentExtractionQuery,
+        });
+    }
+
+    createWithQuery(newModel: DNENewConfigurationModel) {
+        return this.api.post<DNEConfigurationModel>(`${DNEConfiguration.baseUrl}/model`, newModel);
+    }
+
+    delete(modelId: string) {
+        return this.api.delete<void>(`${DNEConfiguration.baseUrl}/model/${modelId}`);
+    }
+
+    get(modelId: string) {
+        return this.api.get<DNEConfigurationModel>(`${DNEConfiguration.baseUrl}/model/${modelId}`);
+    }
+
+    update(modelId: string, modelConfig: DNEConfigurationModel) {
+        return this.api.put<DNEConfigurationModel>(`${DNEConfiguration.baseUrl}/model/${modelId}`, modelConfig);
+    }
+}

--- a/src/resources/MachineLearning/DNEConfiguration/DNEConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/DNEConfiguration/DNEConfigurationInterfaces.ts
@@ -1,0 +1,50 @@
+import {IntervalUnit} from '../../Enums';
+
+export interface AutoSelectionFieldCandidateModel {
+    name?: string;
+    description?: string;
+}
+
+export interface ListCandidateFieldsParams {
+    filter?: string;
+    page?: number;
+    perPage?: number;
+}
+
+export interface DocumentExtractionPreviewModel {
+    numberOfDocuments?: number;
+    recommendedNumberOfDocuments?: number;
+    sources?: DocumentSourceModel[];
+}
+
+export interface DocumentSourceModel {
+    name?: string;
+    numberOfDocuments?: number;
+}
+
+export interface DocumentExtractionPreviewParams {
+    fields?: string[];
+    maximumNumberOfSources?: number;
+}
+
+export interface DocumentExtractionQueryModel {
+    fields?: string[];
+    sources?: string[];
+}
+
+export interface DNEConfigurationModel extends DNENewConfigurationModel {
+    documentGroupId?: string;
+    modelId?: string;
+}
+
+export interface DNENewConfigurationModel {
+    commonFilter?: string;
+    documentExtractionQuery?: string;
+    exportPeriod?: string;
+    fieldsToAutoSelect?: string[];
+    intervalTime?: number;
+    intervalUnit?: IntervalUnit;
+    modelDisplayName: string;
+    searchEventFilter?: string;
+    viewAllContent?: boolean;
+}

--- a/src/resources/MachineLearning/DNEConfiguration/index.ts
+++ b/src/resources/MachineLearning/DNEConfiguration/index.ts
@@ -1,0 +1,2 @@
+export * from './DNEConfiguration';
+export * from './DNEConfigurationInterfaces';

--- a/src/resources/MachineLearning/DNEConfiguration/tests/DNEConfiguration.spec.ts
+++ b/src/resources/MachineLearning/DNEConfiguration/tests/DNEConfiguration.spec.ts
@@ -1,0 +1,102 @@
+import API from '../../../../APICore';
+import DNEConfiguration from '../DNEConfiguration';
+import {
+    DNEConfigurationModel,
+    DNENewConfigurationModel,
+    DocumentExtractionQueryModel,
+} from '../DNEConfigurationInterfaces';
+
+jest.mock('../../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('DNEConfiguration', () => {
+    let dneConfig: DNEConfiguration;
+    const api = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        dneConfig = new DNEConfiguration(api);
+    });
+
+    describe('listFields', () => {
+        it('should make a GET call to the specific DNEConfiguration url', () => {
+            dneConfig.listFields();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/autoselectionfieldcandidates`);
+        });
+    });
+
+    describe('getDocumentExtractionPreview', () => {
+        it('should make a GET call to the specific DNEConfiguration url', () => {
+            dneConfig.getDocumentExtractionPreview();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/documentextractionpreview`);
+        });
+    });
+
+    describe('getDocumentExtractionQuery', () => {
+        it('should make a POST call to the specific DNEConfiguration url', () => {
+            const model: DocumentExtractionQueryModel = {};
+            dneConfig.getDocumentExtractionQuery(model);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/documentextractionquery`, model);
+        });
+    });
+
+    describe('createWithoutQuery', () => {
+        it('should make a POST call to get documentExtractionQueryModel, then use this param to create a new DNE model ', async () => {
+            const newModel: DNENewConfigurationModel = {modelDisplayName: '🐩'};
+            const documentExtractionQueryModel = await dneConfig.createWithoutQuery(newModel, {});
+
+            expect(api.post).toHaveBeenCalledTimes(2);
+            expect(api.post).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/documentextractionquery`, {});
+            expect(api.post).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/model`, {
+                ...newModel,
+                documentExtractionQueryModel,
+            });
+        });
+    });
+
+    describe('createWithQuery', () => {
+        it('should make a POST call to the specific DNEConfiguration url', () => {
+            const model: DNENewConfigurationModel = {modelDisplayName: '🐩'};
+            dneConfig.createWithQuery(model);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/model`, model);
+        });
+    });
+
+    describe('delete', () => {
+        it('should make a DELETE call to the specific DNEConfiguration url', () => {
+            const modelId = '🦆';
+            dneConfig.delete(modelId);
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/model/${modelId}`);
+        });
+    });
+
+    describe('get', () => {
+        it('should make a GET call to the specific DNEConfiguration url', () => {
+            const modelId = '🦆';
+            dneConfig.get(modelId);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/model/${modelId}`);
+        });
+    });
+
+    describe('update', () => {
+        it('should make a PUT call to the specific DNEConfiguration url', () => {
+            const modelId = '🦆';
+            const modelConfig: DNEConfigurationModel = {modelDisplayName: '🐺'};
+            dneConfig.update(modelId, modelConfig);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/model/${modelId}`, modelConfig);
+        });
+    });
+});

--- a/src/resources/MachineLearning/MachineLearning.ts
+++ b/src/resources/MachineLearning/MachineLearning.ts
@@ -4,6 +4,7 @@ import {MLModelCreated, RegistrationModel} from './MachineLearningInterfaces';
 import ModelConfiguration from './ModelConfiguration/ModelConfiguration';
 import ModelInformation from './ModelInformation/ModelInformation';
 import Models from './Models/Models';
+import DNEConfiguration from './DNEConfiguration/DNEConfiguration';
 
 export default class MachineLearning extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning`;
@@ -11,6 +12,7 @@ export default class MachineLearning extends Resource {
     models: Models;
     modelInfo: ModelInformation;
     modelConfig: ModelConfiguration;
+    dneConfig: DNEConfiguration;
 
     constructor(protected api: API) {
         super(api);
@@ -18,6 +20,7 @@ export default class MachineLearning extends Resource {
         this.models = new Models(api);
         this.modelInfo = new ModelInformation(api);
         this.modelConfig = new ModelConfiguration(api);
+        this.dneConfig = new DNEConfiguration(api);
     }
 
     register(registration: RegistrationModel) {

--- a/src/resources/MachineLearning/index.ts
+++ b/src/resources/MachineLearning/index.ts
@@ -3,3 +3,4 @@ export * from './MachineLearningInterfaces';
 export * from './Models/';
 export * from './ModelInformation/';
 export * from './ModelConfiguration/';
+export * from './DNEConfiguration';


### PR DESCRIPTION
https://platformdev.cloud.coveo.com/docs/?api=MLConfig#/Dynamic32Navigation32Experience32Configuration

Side note:
We could abstract the call to `/documentextractionquery` inside the create model call in the platform-client. That way it would remove this complexity from the admin UI repo.