### PR TITLE
feat(sfint-3612): Expose "classify" and "documents/suggest" API calls to retrieve suggestions.

### DIFF
--- a/src/resources/CaseAssistConfigs/CaseAssistConfig.ts
+++ b/src/resources/CaseAssistConfigs/CaseAssistConfig.ts
@@ -1,12 +1,7 @@
 import API from '../../APICore';
 import {New, PageModel} from '../BaseInterfaces';
 import Resource from '../Resource';
-import {
-    CaseAssistConfigListOptions,
-    CaseAssistConfigModel,
-    ClassifyRequestBody,
-    DocumentsSuggestRequestBody,
-} from './CaseAssistConfigInterfaces';
+import {CaseAssistConfigListOptions, CaseAssistConfigModel, SuggestionRequestBody} from './CaseAssistConfigInterfaces';
 import {PreviewRequestBody, DocumentSuggestions, CaseClassifications} from './CaseAssistPreviewInterfaces';
 
 export default class CaseAssistConfig extends Resource {
@@ -37,11 +32,11 @@ export default class CaseAssistConfig extends Resource {
         );
     }
 
-    classify(caseAssistConfigId: string, body: ClassifyRequestBody) {
+    classify(caseAssistConfigId: string, body: SuggestionRequestBody) {
         return this.api.post<CaseClassifications>(`${CaseAssistConfig.baseUrl}/${caseAssistConfigId}/classify`, body);
     }
 
-    suggestDocuments(caseAssistConfigId: string, body: DocumentsSuggestRequestBody) {
+    suggestDocuments(caseAssistConfigId: string, body: SuggestionRequestBody) {
         return this.api.post<DocumentSuggestions>(
             `${CaseAssistConfig.baseUrl}/${caseAssistConfigId}/documents/suggest`,
             body

--- a/src/resources/CaseAssistConfigs/CaseAssistConfig.ts
+++ b/src/resources/CaseAssistConfigs/CaseAssistConfig.ts
@@ -1,7 +1,12 @@
 import API from '../../APICore';
 import {New, PageModel} from '../BaseInterfaces';
 import Resource from '../Resource';
-import {CaseAssistConfigListOptions, CaseAssistConfigModel} from './CaseAssistConfigInterfaces';
+import {
+    CaseAssistConfigListOptions,
+    CaseAssistConfigModel,
+    ClassifyRequestBody,
+    DocumentsSuggestRequestBody,
+} from './CaseAssistConfigInterfaces';
 import {PreviewRequestBody, DocumentSuggestions, CaseClassifications} from './CaseAssistPreviewInterfaces';
 
 export default class CaseAssistConfig extends Resource {
@@ -29,6 +34,17 @@ export default class CaseAssistConfig extends Resource {
         return this.api.put<CaseAssistConfigModel>(
             `${CaseAssistConfig.baseUrl}/${caseAssistConfig.id}`,
             caseAssistConfig
+        );
+    }
+
+    classify(caseAssistConfigId: string, body: ClassifyRequestBody) {
+        return this.api.post<CaseClassifications>(`${CaseAssistConfig.baseUrl}/${caseAssistConfigId}/classify`, body);
+    }
+
+    suggestDocuments(caseAssistConfigId: string, body: DocumentsSuggestRequestBody) {
+        return this.api.post<DocumentSuggestions>(
+            `${CaseAssistConfig.baseUrl}/${caseAssistConfigId}/documents/suggest`,
+            body
         );
     }
 

--- a/src/resources/CaseAssistConfigs/CaseAssistConfigInterfaces.ts
+++ b/src/resources/CaseAssistConfigs/CaseAssistConfigInterfaces.ts
@@ -59,17 +59,9 @@ export interface ContextField {
     value: string;
 }
 
-export interface ContextFields {
-    [key: string]: ContextField;
-}
+export type ContextFields = Record<string, ContextField>;
 
-export interface ClassifyRequestBody {
-    visitorId: string;
-    locale: string;
-    fields: ContextFields;
-}
-
-export interface DocumentsSuggestRequestBody {
+export interface SuggestionRequestBody {
     visitorId: string;
     locale: string;
     fields: ContextFields;

--- a/src/resources/CaseAssistConfigs/CaseAssistConfigInterfaces.ts
+++ b/src/resources/CaseAssistConfigs/CaseAssistConfigInterfaces.ts
@@ -54,3 +54,23 @@ export interface CaseAssistConfigModel {
     typingAidsConfiguration?: TypingAidsConfigurations;
     classificationConfigurations?: CaseClassificationConfiguration[];
 }
+
+export interface ContextField {
+    value: string;
+}
+
+export interface ContextFields {
+    [key: string]: ContextField;
+}
+
+export interface ClassifyRequestBody {
+    visitorId: string;
+    locale: string;
+    fields: ContextFields;
+}
+
+export interface DocumentsSuggestRequestBody {
+    visitorId: string;
+    locale: string;
+    fields: ContextFields;
+}

--- a/src/resources/CaseAssistConfigs/CaseAssistPreviewInterfaces.ts
+++ b/src/resources/CaseAssistConfigs/CaseAssistPreviewInterfaces.ts
@@ -1,5 +1,5 @@
 import {New} from '../BaseInterfaces';
-import {CaseAssistConfigModel} from './CaseAssistConfigInterfaces';
+import {CaseAssistConfigModel, ContextFields} from './CaseAssistConfigInterfaces';
 
 export interface Document {
     title: string;
@@ -22,14 +22,6 @@ export interface FieldValueSuggestion {
 
 export interface CaseClassifications {
     fields: Record<string, FieldValueSuggestion>;
-}
-
-export interface ContextField {
-    value: string;
-}
-
-export interface ContextFields {
-    [key: string]: ContextField;
 }
 
 export interface PreviewRequestBody {

--- a/src/resources/CaseAssistConfigs/tests/CaseAssistConfig.spec.ts
+++ b/src/resources/CaseAssistConfigs/tests/CaseAssistConfig.spec.ts
@@ -4,10 +4,9 @@ import CaseAssistConfig from '../CaseAssistConfig';
 import {
     CaseAssistConfigModel,
     CaseClassificationStrategies,
-    ClassifyRequestBody,
     ContextFields,
-    DocumentsSuggestRequestBody,
     DocumentSuggestionsStrategies,
+    SuggestionRequestBody,
     TypingAidsStrategies,
 } from '../CaseAssistConfigInterfaces';
 import {PreviewRequestBody} from '../CaseAssistPreviewInterfaces';
@@ -147,7 +146,7 @@ describe('CaseAssistConfig', () => {
     describe('classify', () => {
         it('should make a POST call to get classifications', () => {
             const testId = 'some config id';
-            const testBody: ClassifyRequestBody = {
+            const testBody: SuggestionRequestBody = {
                 visitorId: testVisitorId,
                 locale: testLocale,
                 fields: testContextFields,
@@ -163,7 +162,7 @@ describe('CaseAssistConfig', () => {
     describe('suggestDocuments', () => {
         it('should make a POST call to get document suggestions', () => {
             const testId = 'some config id';
-            const testBody: DocumentsSuggestRequestBody = {
+            const testBody: SuggestionRequestBody = {
                 visitorId: testVisitorId,
                 locale: testLocale,
                 fields: testContextFields,

--- a/src/resources/CaseAssistConfigs/tests/CaseAssistConfig.spec.ts
+++ b/src/resources/CaseAssistConfigs/tests/CaseAssistConfig.spec.ts
@@ -4,10 +4,13 @@ import CaseAssistConfig from '../CaseAssistConfig';
 import {
     CaseAssistConfigModel,
     CaseClassificationStrategies,
+    ClassifyRequestBody,
+    ContextFields,
+    DocumentsSuggestRequestBody,
     DocumentSuggestionsStrategies,
     TypingAidsStrategies,
 } from '../CaseAssistConfigInterfaces';
-import {ContextFields, PreviewRequestBody} from '../CaseAssistPreviewInterfaces';
+import {PreviewRequestBody} from '../CaseAssistPreviewInterfaces';
 
 jest.mock('../../../APICore');
 
@@ -138,6 +141,38 @@ describe('CaseAssistConfig', () => {
                     caseAssistModel
                 );
             });
+        });
+    });
+
+    describe('classify', () => {
+        it('should make a POST call to get classifications', () => {
+            const testId = 'some config id';
+            const testBody: ClassifyRequestBody = {
+                visitorId: testVisitorId,
+                locale: testLocale,
+                fields: testContextFields,
+            };
+
+            caseAssist.classify(testId, testBody);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${CaseAssistConfig.baseUrl}/${testId}/classify`, testBody);
+        });
+    });
+
+    describe('suggestDocuments', () => {
+        it('should make a POST call to get document suggestions', () => {
+            const testId = 'some config id';
+            const testBody: DocumentsSuggestRequestBody = {
+                visitorId: testVisitorId,
+                locale: testLocale,
+                fields: testContextFields,
+            };
+
+            caseAssist.suggestDocuments(testId, testBody);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${CaseAssistConfig.baseUrl}/${testId}/documents/suggest`, testBody);
         });
     });
 


### PR DESCRIPTION
This PR exposes the [/classify](https://platform.cloud.coveo.com/docs?urls.primaryName=Customer%20Service#/Suggestions/postClassify) and [documents/suggest](https://platform.cloud.coveo.com/docs?urls.primaryName=Customer%20Service#/Suggestions/getSuggestDocument) Case Assist API calls.

These calls are very similar to the preview ones, except they return suggestions for an existing Case Assist configuration.