### PR TITLE
fix(schema update)!: streamline schema interface

### DIFF
--- a/src/resources/SchemaService/SchemaService.ts
+++ b/src/resources/SchemaService/SchemaService.ts
@@ -26,9 +26,9 @@ export default class SchemaService extends Ressource {
         );
     }
 
-    getFields(sourceType: SourceType, entityName, parameters?: SchemaServiceQueryParams) {
+    getFields(sourceType: SourceType, entityId: string, parameters?: SchemaServiceQueryParams) {
         return this.api.get<SchemaEntity>(
-            this.buildPath(`${SchemaService.baseUrl}/${sourceType}/entity/${entityName}`, parameters)
+            this.buildPath(`${SchemaService.baseUrl}/${sourceType}/entity/${entityId}`, parameters)
         );
     }
 

--- a/src/resources/SchemaService/SchemaServiceInterfaces.ts
+++ b/src/resources/SchemaService/SchemaServiceInterfaces.ts
@@ -1,14 +1,17 @@
 import {SourceModel, CreateSourceModel, CreateSourceOptions} from '../Sources/SourcesInterfaces';
 
 export interface SchemaEntities {
-    entities: SchemaEntity[];
+    entities: SimpleSchemaEntity[];
 }
 
-export interface SchemaEntity {
-    displayName: string;
-    id: string;
+export interface SchemaEntity extends SimpleSchemaEntity {
     fields?: SchemaField[];
     recordCount?: number;
+}
+
+export interface SimpleSchemaEntity {
+    id: string;
+    displayName: string;
 }
 
 // look into renaming to SchemaEntityField


### PR DESCRIPTION
Added the `SimpleSchemaEntity` interface to differentiate an incomplete and a complete Entity
Switch param `entityName` for `entityId` in `getFields`
SNOW-554