### PR TITLE
fix(api): support node js environments with FormData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2718,8 +2718,7 @@
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-            "dev": true
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "at-least-node": {
             "version": "1.0.0",
@@ -3520,7 +3519,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
@@ -4239,8 +4237,7 @@
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "dev": true
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "deprecation": {
             "version": "2.3.1",
@@ -5912,13 +5909,12 @@
             "dev": true
         },
         "form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "dev": true,
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+            "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
             "requires": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
+                "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
             }
         },
@@ -11021,14 +11017,12 @@
         "mime-db": {
             "version": "1.44.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-            "dev": true
+            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
         },
         "mime-types": {
             "version": "2.1.27",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
             "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-            "dev": true,
             "requires": {
                 "mime-db": "1.44.0"
             }
@@ -15884,6 +15878,17 @@
                 "uuid": "^3.3.2"
             },
             "dependencies": {
+                "form-data": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
                 "tough-cookie": {
                     "version": "2.5.0",
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     },
     "dependencies": {
         "exponential-backoff": "^3.1.0",
+        "form-data": "^3.0.0",
         "query-string": "^6.13.1"
     }
 }

--- a/src/APICore.ts
+++ b/src/APICore.ts
@@ -4,6 +4,7 @@ import getEndpoint, {Environment, Region} from './Endpoints';
 import {ResponseHandler} from './handlers/ResponseHandlerInterfaces';
 import handleResponse, {defaultResponseHandlers, ResponseHandlers} from './handlers/ResponseHandlers';
 import {UserModel} from './resources/Users';
+import {getFormData} from './utils/FormData';
 import retrieve from './utils/Retriever';
 
 export default class API {
@@ -88,8 +89,8 @@ export default class API {
     }
 
     async checkToken() {
-        const formData = new FormData();
-        formData.set('token', this.accessToken);
+        const formData = getFormData();
+        formData.append('token', this.accessToken);
         this.tokenInfo = await this.postForm<any>('/oauth/check_token', formData);
     }
 

--- a/src/resources/Pipelines/Statements/Statements.ts
+++ b/src/resources/Pipelines/Statements/Statements.ts
@@ -1,3 +1,4 @@
+import {getFormData} from '../../../utils/FormData';
 import Resource from '../../Resource';
 import {
     CopyStatementModel,
@@ -31,8 +32,8 @@ export default class Statements extends Resource {
     }
 
     importCSV(pipelineId: string, csvFile: File, options?: ExportStatementParams) {
-        const formData = new FormData();
-        formData.set('file', csvFile);
+        const formData = getFormData();
+        formData.append('file', csvFile);
         return this.api.postForm(
             this.buildPath(`${Statements.getLegacyUrl(pipelineId)}/import`, {
                 mode: 'overwrite',

--- a/src/resources/Pipelines/Statements/tests/Statements.spec.ts
+++ b/src/resources/Pipelines/Statements/tests/Statements.spec.ts
@@ -132,7 +132,7 @@ describe('Statements', () => {
 
     describe('import', () => {
         const mockedFormData = {
-            set: jest.fn(),
+            append: jest.fn(),
         };
 
         beforeEach(() => {
@@ -150,8 +150,8 @@ describe('Statements', () => {
                 '/rest/search/admin/pipelines/🥚/statements/import?mode=overwrite&feature=stop',
                 mockedFormData
             );
-            expect(mockedFormData.set).toHaveBeenCalledTimes(1);
-            expect(mockedFormData.set).toHaveBeenCalledWith('file', myCSVFile);
+            expect(mockedFormData.append).toHaveBeenCalledTimes(1);
+            expect(mockedFormData.append).toHaveBeenCalledWith('file', myCSVFile);
         });
     });
 });

--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -1,4 +1,5 @@
 import API from '../../APICore';
+import {getFormData} from '../../utils/FormData';
 import Resource from '../Resource';
 import {
     ApplyOptions,
@@ -51,8 +52,8 @@ export default class ResourceSnapshots extends Resource {
             throw new Error('The uploaded file must be either a ZIP or a JSON file.');
         }
 
-        const form: FormData = new FormData();
-        form.set('file', file);
+        const form: FormData = getFormData();
+        form.append('file', file);
 
         return this.api.postForm<ResourceSnapshotsModel>(
             this.buildPath(`${ResourceSnapshots.baseUrl}/file`, computedOptions),

--- a/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
+++ b/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
@@ -99,7 +99,7 @@ describe('ResourceSnapshots', () => {
 
     describe('createFromFile', () => {
         const mockedFormData = {
-            set: jest.fn(),
+            append: jest.fn(),
         };
         const mockedFile = {
             type: 'application/zip',

--- a/src/tests/APICore.spec.ts
+++ b/src/tests/APICore.spec.ts
@@ -322,7 +322,7 @@ describe('APICore', () => {
 
     describe('checkToken', () => {
         const mockedFormData = {
-            set: jest.fn(),
+            append: jest.fn(),
         };
 
         beforeEach(() => {
@@ -337,8 +337,8 @@ describe('APICore', () => {
 
             expect(postFormSpy).toHaveBeenCalledTimes(1);
             expect(postFormSpy).toHaveBeenCalledWith('/oauth/check_token', mockedFormData);
-            expect(mockedFormData.set).toHaveBeenCalledTimes(1);
-            expect(mockedFormData.set).toHaveBeenCalledWith('token', 'my-token');
+            expect(mockedFormData.append).toHaveBeenCalledTimes(1);
+            expect(mockedFormData.append).toHaveBeenCalledWith('token', 'my-token');
         });
 
         it('should throw an error if the check token call fails', async () => {

--- a/src/utils/FormData.ts
+++ b/src/utils/FormData.ts
@@ -1,0 +1,12 @@
+export const getFormData = (): FormData => {
+    // Non browser environment does not support FormData
+    if (typeof FormData !== 'undefined') {
+        return new FormData();
+    }
+    // eslint-disable-next-line
+    const formDataNode = require('form-data');
+    const formDataNodeInstance = new formDataNode();
+    // formData.set not available in node.
+    formDataNodeInstance.set = formDataNodeInstance.append;
+    return formDataNodeInstance;
+};


### PR DESCRIPTION
FormData is a Web JS only API, not available in NodeJS.

This PR adds a way to load https://github.com/form-data/form-data when it's not available.

If you guys prefer, we can also just document how to polyfill it from an end user point of view, but I personally find this to be very annoying for end users.

Just tell me what you prefer, either like this PR propose, or a README change with the documentation on how to do it as a end user.

Also replaced all `formData.set` to `formData.append`, as it is not present on the most popular node module for FormData. 
Everywhere I could see in the codebase, using append instead of set should not produce any difference in the end.

https://coveord.atlassian.net/browse/CDX-63