### PR TITLE
feat(models): new method in Models class for updating Models

### DIFF
--- a/src/resources/MachineLearning/Models/Models.ts
+++ b/src/resources/MachineLearning/Models/Models.ts
@@ -1,5 +1,6 @@
 import API from '../../../APICore';
 import Resource from '../../Resource';
+import {RegistrationModel} from '../MachineLearningInterfaces';
 import {MLModelInfo} from '../ModelInformation/ModelInformationInterfaces';
 import {MLModel} from './ModelsInterfaces';
 
@@ -24,5 +25,9 @@ export default class Models extends Resource {
 
     delete(modelId: string) {
         return this.api.delete(`${Models.baseUrl}/${modelId}`);
+    }
+
+    update(modelId: string, update: RegistrationModel) {
+        return this.api.put<MLModel>(`${Models.baseUrl}/${modelId}`, update);
     }
 }

--- a/src/resources/MachineLearning/Models/tests/Models.spec.ts
+++ b/src/resources/MachineLearning/Models/tests/Models.spec.ts
@@ -1,4 +1,6 @@
 import API from '../../../../APICore';
+import {IntervalUnit} from '../../../Enums';
+import {RegistrationModel} from '../../MachineLearningInterfaces';
 import Models from '../Models';
 
 jest.mock('../../../../APICore');
@@ -58,6 +60,23 @@ describe('Models', () => {
             models.delete(modelId);
             expect(api.delete).toHaveBeenCalledTimes(1);
             expect(api.delete).toHaveBeenCalledWith(`${Models.baseUrl}/${modelId}`);
+        });
+    });
+
+    describe('update', () => {
+        it('should make a PUT call to the specific Models url', () => {
+            const modelId = 'O .O';
+            const registrationUpdate: RegistrationModel = {
+                engineId: 'OvO',
+                modelName: 'super model',
+                exportPeriod: 'ABC',
+                intervalTime: 666,
+                intervalUnit: IntervalUnit.DAY,
+            };
+
+            models.update(modelId, registrationUpdate);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${Models.baseUrl}/${modelId}`, registrationUpdate);
         });
     });
 });


### PR DESCRIPTION
New method uses same registration model interface that is documented under the [Platform API Swagger docs](https://platform.cloud.coveo.com/docs?urls.primaryName=Machine%20Learning#/Machine%20Learning%20Models/rest_organizations_paramId_machinelearning_models_paramId_put)