### PR TITLE
feat: add displayName to entities interface

### DIFF
--- a/src/resources/SchemaService/SchemaServiceInterfaces.ts
+++ b/src/resources/SchemaService/SchemaServiceInterfaces.ts
@@ -1,10 +1,10 @@
 export interface SchemaEntities {
     entities?: SchemaEntity[];
-    extensions?: string[];
 }
 
 export interface SchemaEntity {
     name?: string;
+    displayName?: string;
     id?: string;
 }
 


### PR DESCRIPTION
I added a third field in the SchemaEntity object for the real logical name of the entity to prevent situations where the display name is the same for some entities.

 {
            "name": "sys_amb_message0001",
            "id": "ae5b6d142c1700100c1dbc48b5c9f585",
            "displayName": "AMB Message"
        },
        {
            "name": "sys_amb_message0002",
            "id": "b65b6d142c1700100c1dbc48b5c9f59d",
            "displayName": "AMB Message"
        },
        {
            "name": "sys_amb_message0004",
            "id": "b65b6d142c1700100c1dbc48b5c9f5cc",
            "displayName": "AMB Message"
        },