### PR TITLE
Feat snow 547 references otg interface

### DIFF
--- a/src/resources/SchemaService/SchemaService.ts
+++ b/src/resources/SchemaService/SchemaService.ts
@@ -69,4 +69,8 @@ export default class SchemaService extends Ressource {
             specificObjectsToGet
         );
     }
+
+    getDefaultObjectsToGet(sourceType: string) {
+        return this.api.get<ObjectsToGet>(`${SchemaService.baseUrl}/${sourceType}/defaultObjectsToGet`);
+    }
 }

--- a/src/resources/SchemaService/test/SchemaService.spec.ts
+++ b/src/resources/SchemaService/test/SchemaService.spec.ts
@@ -125,4 +125,12 @@ describe('SchemaService', () => {
             });
         });
     });
+
+    describe('getDefaultObjectsToGet', () => {
+        it('should make a GET call to the specific SchemaSources url', () => {
+            schemaService.getDefaultObjectsToGet(sourceType);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${SchemaService.baseUrl}/${sourceType}/defaultObjectsToGet`);
+        });
+    });
 });


### PR DESCRIPTION
Add `/defaultObjectsToGet` route in `SchemaService` interface. It retrieves the default Objects to Get configuration for a given source type

THIS PR is needed for [THIS PR in admin-ui](https://github.com/coveo/admin-ui/pull/1935)