### PR TITLE
feat(license): added a call to update the whole license

### DIFF
--- a/src/resources/License/License.ts
+++ b/src/resources/License/License.ts
@@ -4,8 +4,8 @@ import {LicenseModel} from './LicenseInterfaces';
 import API from '../../APICore';
 
 export default class License extends Resource {
-    static getBaseUrl = (sectionName: LicenseSection) =>
-        `/rest/organizations/${API.orgPlaceholder}/license/${sectionName}`;
+    static getBaseUrl = (sectionName?: LicenseSection) =>
+        `/rest/organizations/${API.orgPlaceholder}/license${sectionName ? `/${sectionName}` : ''}`;
 
     get(sectionName: LicenseSection) {
         return this.api.get<LicenseModel>(License.getBaseUrl(sectionName));
@@ -13,5 +13,9 @@ export default class License extends Resource {
 
     update(sectionName: LicenseSection, licenseSection: Record<string, number>) {
         return this.api.put<LicenseModel>(License.getBaseUrl(sectionName), licenseSection);
+    }
+
+    updateLicense(license: LicenseModel) {
+        return this.api.put<LicenseModel>(License.getBaseUrl(), license);
     }
 }

--- a/src/resources/License/License.ts
+++ b/src/resources/License/License.ts
@@ -4,18 +4,17 @@ import {LicenseModel} from './LicenseInterfaces';
 import API from '../../APICore';
 
 export default class License extends Resource {
-    static getBaseUrl = (sectionName?: LicenseSection) =>
-        `/rest/organizations/${API.orgPlaceholder}/license${sectionName ? `/${sectionName}` : ''}`;
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/license`;
 
     get(sectionName: LicenseSection) {
-        return this.api.get<LicenseModel>(License.getBaseUrl(sectionName));
+        return this.api.get<LicenseModel>(`${License.baseUrl}/${sectionName}`);
     }
 
     update(sectionName: LicenseSection, licenseSection: Record<string, number>) {
-        return this.api.put<LicenseModel>(License.getBaseUrl(sectionName), licenseSection);
+        return this.api.put<LicenseModel>(`${License.baseUrl}/${sectionName}`, licenseSection);
     }
 
     updateLicense(license: LicenseModel) {
-        return this.api.put<LicenseModel>(License.getBaseUrl(), license);
+        return this.api.put<LicenseModel>(License.baseUrl, license);
     }
 }

--- a/src/resources/License/tests/License.spec.ts
+++ b/src/resources/License/tests/License.spec.ts
@@ -1,6 +1,7 @@
 import {LicenseSection} from '../..';
 import API from '../../../APICore';
 import License from '../License';
+import {LicenseModel} from '../LicenseInterfaces';
 
 jest.mock('../../../APICore');
 
@@ -30,6 +31,16 @@ describe('License', () => {
             license.update(sectionName, {value: 100});
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(`/rest/organizations/{organizationName}/license/searchapi`, {
+                value: 100,
+            });
+        });
+    });
+
+    describe('updateAll', () => {
+        it('should make a PUT call to the specific License url', () => {
+            license.updateLicense(({value: 100} as unknown) as LicenseModel);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`/rest/organizations/{organizationName}/license`, {
                 value: 100,
             });
         });


### PR DESCRIPTION
in swagger theres an endpoint to update the whole license, but theres no call to this endpoint in
platform-client. This endpoint is needed for the next part to [this PR](https://coveord.atlassian.net/browse/ADUI-6297)

[Swagger endpoint in question](https://platformdev.cloud.coveo.com/docs/internal/?urls.primaryName=Platform#/License/rest_organizations_paramId_license_put)

