### PR TITLE
feat(catalog): remove fields from catalog creation

### DIFF
--- a/src/resources/Catalogs/Catalog.ts
+++ b/src/resources/Catalogs/Catalog.ts
@@ -22,7 +22,7 @@ export default class Catalog extends Resource {
         return this.api.get<CatalogModel>(`${Catalog.baseUrl}/${catalogId}`);
     }
 
-    update(catalog: CatalogModel) {
-        return this.api.put<CatalogModel>(`${Catalog.baseUrl}/${catalog.id}`, catalog);
+    update(catalog: CreateCatalogModel) {
+        return this.api.put<CreateCatalogModel>(`${Catalog.baseUrl}/${catalog.id}`, catalog);
     }
 }

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -3,19 +3,32 @@ export interface CatalogsListOptions {
     pageSize?: number;
 }
 
-export interface CatalogModel {
+export interface BaseCatalogModel {
     id: string;
     name: string;
-    product: ProductHierarchyModel;
-    availability?: AvailabilityHierarchyModel;
     description?: string;
     scope?: ScopeModel;
-    variant?: VariantHierarchyModel;
 }
 
-export interface CreateCatalogModel extends CatalogModel {
+export interface CatalogModel extends BaseCatalogModel {
+    product: ProductHierarchyModel;
+    variant?: VariantHierarchyModel;
+    availability?: AvailabilityHierarchyModel;
+}
+
+export interface CreateCatalogModel extends BaseCatalogModel {
+    product: CreateProductHierarchyModel;
+    variant?: CreateVariantHierarchyModel;
     availability?: CreateAvailabilityHierarchyModel;
 }
+
+export interface ProductHierarchyModel {
+    idField: string;
+    objectType: string;
+    fields: string[];
+}
+
+export type CreateProductHierarchyModel = Omit<ProductHierarchyModel, 'fields'>;
 
 export interface VariantHierarchyModel {
     fields: string[];
@@ -23,10 +36,7 @@ export interface VariantHierarchyModel {
     objectType: string;
 }
 
-export interface ProductHierarchyModel {
-    idField: string;
-    objectType: string;
-}
+export type CreateVariantHierarchyModel = Omit<VariantHierarchyModel, 'fields'>;
 
 export interface AvailabilityHierarchyModel {
     availableSkusField: string;
@@ -35,9 +45,10 @@ export interface AvailabilityHierarchyModel {
     objectType: string;
 }
 
-export interface CreateAvailabilityHierarchyModel extends AvailabilityHierarchyModel {
+export type CreateAvailabilityHierarchyModel = Omit<AvailabilityHierarchyModel, 'fields'> & {
+    // Override `idField` to make it required
     idField: string;
-}
+};
 
 export type ScopeModel =
     | {

--- a/src/resources/Catalogs/tests/Catalog.spec.ts
+++ b/src/resources/Catalogs/tests/Catalog.spec.ts
@@ -60,7 +60,7 @@ describe('Catalog', () => {
 
     describe('update', () => {
         it('should make a PUT call to the specific catalog url', () => {
-            const catalogModel: CatalogModel = {
+            const catalogModel: CreateCatalogModel = {
                 id: 'catalog-to-update-id',
                 name: 'Catalog to be updated',
                 product: {


### PR DESCRIPTION
[COM-567]

We removed `variant.fields` and `availability.fields` properties when creating and updating a catalog, but still return them when fetching the catalog.

Also, we now return `product.fields`.

So this update reflects those two changes :)

[COM-567]: https://coveord.atlassian.net/browse/COM-567