### PR TITLE
feat(extension): added support for extension CRUD operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7072,6 +7072,24 @@
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
             "dev": true
         },
+        "isomorphic-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+            "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+            "dev": true,
+            "requires": {
+                "node-fetch": "^2.6.1",
+                "whatwg-fetch": "^3.4.1"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+                    "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+                    "dev": true
+                }
+            }
+        },
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -18120,6 +18138,12 @@
             "requires": {
                 "iconv-lite": "0.4.24"
             }
+        },
+        "whatwg-fetch": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+            "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==",
+            "dev": true
         },
         "whatwg-mimetype": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "eslint-plugin-jest": "^23.20.0",
         "eslint-plugin-prettier": "^3.1.4",
         "husky": "^4.2.5",
+        "isomorphic-fetch": "^3.0.0",
         "jest": "^26.4.2",
         "jest-fetch-mock": "^3.0.3",
         "jest-runner-eslint": "^0.10.0",

--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -54,6 +54,17 @@ export enum OperationType {
     SECURITY_CACHE_REFRESH_ENTITIES_IN_ERROR = 'SECURITY_CACHE_REFRESH_ENTITIES_IN_ERROR',
 }
 
+export enum DataStreamType {
+    BODY_TEXT = 'BODY_TEXT',
+    BODY_HTML = 'BODY_HTML',
+    THUMBNAIL = 'THUMBNAIL',
+    DOCUMENT_DATA = 'DOCUMENT_DATA',
+}
+
+export enum ExtensionLanguageType {
+    'PYTHON3' = 'PYTHON3',
+}
+
 export enum SourceStatusType {
     CREATING = 'CREATING',
     DISABLED = 'DISABLED',

--- a/src/resources/Extensions/Extensions.ts
+++ b/src/resources/Extensions/Extensions.ts
@@ -1,9 +1,33 @@
 import API from '../../APICore';
 import Resource from '../Resource';
-import {ExtensionModel} from './ExtensionsInterfaces';
+import {CreateExtension, ExtensionModel} from './ExtensionsInterfaces';
 
 export default class Extension extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/extensions`;
+
+    create(extension: CreateExtension) {
+        return this.api.post<ExtensionModel>(Extension.baseUrl, extension);
+    }
+
+    update(extensionId: string, options: CreateExtension) {
+        return this.api.put<ExtensionModel>(`${Extension.baseUrl}/${extensionId}`, options);
+    }
+
+    delete(extensionId: string) {
+        return this.api.delete<void>(`${Extension.baseUrl}/${extensionId}`);
+    }
+
+    enable(extensionId: string) {
+        return this.api.post<void>(`${Extension.baseUrl}/${extensionId}/enable`);
+    }
+
+    disable(extensionId: string, reason?: string) {
+        return this.api.post<void>(`${Extension.baseUrl}/${extensionId}/disable`, {reason});
+    }
+
+    get(extensionId: string) {
+        return this.api.get<ExtensionModel>(`${Extension.baseUrl}/${extensionId}`);
+    }
 
     list() {
         return this.api.get<ExtensionModel[]>(Extension.baseUrl);

--- a/src/resources/Extensions/ExtensionsInterfaces.ts
+++ b/src/resources/Extensions/ExtensionsInterfaces.ts
@@ -1,14 +1,19 @@
+import {GranularResource} from '../../Entry';
+import {DataStreamType, ExtensionLanguageType} from '../Enums';
+
+type Version = 'v1' | 'v2';
+
 export interface ExtensionModel {
-    apiVersion: string;
+    apiVersion: Version;
     content: string;
     createdDate: number;
     description: string;
     enabled: boolean;
     id: string;
-    language: string;
+    language: ExtensionLanguageType;
     lastModified: number;
     name: string;
-    requiredDataStreams: string[];
+    requiredDataStreams: DataStreamType[];
     status: {
         dailyStatistics: {
             averageDurationInSeconds: number;
@@ -40,4 +45,13 @@ export interface ExtensionModel {
         }
     ];
     versionId: string;
+}
+
+export interface CreateExtension extends GranularResource {
+    content: string;
+    name: string;
+    apiVersion?: Version;
+    description?: string;
+    language?: ExtensionLanguageType;
+    requiredDataStreams?: DataStreamType[];
 }

--- a/src/resources/Extensions/tests/Extensions.spec.ts
+++ b/src/resources/Extensions/tests/Extensions.spec.ts
@@ -1,5 +1,6 @@
 import API from '../../../APICore';
 import Extension from '../Extensions';
+import {CreateExtension} from '../ExtensionsInterfaces';
 
 jest.mock('../../../APICore');
 
@@ -13,6 +14,75 @@ describe('Extension', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         extension = new Extension(api, serverlessApi);
+    });
+
+    describe('create', () => {
+        it('should make a post call to the specific Extension url', () => {
+            const testExtension: CreateExtension = {
+                name: 'Test',
+                content: 'print("hello world")',
+            };
+            extension.create(testExtension);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(Extension.baseUrl, testExtension);
+        });
+    });
+
+    describe('update', () => {
+        it('should make a put call to the specific Extension url', () => {
+            const extensionId = '1';
+            const testExtension: CreateExtension = {
+                name: 'Test',
+                content: 'print("hello worlds")',
+            };
+            extension.update(extensionId, testExtension);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${Extension.baseUrl}/${extensionId}`, testExtension);
+        });
+    });
+
+    describe('delete', () => {
+        it('should make a delete call to the specific Extension url', () => {
+            const extensionId = '1';
+            extension.delete(extensionId);
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${Extension.baseUrl}/${extensionId}`);
+        });
+    });
+
+    describe('enable', () => {
+        it('should make a post call to the specific Extension url to enable an extension', () => {
+            const extensionId = '1';
+            extension.enable(extensionId);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Extension.baseUrl}/${extensionId}/enable`);
+        });
+    });
+
+    describe('disable', () => {
+        it('should make a post call to the specific Extension url to disable an extension', () => {
+            const extensionId = '1';
+            extension.disable(extensionId);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Extension.baseUrl}/${extensionId}/disable`, {});
+        });
+
+        it('should make a post call to the specific Extension url to disable an extension with a reason', () => {
+            const extensionId = '1';
+            const reason = 'maintenance';
+            extension.disable(extensionId, reason);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Extension.baseUrl}/${extensionId}/disable`, {reason});
+        });
+    });
+
+    describe('get', () => {
+        it('should make a get call to the specific Extension url', () => {
+            const extensionId = '1';
+            extension.get(extensionId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Extension.baseUrl}/${extensionId}`);
+        });
     });
 
     describe('list', () => {


### PR DESCRIPTION
Added support for the following extension operations:

- create
- update
- delete
- enable
- disable
- get

The interface was built from this [doc](https://docs.coveo.com/en/7/cloud-v2-api-reference/extension-api#operation/). However, the documented response from the create operation didn't match the actual value. I decided to use the full `ExtensionModel` interface as the response instead of just the ID.

This doesn't cover the extension testing and version APIs. These may be covered in a later PR.