### PR TITLE
build(release): add noteKeywords parser options

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,15 @@
+{
+    "plugins": [
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "parserOpts": {
+                    "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
+                }
+            }
+        ],
+        "@semantic-release/release-notes-generator",
+        "@semantic-release/npm",
+        "@semantic-release/github"
+    ]
+}


### PR DESCRIPTION
I merged this PR https://github.com/coveo/platform-client/pull/252, the build was green but the release was failed. It seems that `BREAKING CHANGES` should be `BREAKING CHANGE` in the commit message.
![image](https://user-images.githubusercontent.com/52677246/108890808-03af3100-75dc-11eb-9b84-80fa0a7ae6f4.png)

I tried to add `noteKeywords` to include `BREAKING CHANGES` by creating the file `.releaserc.json`.
https://github.com/semantic-release/commit-analyzer#usage
https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration-file

Also included default plugins `['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/npm', '@semantic-release/github']` to be safer. 
https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#plugins

Unfortunately, I'm not able to test this locally by running `npm run release`, since we don't have the permission to push on master and other branches are not acceptable by `.releaserc` file. Please let me know if there is any better solution, thanks!