### PR TITLE
feat(resource snapshots): add deleteAllLinks

### DIFF
--- a/src/resources/ResourceSnapshots/index.ts
+++ b/src/resources/ResourceSnapshots/index.ts
@@ -1,2 +1,3 @@
 export * from './ResourceSnapshots';
 export * from './ResourceSnapshotsInterfaces';
+export * from './links/Links';

--- a/src/resources/ResourceSnapshots/links/Links.ts
+++ b/src/resources/ResourceSnapshots/links/Links.ts
@@ -1,0 +1,10 @@
+import Resource from '../../Resource';
+import API from '../../../APICore';
+
+export default class Links extends Resource {
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/links`;
+
+    deleteAll() {
+        return this.api.delete(Links.baseUrl);
+    }
+}

--- a/src/resources/ResourceSnapshots/links/tests/Links.spec.ts
+++ b/src/resources/ResourceSnapshots/links/tests/Links.spec.ts
@@ -1,0 +1,26 @@
+import API from '../../../../APICore';
+import Links from '../Links';
+
+jest.mock('../../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('Links', () => {
+    let links: Links;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        links = new Links(api, serverlessApi);
+    });
+
+    describe('delete all links', () => {
+        it('should make a DELETE call to the specific links url', () => {
+            links.deleteAll();
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${Links.baseUrl}`);
+        });
+    });
+});


### PR DESCRIPTION
![Screen Shot 2021-01-19 at 4 45 19 PM](https://user-images.githubusercontent.com/52545119/105096925-c8b65c80-5a75-11eb-9305-32f3f5f2b59f.png)

add delete all links to clear all the links in a organization to be able to restart synchronization from scratch