### PR TITLE
feat: added new call for provider entity

### DIFF
--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -78,4 +78,11 @@ export default class SecurityCache extends Ressource {
     getProvider(providerId: string) {
         return this.api.get<SecurityProviderModelWithStatus>(`${SecurityCache.providersUrl}/${providerId}`);
     }
+
+    providerEntity(providerId: string, member: SecurityCacheMemberModel) {
+        return this.api.post<DetailedSecurityCacheMemberModel>(
+            `${SecurityCache.cacheUrl}/entities/${providerId}/entity`,
+            member
+        );
+    }
 }

--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -79,7 +79,7 @@ export default class SecurityCache extends Ressource {
         return this.api.get<SecurityProviderModelWithStatus>(`${SecurityCache.providersUrl}/${providerId}`);
     }
 
-    providerEntity(providerId: string, member: SecurityCacheMemberModel) {
+    getProviderEntity(providerId: string, member: SecurityCacheMemberModel) {
         return this.api.post<DetailedSecurityCacheMemberModel>(
             `${SecurityCache.cacheUrl}/entities/${providerId}/entity`,
             member

--- a/src/resources/SecurityCache/tests/SecurityCache.spec.ts
+++ b/src/resources/SecurityCache/tests/SecurityCache.spec.ts
@@ -146,8 +146,8 @@ describe('securityCache', () => {
         });
     });
 
-    describe('providerEntity', () => {
-        it('should make a POST call to the security Identity refresh url', () => {
+    describe('getProviderEntity', () => {
+        it('should make a POST call to the specified security provider member', () => {
             const member: SecurityCacheMemberModel = {
                 infos: [
                     {
@@ -160,7 +160,7 @@ describe('securityCache', () => {
                 type: PermissionIdentityType.Group,
             };
 
-            securityCache.providerEntity('🏀', member);
+            securityCache.getProviderEntity('🏀', member);
 
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${SecurityCache.cacheUrl}/entities/🏀/entity`, member);

--- a/src/resources/SecurityCache/tests/SecurityCache.spec.ts
+++ b/src/resources/SecurityCache/tests/SecurityCache.spec.ts
@@ -145,4 +145,25 @@ describe('securityCache', () => {
             expect(api.get).toHaveBeenCalledWith(`${SecurityCache.cacheUrl}/status`);
         });
     });
+
+    describe('providerEntity', () => {
+        it('should make a POST call to the security Identity refresh url', () => {
+            const member: SecurityCacheMemberModel = {
+                infos: [
+                    {
+                        key: '🥔',
+                        value: '👑',
+                    },
+                ],
+                name: '👌',
+                provider: '💰',
+                type: PermissionIdentityType.Group,
+            };
+
+            securityCache.providerEntity('🏀', member);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${SecurityCache.cacheUrl}/entities/🏀/entity`, member);
+        });
+    });
 });


### PR DESCRIPTION
I've added the new sec cache call [here](https://platformdev.cloud.coveo.com/docs/internal?urls.primaryName=SecurityCache#/Security%20Cache/rest_organizations_paramId_securitycache_entities_paramId_entity_post) 
