### PR TITLE
feat(catalog): create route and interface to use catalog fields

### DIFF
--- a/src/resources/Catalogs/Catalog.ts
+++ b/src/resources/Catalogs/Catalog.ts
@@ -1,7 +1,7 @@
 import API from '../../APICore';
 import {New, PageModel} from '../BaseInterfaces';
 import Resource from '../Resource';
-import {CatalogModel, CatalogsListOptions, CreateCatalogModel} from './CatalogInterfaces';
+import {CachedCatalogFieldsModel, CatalogModel, CatalogsListOptions, CreateCatalogModel} from './CatalogInterfaces';
 
 export default class Catalog extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/catalogs`;
@@ -20,6 +20,10 @@ export default class Catalog extends Resource {
 
     get(catalogId: string) {
         return this.api.get<CatalogModel>(`${Catalog.baseUrl}/${catalogId}`);
+    }
+
+    getFields(catalogId: string) {
+        return this.api.get<CachedCatalogFieldsModel>(`${Catalog.baseUrl}/${catalogId}/fields`);
     }
 
     /* eslint-disable @typescript-eslint/unified-signatures */

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -14,6 +14,20 @@ export type HierarchyWithFields<T extends {fields?: string[]}> = Omit<T, 'fields
     fields: string[];
 };
 
+interface Cached<T> {
+    item: T;
+    lastUpdated: number;
+    nextUpdate: number;
+}
+
+interface CatalogFieldsModel {
+    productFields: string[];
+    variantFields: string[];
+    availabilityFields: string[];
+}
+
+export type CachedCatalogFieldsModel = Cached<CatalogFieldsModel>;
+
 export interface CatalogModel extends BaseCatalogModel {
     product: ProductHierarchyModel;
     variant?: HierarchyWithFields<VariantHierarchyModel>;

--- a/src/resources/Catalogs/tests/Catalog.spec.ts
+++ b/src/resources/Catalogs/tests/Catalog.spec.ts
@@ -84,6 +84,15 @@ describe('Catalog', () => {
         });
     });
 
+    describe('getFields', () => {
+        it("should make a GET call to the specific catalog's fields url", () => {
+            const catalogOfFieldsToGetId = 'catalog-of-fields';
+            catalog.getFields(catalogOfFieldsToGetId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Catalog.baseUrl}/${catalogOfFieldsToGetId}/fields`);
+        });
+    });
+
     describe('update', () => {
         it('should make a PUT call to the specific catalog url', () => {
             const catalogModel: CreateCatalogModel = {


### PR DESCRIPTION
[COM-588](https://coveord.atlassian.net/browse/COM-588)

This PR adds a new route and a new `Cached` interface to allow usage of the catalog fields endpoint.