### PR TITLE
feat(connectivity service): add basic call to the diagnostic api

### DIFF
--- a/src/resources/Connectivity/Connectivity.ts
+++ b/src/resources/Connectivity/Connectivity.ts
@@ -1,0 +1,15 @@
+import Resource from '../Resource';
+import API from '../../APICore';
+import {LogRequestState} from './ConnectivityInterface';
+
+export default class Connectivity extends Resource {
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/sources`;
+
+    requestLog(sourceId: string, activityId: string) {
+        return this.api.post(`${Connectivity.baseUrl}/${sourceId}/diagnostics/${activityId}/logs`);
+    }
+
+    getLogRequestState(sourceId: string, activityId) {
+        return this.api.get<LogRequestState>(`${Connectivity.baseUrl}/${sourceId}/diagnostics/${activityId}/state`);
+    }
+}

--- a/src/resources/Connectivity/ConnectivityInterface.ts
+++ b/src/resources/Connectivity/ConnectivityInterface.ts
@@ -1,0 +1,5 @@
+export interface LogRequestState {
+    state: string;
+    url?: string;
+    error?: string;
+}

--- a/src/resources/Connectivity/index.ts
+++ b/src/resources/Connectivity/index.ts
@@ -1,0 +1,2 @@
+export * from './Connectivity';
+export * from './ConnectivityInterface';

--- a/src/resources/Connectivity/tests/Connectivity.spec.ts
+++ b/src/resources/Connectivity/tests/Connectivity.spec.ts
@@ -1,0 +1,34 @@
+import API from '../../../APICore';
+import Connectivity from '../Connectivity';
+
+jest.mock('../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('Connectivity Service', () => {
+    let connectivity: Connectivity;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        connectivity = new Connectivity(api, serverlessApi);
+    });
+
+    describe('diagnostic', () => {
+        const sourceId = 'SOURCE_ID';
+        const activityId = 'ACTIVITY_ID';
+
+        it('should post a new new log request', () => {
+            connectivity.requestLog(sourceId, activityId);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Connectivity.baseUrl}/${sourceId}/diagnostics/${activityId}/logs`);
+        });
+
+        it('should get the state of a log request', () => {
+            connectivity.getLogRequestState(sourceId, activityId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Connectivity.baseUrl}/${sourceId}/diagnostics/${activityId}/state`);
+        });
+    });
+});

--- a/src/resources/PlatformResources.ts
+++ b/src/resources/PlatformResources.ts
@@ -30,6 +30,7 @@ import Sources from './Sources/Sources';
 import UsageAnalytics from './UsageAnalytics/UsageAnalytics';
 import User from './Users/User';
 import Links from './ResourceSnapshots/links/Links';
+import Connectivity from './Connectivity/Connectivity';
 
 const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'apiKey', resource: ApiKey},
@@ -74,6 +75,7 @@ class PlatformResources {
     catalogConfiguration: CatalogConfiguration;
     cluster: Cluster;
     crawlingModule: CrawlingModule;
+    connectivity: Connectivity;
     extension: Extensions;
     field: Field;
     global: Global;

--- a/src/resources/PlatformResources.ts
+++ b/src/resources/PlatformResources.ts
@@ -39,6 +39,7 @@ const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'catalog', resource: Catalog},
     {key: 'catalogConfiguration', resource: CatalogConfiguration},
     {key: 'cluster', resource: Cluster},
+    {key: 'connectivity', resource: Connectivity},
     {key: 'crawlingModule', resource: CrawlingModule},
     {key: 'extension', resource: Extensions},
     {key: 'field', resource: Field},

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -28,3 +28,4 @@ export * from './SchemaService';
 export * from './SearchPages';
 export * from './Limits';
 export * from './Notification';
+export * from './Connectivity';

--- a/src/resources/tests/PlatformResources.spec.ts
+++ b/src/resources/tests/PlatformResources.spec.ts
@@ -27,6 +27,7 @@ import SchemaService from '../SchemaService/SchemaService';
 import SearchPages from '../SearchPages/SearchPages';
 import Notifications from '../Notification/notification';
 import Logs from '../Logs/Logs';
+import Connectivity from '../Connectivity/Connectivity';
 
 describe('PlatformResources', () => {
     describe('registerAll', () => {
@@ -252,6 +253,14 @@ describe('PlatformResources', () => {
 
             expect(platformResources.logs).toBeDefined();
             expect(platformResources.logs).toBeInstanceOf(Logs);
+        });
+
+        it('should register the Connectivity resource on the platform instance', () => {
+            const platformResources = new PlatformResources();
+            platformResources.registerAll();
+
+            expect(platformResources.connectivity).toBeDefined();
+            expect(platformResources.connectivity).toBeInstanceOf(Connectivity);
         });
     });
 });


### PR DESCRIPTION
Add new API call to the Connectivity service. Those will be used to generate downloadable logs for a source. 