### PR TITLE
feat(sources): update interfaces with current model in backbone

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -116,6 +116,12 @@ export enum SourceVisibility {
     SHARED = 'SHARED',
 }
 
+export enum SourceCategory {
+    CLOUD = 'CLOUD',
+    ON_PREM = 'ON_PREM',
+    CRAWLING_MODULE = 'CRAWLING_MODULE',
+}
+
 export enum FilterHostType {
     CLOUD = 'CLOUD',
     CRAWLING_MODULE = 'CRAWLING_MODULE',
@@ -686,4 +692,17 @@ export enum DimensionEventTypes {
 export enum RegionType {
     Primary = 'PRIMARY',
     Secondary = 'SECONDARY',
+}
+
+export enum FormAuthenticationFailedMethod {
+    RedirectedToUrl = 'RedirectedToUrl',
+    PageDoesNotContain = 'PageDoesNotContain',
+    PageContains = 'PageContains',
+    CookieNotSet = 'CookieNotSet',
+}
+
+export enum FormInputType {
+    Username = 'Username',
+    Password = 'Password',
+    Input = 'Input',
 }

--- a/src/resources/Sources/Sources.ts
+++ b/src/resources/Sources/Sources.ts
@@ -5,6 +5,7 @@ import Resource from '../Resource';
 import {ScheduleModel} from '../SecurityCache';
 import SourcesFields from './SourcesFields/SourcesFields';
 import {
+    CreateSourceModel,
     CreateSourceOptions,
     LightSourceModel,
     ListSourcesParams,
@@ -23,7 +24,7 @@ export default class Sources extends Resource {
         this.field = new SourcesFields(api);
     }
 
-    create(source: New<SourceModel, 'resourceId'>, options?: CreateSourceOptions) {
+    create(source: New<CreateSourceModel, 'resourceId'>, options?: CreateSourceOptions) {
         return this.api.post<{id: string}>(this.buildPath(Sources.baseUrl, options), source);
     }
 
@@ -43,7 +44,7 @@ export default class Sources extends Resource {
         return this.api.get<SourceModel>(`${Sources.baseUrl}/${sourceId}`);
     }
 
-    update(sourceId: string, source: SourceModel, options?: CreateSourceOptions) {
+    update(sourceId: string, source: CreateSourceModel, options?: CreateSourceOptions) {
         return this.api.put<{id: string}>(this.buildPath(`${Sources.baseUrl}/${sourceId}`, options), source);
     }
 

--- a/src/resources/Sources/SourcesInterfaces.ts
+++ b/src/resources/Sources/SourcesInterfaces.ts
@@ -13,6 +13,8 @@ import {
     FilterLastOperationResultType,
     FilterLastOperationType,
     FilterStatusType,
+    FormAuthenticationFailedMethod,
+    FormInputType,
     MappingModelKind,
     OperationType,
     PatternType,
@@ -39,7 +41,7 @@ import {
 export interface SourceModel extends GranularResource {
     configurationError?: ConfigurationError;
     crawlingModuleId?: string;
-    customParameters?: any;
+    customParameters?: Record<string, string>;
     id?: string;
     information?: SourceInformation;
     logicalIndex?: string;
@@ -58,6 +60,22 @@ export interface SourceModel extends GranularResource {
     sourceType?: SourceType;
     sourceVisibility?: SourceVisibility;
     urlFilters?: UrlFilter[];
+    alwaysTrustCertificates?: boolean;
+    username?: string;
+    password?: string;
+    formAuthenticationConfig?: FormAuthenticationConfig;
+}
+
+export interface CreateSourceModel extends SourceModel, SourceInformation {
+    AutomaticFormAuth?: string;
+    FormAuth?: string;
+    authentication?: string;
+    ocrType?: string;
+    passwordInputName?: string;
+    passwordInputValue?: string;
+    usernameInputName?: string;
+    usernameInputValue?: string;
+    [key: string]: any;
 }
 
 export interface ConfigurationError {
@@ -66,6 +84,7 @@ export interface ConfigurationError {
 }
 
 export interface SourceInformation {
+    id?: string;
     collectionId?: number;
     collectionName?: string;
     documentsTotalSize?: number;
@@ -86,6 +105,8 @@ export interface MappingModel {
     id?: string;
     kind?: MappingModelKind;
     type?: string;
+    literalContent?: string;
+    metadataContent?: string;
 }
 
 export interface DocumentPermissionModel {
@@ -99,7 +120,7 @@ export interface SourceExtensionModel {
     condition?: string;
     extensionId?: string;
     itemType?: string;
-    parameters?: any;
+    parameters?: Record<string, string>;
     versionId?: string;
 }
 
@@ -255,6 +276,31 @@ export interface FormAuthenticationInput {
     name?: string;
     type?: AuthenticationInputType;
     value?: string;
+}
+
+export interface FormAuthenticationConfig {
+    actionMethod?: string;
+    actionUrl?: string;
+    addFoundInputs?: boolean;
+    authenticationFailed?: FormAuthenticationFailedConfiguration;
+    enableJavaScript?: boolean;
+    formContentType?: string;
+    formId?: string;
+    formUrl?: string;
+    inputs?: FormInput[];
+    javaScriptLoadingDelayInMilliseconds?: number;
+    customLoginSequence?: JSON;
+}
+
+export interface FormAuthenticationFailedConfiguration {
+    method: FormAuthenticationFailedMethod;
+    values: string[];
+}
+
+export interface FormInput {
+    name: string;
+    value?: string;
+    inputType: FormInputType;
 }
 
 export interface DataFile {

--- a/src/resources/Sources/SourcesInterfaces.ts
+++ b/src/resources/Sources/SourcesInterfaces.ts
@@ -289,7 +289,7 @@ export interface FormAuthenticationConfig {
     formUrl?: string;
     inputs?: FormInput[];
     javaScriptLoadingDelayInMilliseconds?: number;
-    customLoginSequence?: JSON;
+    customLoginSequence?: any;
 }
 
 export interface FormAuthenticationFailedConfiguration {

--- a/src/resources/Sources/tests/Sources.spec.ts
+++ b/src/resources/Sources/tests/Sources.spec.ts
@@ -3,7 +3,7 @@ import {New} from '../../BaseInterfaces';
 import {ActivityOperation} from '../../Enums';
 import {ScheduleModel} from '../../SecurityCache';
 import Sources from '../Sources';
-import {RawSourceConfig, SourceModel} from '../SourcesInterfaces';
+import {CreateSourceModel, RawSourceConfig} from '../SourcesInterfaces';
 
 jest.mock('../../../APICore');
 
@@ -20,7 +20,7 @@ describe('Sources', () => {
 
     describe('create', () => {
         it('should make a POST call to the Sources base url', () => {
-            const sourceModel: New<SourceModel> = {};
+            const sourceModel: New<CreateSourceModel> = {};
 
             source.create(sourceModel);
             expect(api.post).toHaveBeenCalledTimes(1);
@@ -69,7 +69,7 @@ describe('Sources', () => {
     describe('update', () => {
         it('should make a PUT call to the specific Sources url', () => {
             const sourceId = '🙀';
-            const sourceModel: SourceModel = {};
+            const sourceModel: CreateSourceModel = {};
 
             source.update(sourceId, sourceModel);
             expect(api.put).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
The Sources interfaces in swagger are a bit different from what we have in actual calls. This PR was created to update typing for `SourceModel` and `CreateSourceModel` according to the backbone model we currently use. Once Source team update swagger, I'll create another PR for the final adjustment. 
One thing to note, `SourceModel` here is a base model shared by all source types, and each type of source can have its proper additional properties.
