### PR TITLE
feat(result-rankings): update resultRankings.list params/response types

### DIFF
--- a/src/resources/Pipelines/ResultRankings/ResultRankings.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankings.ts
@@ -51,6 +51,7 @@ export default class ResultRankings extends Resource {
             this.buildPath(ResultRankings.getBaseUrl(pipelineId), {
                 organizationId: this.api.organizationId,
                 ...params,
+                associatedGroups: JSON.stringify(params?.associatedGroups)
             })
         );
     }

--- a/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
@@ -89,8 +89,31 @@ export interface ResultRankingQplCodePredicate {
     code: string;
 }
 
+export interface ResultRankingGroupByStatementGroups {
+    associated: Record<string,number>
+    orphaned: number;
+}
+
+export interface ResultRankingGroupByStatus {
+    active: number;
+    inactive: number;
+}
+
+export interface ResultRankingGroupByTypes {
+    rankingExpressions: number;
+    featuredResults: number;
+}
+
+export interface ResultRankingGroupBy{
+    groups: ResultRankingGroupByStatementGroups;
+    status: ResultRankingGroupByStatus;
+    type: ResultRankingGroupByTypes;
+
+}
+
 export interface ListResultRankingResponse {
     resultRankings: ResultRanking[];
+    groupedBy: ResultRankingGroupBy;
     totalCount: number;
     totalPages: number;
 }
@@ -102,4 +125,6 @@ export interface ListResultRankingParams {
     page?: number;
     perPage?: number;
     organizationId?: string;
+    associatedGroups?: Array<string | null>;
+    kind?: ResultRankingsKind;
 }

--- a/src/resources/Pipelines/ResultRankings/tests/ResultRankings.spec.ts
+++ b/src/resources/Pipelines/ResultRankings/tests/ResultRankings.spec.ts
@@ -1,7 +1,7 @@
 import API from '../../../../APICore';
 import {PredicateKind, ResultRankingLocales, ResultRankingMatchOperators} from '../../../Enums';
 import ResultRankings from '../ResultRankings';
-import {ResultRanking} from '../ResultRankingsInterfaces';
+import {ListResultRankingParams, ResultRanking} from '../ResultRankingsInterfaces';
 
 jest.mock('../../../../APICore');
 
@@ -112,6 +112,30 @@ describe('Result Rankings', () => {
             resultRankings.list(pipelineId);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(ResultRankings.getBaseUrl(pipelineId));
+        });
+        it('should convert associated groups empty array to a JSON string', () => {
+            const pipelineId = '️a';
+            const associatedGroups = [];
+            const expectedUri =
+                ResultRankings.getBaseUrl(pipelineId) +
+                '?associatedGroups=' +
+                encodeURIComponent(JSON.stringify(associatedGroups));
+
+            resultRankings.list(pipelineId, {associatedGroups});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(expectedUri);
+        });
+        it('should convert associated groups array to a JSON string', () => {
+            const pipelineId = '️a';
+            const associatedGroups = [null, 'g1', 'g2'];
+            const expectedUri =
+                ResultRankings.getBaseUrl(pipelineId) +
+                '?associatedGroups=' +
+                encodeURIComponent(JSON.stringify(associatedGroups));
+
+            resultRankings.list(pipelineId, {associatedGroups});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(expectedUri);
         });
     });
 


### PR DESCRIPTION
Update resultRankings.list parameters to allow filtering by statement groups. Update
resultRanking.list response to type groupedBy informations.
https://coveord.atlassian.net/browse/SEARCHAPI-5679