### PR TITLE
feat(catalog): product hierarchy is optional

### DIFF
--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -83,7 +83,7 @@ export interface CatalogModel extends BaseCatalogModel {
 export type CreateCatalogModel = BaseCatalogModel &
     (
         | {
-              product: CreateProductHierarchyModel;
+              product?: CreateProductHierarchyModel;
               variant?: CreateVariantHierarchyModel;
               availability?: CreateAvailabilityHierarchyModel;
               catalogConfigurationId?: never;


### PR DESCRIPTION
New `Edit Catalog` page will not be saving a product (objecttype/field) in the catalog model as it is moved to `Edit Configuration`.