### PR TITLE
feat(catalog): correct configurations parameter names

### DIFF
--- a/src/resources/Catalogs/CatalogConfiguration.ts
+++ b/src/resources/Catalogs/CatalogConfiguration.ts
@@ -12,12 +12,12 @@ export default class CatalogConfiguration extends Resource {
         );
     }
 
-    create(catalog: New<CreateCatalogConfigurationModel>) {
-        return this.api.post<CatalogConfigurationModel>(CatalogConfiguration.baseUrl, catalog);
+    create(configuration: New<CreateCatalogConfigurationModel>) {
+        return this.api.post<CatalogConfigurationModel>(CatalogConfiguration.baseUrl, configuration);
     }
 
-    delete(catalogId: string) {
-        return this.api.delete(`${CatalogConfiguration.baseUrl}/${catalogId}`);
+    delete(configurationId: string) {
+        return this.api.delete(`${CatalogConfiguration.baseUrl}/${configurationId}`);
     }
 
     get(configurationId: string) {

--- a/src/resources/Catalogs/tests/CatalogConfigurations.spec.ts
+++ b/src/resources/Catalogs/tests/CatalogConfigurations.spec.ts
@@ -44,19 +44,19 @@ describe('CatalogConfiguration', () => {
 
     describe('delete', () => {
         it('should make a DELETE call to the specific configuration url', () => {
-            const catalogToDeleteId = 'configuration-to-be-deleted';
-            catalogConfiguration.delete(catalogToDeleteId);
+            const configurationToDeleteId = 'configuration-to-be-deleted';
+            catalogConfiguration.delete(configurationToDeleteId);
             expect(api.delete).toHaveBeenCalledTimes(1);
-            expect(api.delete).toHaveBeenCalledWith(`${CatalogConfiguration.baseUrl}/${catalogToDeleteId}`);
+            expect(api.delete).toHaveBeenCalledWith(`${CatalogConfiguration.baseUrl}/${configurationToDeleteId}`);
         });
     });
 
     describe('get', () => {
         it('should make a GET call to the specific configuration url', () => {
-            const catalogToGetId = 'configuration-to-be-fetched';
-            catalogConfiguration.get(catalogToGetId);
+            const configurationToGetId = 'configuration-to-be-fetched';
+            catalogConfiguration.get(configurationToGetId);
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${CatalogConfiguration.baseUrl}/${catalogToGetId}`);
+            expect(api.get).toHaveBeenCalledWith(`${CatalogConfiguration.baseUrl}/${configurationToGetId}`);
         });
     });
 


### PR DESCRIPTION
While working on COM-708, more specifically the deletion of a configuration, I noticed these parameters were misnamed. I also adjusted the tests.

[COM-708]

[COM-708]: https://coveord.atlassian.net/browse/COM-708