### PR TITLE
feat(schema update): update schemaservice interface

### DIFF
--- a/src/resources/SchemaService/SchemaService.ts
+++ b/src/resources/SchemaService/SchemaService.ts
@@ -8,6 +8,7 @@ import {
     SchemaServiceSource,
     CreateSchemaSourceModel,
     CreateSchemaSourceOptions,
+    ObjectsToGet,
 } from './SchemaServiceInterfaces';
 import {SourceType} from '../Enums';
 
@@ -44,5 +45,26 @@ export default class SchemaService extends Ressource {
 
     create(source: New<CreateSchemaSourceModel, 'resourceId'>, options?: CreateSchemaSourceOptions) {
         return this.api.post<{id: string}>(this.buildPath(SchemaService.baseUrl, options), source);
+    }
+
+    translateToSpecificObjectsToGet(sourceType: SourceType, genericObjectsToGet: ObjectsToGet,parameters?: SchemaServiceQueryParams){
+        return this.api.post<any>(
+            this.buildPath(`${SchemaService.baseUrl}/${sourceType}/translate/specific`, parameters),
+            genericObjectsToGet,
+        );
+    }
+
+    translateToGenericObjectsToGet(sourceType: SourceType, specificObjectsToGet: any, parameters?: SchemaServiceQueryParams) {
+        return this.api.post<ObjectsToGet>(
+            this.buildPath(`${SchemaService.baseUrl}/${sourceType}/translate/generic`, parameters),
+            specificObjectsToGet,
+        );
+    }
+
+    translateToSpecificObjectsToGetWithFields(sourceType: SourceType, genericObjectsToGet: ObjectsToGet, parameters?: SchemaServiceQueryParams) {
+        return this.api.post<any>(
+            this.buildPath(`${SchemaService.baseUrl}/${sourceType}/translate/specificWithFields`, parameters),
+            genericObjectsToGet,
+        );
     }
 }

--- a/src/resources/SchemaService/SchemaService.ts
+++ b/src/resources/SchemaService/SchemaService.ts
@@ -9,6 +9,7 @@ import {
     CreateSchemaSourceModel,
     CreateSchemaSourceOptions,
     ObjectsToGet,
+    OffsetOrLimit,
 } from './SchemaServiceInterfaces';
 import {SourceType} from '../Enums';
 
@@ -25,7 +26,7 @@ export default class SchemaService extends Ressource {
         );
     }
 
