### PR TITLE
fix(tsconfig.json): changing from esnext to commonjs for qpl-converter

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "esnext",
+        "module": "commonjs",
         "esModuleInterop": true,
         "sourceMap": true,
         "declaration": true,


### PR DESCRIPTION
BREAKING CHANGE: Need to change tsconfig module to commonjs from esnext to compile Entry.js. ES syntax causing build to fail during qpl-converter tests