### PR TITLE
fix(update)!: case assist config model

### DIFF
--- a/src/resources/CaseAssistConfigs/CaseAssistConfigInterfaces.ts
+++ b/src/resources/CaseAssistConfigs/CaseAssistConfigInterfaces.ts
@@ -14,7 +14,6 @@ export interface CaseAssistConfigListOptions {
 
 export interface ITDConfigurationModel {
     pipeline?: string;
-    fieldsToFeed: string[];
     filter?: string;
     strategy: DocumentSuggestionsStrategies;
 }

--- a/src/resources/CaseAssistConfigs/tests/CaseAssistConfig.spec.ts
+++ b/src/resources/CaseAssistConfigs/tests/CaseAssistConfig.spec.ts
@@ -21,7 +21,6 @@ describe('CaseAssistConfig', () => {
             name: 'New CaseAssistConfig1',
             documentSuggestionConfiguration: {
                 pipeline: 'fake_pipeline1',
-                fieldsToFeed: ['field1', 'field2'],
                 filter: 'filter_string',
                 strategy: DocumentSuggestionsStrategies.ITD,
             },
@@ -35,7 +34,6 @@ describe('CaseAssistConfig', () => {
             name: 'New CaseAssistConfig2',
             documentSuggestionConfiguration: {
                 pipeline: 'fake_pipeline1',
-                fieldsToFeed: ['field1', 'field2'],
                 filter: 'filter_string',
                 strategy: DocumentSuggestionsStrategies.ITD,
             },


### PR DESCRIPTION
The model was updated in the customer service api to remove `fieldsToFeed`.
It is removed here to remain consistent with the service.

> This change is breaking as the current model is in use in packages/jsadmin-service in admin-ui