### PR TITLE
feat(license): support full license API call

### DIFF
--- a/src/resources/License/License.ts
+++ b/src/resources/License/License.ts
@@ -11,7 +11,7 @@ export default class License extends Resource {
     }
 
     full() {
-        return this.api.get<LicenseModel>(`${License.baseUrl}`);
+        return this.api.get<LicenseModel>(License.baseUrl);
     }
 
     update(sectionName: LicenseSection, licenseSection: Record<string, number>) {

--- a/src/resources/License/License.ts
+++ b/src/resources/License/License.ts
@@ -10,6 +10,10 @@ export default class License extends Resource {
         return this.api.get<LicenseModel>(sectionName ? `${License.baseUrl}/${sectionName}` : License.baseUrl);
     }
 
+    full() {
+        return this.api.get<LicenseModel>(`${License.baseUrl}`);
+    }
+
     update(sectionName: LicenseSection, licenseSection: Record<string, number>) {
         return this.api.put<LicenseModel>(`${License.baseUrl}/${sectionName}`, licenseSection);
     }

--- a/src/resources/License/tests/License.spec.ts
+++ b/src/resources/License/tests/License.spec.ts
@@ -33,6 +33,14 @@ describe('License', () => {
         });
     });
 
+    describe('full', () => {
+        it('should make a GET call to the full License url', () => {
+            license.get(sectionName);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`/rest/organizations/{organizationName}/license`);
+        });
+    });
+
     describe('update', () => {
         it('should make a PUT call to the specific License url', () => {
             license.update(sectionName, {value: 100});

--- a/src/resources/License/tests/License.spec.ts
+++ b/src/resources/License/tests/License.spec.ts
@@ -35,7 +35,7 @@ describe('License', () => {
 
     describe('full', () => {
         it('should make a GET call to the full License url', () => {
-            license.get(sectionName);
+            license.full();
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`/rest/organizations/{organizationName}/license`);
         });


### PR DESCRIPTION
The client currently only expose retrieving a section of the license.

There's information that's only available globally, not part of a specific section (eg: the type of the license -- TRIAL, PRODUCTION etc.)

Also, the current `get` function for the License resource is wrong, since it does not actually return a `LicenseModel`, but only an arbitrary section of the full license.

I did not want to touch this as part of this PR though, as it would be a breaking change, and yeah ... 🤷 


https://coveord.atlassian.net/browse/CDX-68