### PR TITLE
feat(config): support explicit no orgID for configuration

### DIFF
--- a/src/ConfigurationInterfaces.ts
+++ b/src/ConfigurationInterfaces.ts
@@ -1,7 +1,6 @@
 import {Environment, Region} from './Endpoints';
 import {ResponseHandler} from './handlers/ResponseHandlerInterfaces';
 import {Retrievable} from './utils/Retriever';
-
 export type Feature = (currentOptions: PlatformClientOptions) => PlatformClientOptions;
 
 export interface PlatformClientOptions {

--- a/src/ConfigurationInterfaces.ts
+++ b/src/ConfigurationInterfaces.ts
@@ -3,11 +3,10 @@ import {ResponseHandler} from './handlers/ResponseHandlerInterfaces';
 import {Retrievable} from './utils/Retriever';
 
 export type Feature = (currentOptions: PlatformClientOptions) => PlatformClientOptions;
-export const NoOrgIDRequiredForGlobalOperations = 'Global';
 
 export interface PlatformClientOptions {
     accessToken: Retrievable<string>;
-    organizationId: Retrievable<string | typeof NoOrgIDRequiredForGlobalOperations>;
+    organizationId?: Retrievable<string>;
     host?: Retrievable<string>;
     serverlessHost?: Retrievable<string>;
     environment?: Environment;

--- a/src/ConfigurationInterfaces.ts
+++ b/src/ConfigurationInterfaces.ts
@@ -3,10 +3,11 @@ import {ResponseHandler} from './handlers/ResponseHandlerInterfaces';
 import {Retrievable} from './utils/Retriever';
 
 export type Feature = (currentOptions: PlatformClientOptions) => PlatformClientOptions;
+export const NoOrgIDRequiredForGlobalOperations = 'Global';
 
 export interface PlatformClientOptions {
     accessToken: Retrievable<string>;
-    organizationId: Retrievable<string>;
+    organizationId: Retrievable<string | typeof NoOrgIDRequiredForGlobalOperations>;
     host?: Retrievable<string>;
     serverlessHost?: Retrievable<string>;
     environment?: Environment;


### PR DESCRIPTION
For some operations, no organization ID is actually required by the platform.

For example, if you need to `list all org` ( https://platformdev.cloud.coveo.com/docs?urls.primaryName=Organization#/Organizations/rest_organizations_get), `list regions` ( https://platformdev.cloud.coveo.com/docs?urls.primaryName=Organization#/Region%20Configuration/rest_global_regions_get ) etc.

While in theory you could, as a consumer of the library, pass in `organizationId: ''` when creating a PlatformClient, I propose adding an explicit parameter, globally exported.

Just so the consumer code can do something like: 

```
import PlatformClient, {
  NoOrgIDRequiredForGlobalOperations,
} from '@coveord/platform-client';

const client = new PlatformClient({
      accessToken: myToken,
      environment: myEnvironment,
      organizationId: NoOrgIDRequiredForGlobalOperations,
 });

await client.organization.list();
```


https://coveord.atlassian.net/browse/CDX-56