### PR TITLE
feat(catalog): update interface with catalog configuration

### DIFF
--- a/src/resources/Catalogs/CatalogConfiguration.ts
+++ b/src/resources/Catalogs/CatalogConfiguration.ts
@@ -1,0 +1,33 @@
+import API from '../../APICore';
+import {New, PageModel} from '../BaseInterfaces';
+import Resource from '../Resource';
+import {CatalogConfigurationModel, CatalogsListOptions, CreateCatalogConfigurationModel} from './CatalogInterfaces';
+
+export default class CatalogConfiguration extends Resource {
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/catalogconfigurations`;
+
+    list(options?: CatalogsListOptions) {
+        return this.api.get<PageModel<CatalogConfigurationModel>>(
+            this.buildPath(CatalogConfiguration.baseUrl, options)
+        );
+    }
+
+    create(catalog: New<CreateCatalogConfigurationModel>) {
+        return this.api.post<CatalogConfigurationModel>(CatalogConfiguration.baseUrl, catalog);
+    }
+
+    delete(catalogId: string) {
+        return this.api.delete(`${CatalogConfiguration.baseUrl}/${catalogId}`);
+    }
+
+    get(configurationId: string) {
+        return this.api.get<CatalogConfigurationModel>(`${CatalogConfiguration.baseUrl}/${configurationId}`);
+    }
+
+    update(configuration: CreateCatalogConfigurationModel) {
+        return this.api.put<CatalogConfigurationModel>(
+            `${CatalogConfiguration.baseUrl}/${configuration.id}`,
+            configuration
+        );
+    }
+}

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -3,10 +3,37 @@ export interface CatalogsListOptions {
     pageSize?: number;
 }
 
+export interface CatalogFieldsMapping {
+    [name: string]: string;
+}
+
+export interface CreateCatalogConfigurationModel {
+    id: string;
+    name: string;
+    product: Omit<CreateProductHierarchyModel, 'fields'>;
+    variant?: Omit<CreateVariantHierarchyModel, 'fields'>;
+    availability?: Omit<CreateAvailabilityHierarchyModel, 'fields'>;
+    fieldsMapping: CatalogFieldsMapping;
+}
+
+export interface CatalogConfigurationModel {
+    id: string;
+    name: string;
+    product: HierarchyWithFields<ProductHierarchyModel>;
+    variant?: HierarchyWithFields<VariantHierarchyModel>;
+    availability?: HierarchyWithFields<AvailabilityHierarchyModel>;
+    fieldsMapping: CatalogFieldsMapping;
+}
+
 export interface BaseCatalogModel {
     id: string;
     name: string;
     description?: string;
+    sourceId?: string;
+    availabilitySourceId?: string;
+    /**
+     * @deprecated use `sourceId` and `availabilitySourceId` instead.
+     */
     scope?: ScopeModel;
 }
 
@@ -29,16 +56,39 @@ interface CatalogFieldsModel {
 export type CachedCatalogFieldsModel = Cached<CatalogFieldsModel>;
 
 export interface CatalogModel extends BaseCatalogModel {
+    /**
+     * @deprecated use `configuration.product` instead.
+     */
     product: ProductHierarchyModel;
+    /**
+     * @deprecated use `configuration.variant` instead.
+     */
     variant?: HierarchyWithFields<VariantHierarchyModel>;
+    /**
+     * @deprecated use `configuration.availability` instead.
+     */
     availability?: HierarchyWithFields<AvailabilityHierarchyModel>;
+
+    // Have to be optional for backward compatibility.
+    catalogConfigurationId?: string;
+    configuration?: CatalogConfigurationModel;
 }
 
-export interface CreateCatalogModel extends BaseCatalogModel {
-    product: CreateProductHierarchyModel;
-    variant?: CreateVariantHierarchyModel;
-    availability?: CreateAvailabilityHierarchyModel;
-}
+export type CreateCatalogModel = BaseCatalogModel &
+    (
+        | {
+              product: CreateProductHierarchyModel;
+              variant?: CreateVariantHierarchyModel;
+              availability?: CreateAvailabilityHierarchyModel;
+              catalogConfigurationId?: never;
+          }
+        | {
+              product?: never;
+              variant?: never;
+              availability?: never;
+              catalogConfigurationId: string;
+          }
+    );
 
 export interface ProductHierarchyModel {
     /**

--- a/src/resources/Catalogs/index.ts
+++ b/src/resources/Catalogs/index.ts
@@ -1,2 +1,3 @@
 export * from './Catalog';
+export * from './CatalogConfiguration';
 export * from './CatalogInterfaces';

--- a/src/resources/Catalogs/tests/Catalog.spec.ts
+++ b/src/resources/Catalogs/tests/Catalog.spec.ts
@@ -1,7 +1,7 @@
 import API from '../../../APICore';
 import {New} from '../../BaseInterfaces';
 import Catalog from '../Catalog';
-import {CreateCatalogModel, CatalogModel, AvailabilityHierarchyModel} from '../CatalogInterfaces';
+import {CreateCatalogModel, CatalogModel} from '../CatalogInterfaces';
 
 jest.mock('../../../APICore');
 
@@ -28,6 +28,17 @@ describe('Catalog', () => {
         it('should make a POST call to the catalogs base url', () => {
             const catalogModel: New<CreateCatalogModel> = {
                 name: 'New catalog',
+                catalogConfigurationId: 'id',
+            };
+
+            catalog.create(catalogModel);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(Catalog.baseUrl, catalogModel);
+        });
+
+        it('should be backward compatible with the legacy structure', () => {
+            const catalogModel: New<CreateCatalogModel> = {
+                name: 'New catalog',
                 product: {
                     idField: '@uri',
                     objectType: 'product',
@@ -39,7 +50,7 @@ describe('Catalog', () => {
             expect(api.post).toHaveBeenCalledWith(Catalog.baseUrl, catalogModel);
         });
 
-        it('should be backward compatible', () => {
+        it('should be backward compatible with the fields array', () => {
             const catalogModel: New<CreateCatalogModel> = {
                 name: 'New catalog',
                 product: {
@@ -109,7 +120,19 @@ describe('Catalog', () => {
             expect(api.put).toHaveBeenCalledWith(`${Catalog.baseUrl}/${catalogModel.id}`, catalogModel);
         });
 
-        it('should be backward compatible', () => {
+        it('should allow a PUT call with a catalog configuration id', () => {
+            const catalogModel: CreateCatalogModel = {
+                id: 'catalog-to-update-id',
+                name: 'Catalog to be updated',
+                catalogConfigurationId: 'abc-123-def',
+            };
+
+            catalog.update(catalogModel);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${Catalog.baseUrl}/${catalogModel.id}`, catalogModel);
+        });
+
+        it('should be backward compatible with the legacy structure', () => {
             const catalogModel: CatalogModel = {
                 id: 'catalog-to-update-id',
                 name: 'New catalog',

--- a/src/resources/Catalogs/tests/CatalogConfigurations.spec.ts
+++ b/src/resources/Catalogs/tests/CatalogConfigurations.spec.ts
@@ -1,0 +1,82 @@
+import API from '../../../APICore';
+import {New} from '../../BaseInterfaces';
+import CatalogConfiguration from '../CatalogConfiguration';
+import {CreateCatalogConfigurationModel} from '../CatalogInterfaces';
+
+jest.mock('../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('CatalogConfiguration', () => {
+    let catalogConfiguration: CatalogConfiguration;
+    const api = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        catalogConfiguration = new CatalogConfiguration(api);
+    });
+
+    describe('list', () => {
+        it('should make a GET call to the catalog configurations base url', () => {
+            catalogConfiguration.list({page: 2, pageSize: 10});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${CatalogConfiguration.baseUrl}?page=2&pageSize=10`);
+        });
+    });
+
+    describe('create', () => {
+        it('should make a POST call to the catalog configurations base url', () => {
+            const catalogConfigurationModel: New<CreateCatalogConfigurationModel> = {
+                name: 'New configuration',
+                product: {
+                    idField: 'bloup',
+                    objectType: 'ok',
+                },
+                fieldsMapping: {},
+            };
+
+            catalogConfiguration.create(catalogConfigurationModel);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(CatalogConfiguration.baseUrl, catalogConfigurationModel);
+        });
+    });
+
+    describe('delete', () => {
+        it('should make a DELETE call to the specific configuration url', () => {
+            const catalogToDeleteId = 'configuration-to-be-deleted';
+            catalogConfiguration.delete(catalogToDeleteId);
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${CatalogConfiguration.baseUrl}/${catalogToDeleteId}`);
+        });
+    });
+
+    describe('get', () => {
+        it('should make a GET call to the specific configuration url', () => {
+            const catalogToGetId = 'configuration-to-be-fetched';
+            catalogConfiguration.get(catalogToGetId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${CatalogConfiguration.baseUrl}/${catalogToGetId}`);
+        });
+    });
+
+    describe('update', () => {
+        it('should make a PUT call to the specific catalog configuration url', () => {
+            const catalogConfigurationModel: CreateCatalogConfigurationModel = {
+                id: 'wow',
+                name: 'Configuration to be updated',
+                product: {
+                    idField: '@uri',
+                    objectType: 'product',
+                },
+                fieldsMapping: {},
+            };
+
+            catalogConfiguration.update(catalogConfigurationModel);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `${CatalogConfiguration.baseUrl}/${catalogConfigurationModel.id}`,
+                catalogConfigurationModel
+            );
+        });
+    });
+});

--- a/src/resources/PlatformResources.ts
+++ b/src/resources/PlatformResources.ts
@@ -3,6 +3,7 @@ import ApiKey from './ApiKeys/ApiKeys';
 import AWS from './AWS/AWS';
 import CaseAssistConfig from './CaseAssistConfigs/CaseAssistConfig';
 import Catalog from './Catalogs/Catalog';
+import CatalogConfiguration from './Catalogs/CatalogConfiguration';
 import Cluster from './Clusters/Cluster';
 import CrawlingModule from './CrawlingModule/CrawlingModule';
 import Extensions from './Extensions/Extensions';
@@ -33,6 +34,7 @@ const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'aws', resource: AWS},
     {key: 'caseAssistConfig', resource: CaseAssistConfig},
     {key: 'catalog', resource: Catalog},
+    {key: 'catalogConfigurations', resource: CatalogConfiguration},
     {key: 'cluster', resource: Cluster},
     {key: 'crawlingModule', resource: CrawlingModule},
     {key: 'extension', resource: Extensions},
@@ -65,6 +67,7 @@ class PlatformResources {
     aws: AWS;
     caseAssistConfig: CaseAssistConfig;
     catalog: Catalog;
+    catalogConfigurations: CatalogConfiguration;
     cluster: Cluster;
     crawlingModule: CrawlingModule;
     extension: Extensions;

--- a/src/resources/tests/PlatformResources.spec.ts
+++ b/src/resources/tests/PlatformResources.spec.ts
@@ -2,6 +2,7 @@ import ApiKey from '../ApiKeys/ApiKeys';
 import AWS from '../AWS/AWS';
 import CaseAssistConfig from '../CaseAssistConfigs/CaseAssistConfig';
 import Catalog from '../Catalogs/Catalog';
+import CatalogConfiguration from '../Catalogs/CatalogConfiguration';
 import Cluster from '../Clusters/Cluster';
 import CrawlingModule from '../CrawlingModule/CrawlingModule';
 import Extension from '../Extensions/Extensions';
@@ -50,6 +51,14 @@ describe('PlatformResources', () => {
 
             expect(platformResources.catalog).toBeDefined();
             expect(platformResources.catalog).toBeInstanceOf(Catalog);
+        });
+
+        it('should register the catalogConfigurations resource on the platform instance', () => {
+            const platformResources = new PlatformResources();
+            platformResources.registerAll();
+
+            expect(platformResources.catalogConfigurations).toBeDefined();
+            expect(platformResources.catalogConfigurations).toBeInstanceOf(CatalogConfiguration);
         });
 
         it('should register the cluster resource on the platform instance', () => {


### PR DESCRIPTION
[COM-702]

This matches many updates from the Catalog API. Changes include:

* `scope` is deprecated in favor of two first-class properties, `sourceId` and `availabilitySourceId`.
* You can create a catalog with a `catalogConfigurationId`, which is a second object in the Catalog Service. Sending the "old" structure will create a configuration for you.
* `product` + `variant` + `availability` are now set in the Catalog Configuration, so the first-class properties are now deprecated.
* Added the `catalogconfigurations` API which is pretty straightforward

It was tested with a link to `admin-ui`, so no breaking change here

[COM-702]: https://coveord.atlassian.net/browse/COM-702