-    getFields(sourceType: SourceType, entityName, parameters?: SchemaServiceQueryParams) {
+    getFields(sourceType: SourceType, entityName, parameters?: SchemaServiceQueryParams & OffsetOrLimit) {
         return this.api.get<SchemaFields>(
             this.buildPath(`${SchemaService.baseUrl}/${sourceType}/entity/${entityName}`, parameters)
         );
@@ -47,15 +48,8 @@ export default class SchemaService extends Ressource {
         return this.api.post<{id: string}>(this.buildPath(SchemaService.baseUrl, options), source);
     }
 
-    translateToSpecificObjectsToGet(
-        sourceType: SourceType,
-        genericObjectsToGet: ObjectsToGet,
-        parameters?: SchemaServiceQueryParams
-    ) {
-        return this.api.post<any>(
-            this.buildPath(`${SchemaService.baseUrl}/${sourceType}/translate/specific`, parameters),
-            genericObjectsToGet
-        );
+    translateToSpecificObjectsToGet(sourceType: SourceType, genericObjectsToGet: ObjectsToGet) {
+        return this.api.post<any>(`${SchemaService.baseUrl}/${sourceType}/translate/specific`, genericObjectsToGet);
     }
 
     translateToSpecificObjectsToGetWithFields(
@@ -69,13 +63,9 @@ export default class SchemaService extends Ressource {
         );
     }
 
-    translateToGenericObjectsToGet(
-        sourceType: SourceType,
-        specificObjectsToGet: any,
-        parameters?: SchemaServiceQueryParams
-    ) {
+    translateToGenericObjectsToGet(sourceType: SourceType, specificObjectsToGet: any) {
         return this.api.post<ObjectsToGet>(
-            this.buildPath(`${SchemaService.baseUrl}/${sourceType}/translate/generic`, parameters),
+            `${SchemaService.baseUrl}/${sourceType}/translate/generic`,
             specificObjectsToGet
         );
     }

--- a/src/resources/SchemaService/SchemaService.ts
+++ b/src/resources/SchemaService/SchemaService.ts
@@ -4,12 +4,12 @@ import {New} from '../BaseInterfaces';
 import {
     SchemaEntities,
     SchemaServiceQueryParams,
-    SchemaFields,
     SchemaServiceSource,
     CreateSchemaSourceModel,
     CreateSchemaSourceOptions,
     ObjectsToGet,
     OffsetOrLimit,
+    SchemaEntity,
 } from './SchemaServiceInterfaces';
 import {SourceType} from '../Enums';
 
@@ -20,14 +20,14 @@ export default class SchemaService extends Ressource {
         super(api, serverlessApi);
     }
 
-    getEntities(sourceType: SourceType, parameters?: SchemaServiceQueryParams) {
+    getEntities(sourceType: SourceType, parameters?: SchemaServiceQueryParams & OffsetOrLimit) {
         return this.api.get<SchemaEntities>(
             this.buildPath(`${SchemaService.baseUrl}/${sourceType}/entities`, parameters)
         );
     }
 
-    getFields(sourceType: SourceType, entityName, parameters?: SchemaServiceQueryParams & OffsetOrLimit) {
-        return this.api.get<SchemaFields>(
+    getFields(sourceType: SourceType, entityName, parameters?: SchemaServiceQueryParams) {
+        return this.api.get<SchemaEntity>(
             this.buildPath(`${SchemaService.baseUrl}/${sourceType}/entity/${entityName}`, parameters)
         );
     }

--- a/src/resources/SchemaService/SchemaService.ts
+++ b/src/resources/SchemaService/SchemaService.ts
@@ -47,24 +47,36 @@ export default class SchemaService extends Ressource {
         return this.api.post<{id: string}>(this.buildPath(SchemaService.baseUrl, options), source);
     }
 
-    translateToSpecificObjectsToGet(sourceType: SourceType, genericObjectsToGet: ObjectsToGet,parameters?: SchemaServiceQueryParams){
+    translateToSpecificObjectsToGet(
+        sourceType: SourceType,
+        genericObjectsToGet: ObjectsToGet,
+        parameters?: SchemaServiceQueryParams
+    ) {
         return this.api.post<any>(
             this.buildPath(`${SchemaService.baseUrl}/${sourceType}/translate/specific`, parameters),
-            genericObjectsToGet,
+            genericObjectsToGet
         );
     }
 
-    translateToGenericObjectsToGet(sourceType: SourceType, specificObjectsToGet: any, parameters?: SchemaServiceQueryParams) {
-        return this.api.post<ObjectsToGet>(
-            this.buildPath(`${SchemaService.baseUrl}/${sourceType}/translate/generic`, parameters),
-            specificObjectsToGet,
-        );
-    }
-
-    translateToSpecificObjectsToGetWithFields(sourceType: SourceType, genericObjectsToGet: ObjectsToGet, parameters?: SchemaServiceQueryParams) {
+    translateToSpecificObjectsToGetWithFields(
+        sourceType: SourceType,
+        genericObjectsToGet: ObjectsToGet,
+        parameters?: SchemaServiceQueryParams
+    ) {
         return this.api.post<any>(
             this.buildPath(`${SchemaService.baseUrl}/${sourceType}/translate/specificWithFields`, parameters),
-            genericObjectsToGet,
+            genericObjectsToGet
+        );
+    }
+
+    translateToGenericObjectsToGet(
+        sourceType: SourceType,
+        specificObjectsToGet: any,
+        parameters?: SchemaServiceQueryParams
+    ) {
+        return this.api.post<ObjectsToGet>(
+            this.buildPath(`${SchemaService.baseUrl}/${sourceType}/translate/generic`, parameters),
+            specificObjectsToGet
         );
     }
 }

--- a/src/resources/SchemaService/SchemaServiceInterfaces.ts
+++ b/src/resources/SchemaService/SchemaServiceInterfaces.ts
@@ -1,22 +1,20 @@
 import {SourceModel, CreateSourceModel, CreateSourceOptions} from '../Sources/SourcesInterfaces';
 
 export interface SchemaEntities {
-    entities?: SchemaEntity[];
+    entities: SchemaEntity[];
 }
 
 export interface SchemaEntity {
-    id?: string;
-}
-
-export interface SchemaFields {
     id: string;
-    fields: SchemaField[];
+    fields?: SchemaField[];
     recordCount?: number;
 }
 
+// look into renaming to SchemaEntityField
 export interface SchemaField {
-    id?: string;
-    type?: string;
+    id: string;
+    type: string;
+    reference?: string;
 }
 
 export interface SchemaServiceQueryParams {
@@ -33,35 +31,35 @@ export interface OffsetOrLimit {
     limit?: number;
 }
 
-export interface ObjectsToGetField {
+export interface GenericObjectField {
     name?: string;
 }
 
-export interface ObjectsToGetRelation {
+export interface GenericObjectRelation {
     name?: string;
     fields?: string[];
     fromField?: string;
     toField?: string;
     toObject?: string;
 }
-export interface ObjectsToGetCondition {
+export interface GenericObjectCondition {
     field?: string;
     operator?: string;
     type?: string;
     values?: string[];
 }
 
-export interface ObjectsToGetObject {
-    name: string;
-    conditions?: ObjectsToGetCondition[];
-    fields?: ObjectsToGetField[];
-    relations?: ObjectsToGetRelation[];
+export interface GenericObject {
+    name?: string;
+    conditions?: GenericObjectCondition[];
+    fields?: GenericObjectField[];
+    relations?: GenericObjectRelation[];
     attachment?: string;
     filter?: string;
 }
 
 export interface ObjectsToGet {
-    objects?: ObjectsToGetObject[];
+    objects?: GenericObject[];
 }
 
 export interface SchemaServiceSource extends SourceModel {

--- a/src/resources/SchemaService/SchemaServiceInterfaces.ts
+++ b/src/resources/SchemaService/SchemaServiceInterfaces.ts
@@ -26,6 +26,9 @@ export interface SchemaServiceQueryParams {
     clientId?: string;
     passwordGuid?: string;
     username?: string;
+}
+
+export interface OffsetOrLimit {
     offset?: number;
     limit?: number;
 }

--- a/src/resources/SchemaService/SchemaServiceInterfaces.ts
+++ b/src/resources/SchemaService/SchemaServiceInterfaces.ts
@@ -5,22 +5,18 @@ export interface SchemaEntities {
 }
 
 export interface SchemaEntity {
-    name?: string;
-    displayName?: string;
     id?: string;
 }
 
 export interface SchemaFields {
-    name?: string;
-    id?: string;
-    fields?: SchemaField[];
+    id: string;
+    fields: SchemaField[];
+    recordCount?: number;
 }
 
 export interface SchemaField {
-    name?: string;
     id?: string;
-    coveoType?: string;
-    reference?: string;
+    type?: string;
 }
 
 export interface SchemaServiceQueryParams {
@@ -30,6 +26,8 @@ export interface SchemaServiceQueryParams {
     clientId?: string;
     passwordGuid?: string;
     username?: string;
+    offset?: number;
+    limit?: number;
 }
 
 export interface ObjectsToGetField {
@@ -56,6 +54,7 @@ export interface ObjectsToGetObject {
     fields?: ObjectsToGetField[];
     relations?: ObjectsToGetRelation[];
     attachment?: string;
+    filter?: string;
 }
 
 export interface ObjectsToGet {

--- a/src/resources/SchemaService/test/SchemaService.spec.ts
+++ b/src/resources/SchemaService/test/SchemaService.spec.ts
@@ -19,6 +19,13 @@ describe('SchemaService', () => {
         clientSecretGuid: 'les',
         oauthRefreshTokenGuid: 'params',
     };
+    const genericObjectsToGet = {
+        objects: [
+            {
+                name: "I'm a good object",
+            },
+        ],
+    };
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -26,17 +33,17 @@ describe('SchemaService', () => {
     });
 
     describe('getEntities', () => {
-        it('should make a GET call to the specific SchemaService url with the good params', () => {
-            schemaService.getEntities(sourceType, params);
+        it('should make a GET call to the specific SchemaService url with the correct params', () => {
+            schemaService.getEntities(sourceType, {...params, offset: 100, limit: 100});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entities?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`
+                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entities?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}&offset=100&limit=100`
             );
         });
     });
 
     describe('getFields', () => {
-        it('should make a GET call to the specific SchemaService url with the good params', () => {
+        it('should make a GET call to the specific SchemaService url with the correct params', () => {
             const entityName = 'miaowouioui';
             schemaService.getFields(sourceType, entityName, params);
             expect(api.get).toHaveBeenCalledTimes(1);
@@ -84,6 +91,41 @@ describe('SchemaService', () => {
             schemaService.update(sourceId, sourceModel);
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(`${SchemaService.baseUrl}/${sourceId}`, sourceModel);
+        });
+    });
+
+    describe('translateToSpecificObjectsToGet', () => {
+        it('should make a POST call to the specific SchemaSources url', () => {
+            schemaService.translateToSpecificObjectsToGet(sourceType, genericObjectsToGet, params);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(
+                `${SchemaService.baseUrl}/${sourceType}/translate/specific?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`,
+                genericObjectsToGet
+            );
+        });
+    });
+
+    describe('translateToSpecificObjectsToGetWithFields', () => {
+        it('should make a POST call to the specific SchemaSources url', () => {
+            schemaService.translateToSpecificObjectsToGetWithFields(sourceType, genericObjectsToGet, params);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(
+                `${SchemaService.baseUrl}/${sourceType}/translate/specificWithFields?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`,
+                genericObjectsToGet
+            );
+        });
+    });
+
+    describe('translateToGenericObjectsToGet', () => {
+        it('should make a POST call to the specific SchemaSources url', () => {
+            schemaService.translateToGenericObjectsToGet(sourceType, {toTheMoon: '🚀'}, params);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(
+                api.post
+            ).toHaveBeenCalledWith(
+                `${SchemaService.baseUrl}/${sourceType}/translate/generic?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`,
+                {toTheMoon: '🚀'}
+            );
         });
     });
 });

--- a/src/resources/SchemaService/test/SchemaService.spec.ts
+++ b/src/resources/SchemaService/test/SchemaService.spec.ts
@@ -34,10 +34,10 @@ describe('SchemaService', () => {
 
     describe('getEntities', () => {
         it('should make a GET call to the specific SchemaService url with the correct params', () => {
-            schemaService.getEntities(sourceType, params);
+            schemaService.getEntities(sourceType, {...params, offset: 100, limit: 100});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entities?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`
+                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entities?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}&offset=100&limit=100`
             );
         });
     });
@@ -45,10 +45,10 @@ describe('SchemaService', () => {
     describe('getFields', () => {
         it('should make a GET call to the specific SchemaService url with the correct params', () => {
             const entityName = 'miaowouioui';
-            schemaService.getFields(sourceType, entityName, {...params, offset: 100, limit: 100});
+            schemaService.getFields(sourceType, entityName, params);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entity/${entityName}?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}&offset=100&limit=100`
+                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entity/${entityName}?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`
             );
         });
     });

--- a/src/resources/SchemaService/test/SchemaService.spec.ts
+++ b/src/resources/SchemaService/test/SchemaService.spec.ts
@@ -34,10 +34,10 @@ describe('SchemaService', () => {
 
     describe('getEntities', () => {
         it('should make a GET call to the specific SchemaService url with the correct params', () => {
-            schemaService.getEntities(sourceType, {...params, offset: 100, limit: 100});
+            schemaService.getEntities(sourceType, params);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entities?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}&offset=100&limit=100`
+                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entities?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`
             );
         });
     });
@@ -45,10 +45,10 @@ describe('SchemaService', () => {
     describe('getFields', () => {
         it('should make a GET call to the specific SchemaService url with the correct params', () => {
             const entityName = 'miaowouioui';
-            schemaService.getFields(sourceType, entityName, params);
+            schemaService.getFields(sourceType, entityName, {...params, offset: 100, limit: 100});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entity/${entityName}?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`
+                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entity/${entityName}?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}&offset=100&limit=100`
             );
         });
     });
@@ -96,10 +96,10 @@ describe('SchemaService', () => {
 
     describe('translateToSpecificObjectsToGet', () => {
         it('should make a POST call to the specific SchemaSources url', () => {
-            schemaService.translateToSpecificObjectsToGet(sourceType, genericObjectsToGet, params);
+            schemaService.translateToSpecificObjectsToGet(sourceType, genericObjectsToGet);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(
-                `${SchemaService.baseUrl}/${sourceType}/translate/specific?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`,
+                `${SchemaService.baseUrl}/${sourceType}/translate/specific`,
                 genericObjectsToGet
             );
         });
@@ -118,14 +118,11 @@ describe('SchemaService', () => {
 
     describe('translateToGenericObjectsToGet', () => {
         it('should make a POST call to the specific SchemaSources url', () => {
-            schemaService.translateToGenericObjectsToGet(sourceType, {toTheMoon: '🚀'}, params);
+            schemaService.translateToGenericObjectsToGet(sourceType, {toTheMoon: '🚀'});
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(
-                api.post
-            ).toHaveBeenCalledWith(
-                `${SchemaService.baseUrl}/${sourceType}/translate/generic?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`,
-                {toTheMoon: '🚀'}
-            );
+            expect(api.post).toHaveBeenCalledWith(`${SchemaService.baseUrl}/${sourceType}/translate/generic`, {
+                toTheMoon: '🚀',
+            });
         });
     });
 });


### PR DESCRIPTION
Updates to the Schema Service Interfaces to reflect changes to the Schema Service API (starting [here](https://github.com/coveo/schema-service/pull/434) and continuing through multiple PRs).
This PR contains the following changes : 
- support for 3 new routes: 
  - `/translate/specific` to translate a Generic Objects to Get to a source-specific one
  - `/translate/generic` to translate a source-specific Objects to Get to a generic one
  - `/translate/specificWithFields` to translate a Generic Objects to Get to a source-specific one with the Generic Objects to Get fields settings
- update `SchemaEntity`, `SchemaFields`, `SchemaField`, `SchemaServiceQueryParams` and `ObjectsToGetObject` interfaces to reflect changes to the API responses

SNOW-544