### PR TITLE
fix(query pipelines): remove legacy url

### DIFF
--- a/src/resources/Pipelines/Statements/Statements.ts
+++ b/src/resources/Pipelines/Statements/Statements.ts
@@ -12,7 +12,6 @@ import {
 
 export default class Statements extends Resource {
     static getBaseUrl = (pipelineId: string) => `/rest/search/v2/admin/pipelines/${pipelineId}/statements`;
-    static getLegacyUrl = (pipelineId: string) => `/rest/search/admin/pipelines/${pipelineId}/statements`;
     static getStatementUrl = (pipelineId: string, statementId: string) =>
         `${Statements.getBaseUrl(pipelineId)}/${statementId}`;
 
@@ -37,7 +36,7 @@ export default class Statements extends Resource {
         formData.append('file', csvFile, fileName);
 
         return this.api.postForm(
-            this.buildPath(`${Statements.getLegacyUrl(pipelineId)}/import`, {
+            this.buildPath(`${Statements.getBaseUrl(pipelineId)}/import`, {
                 mode: 'overwrite',
                 organizationId: this.api.organizationId,
                 ...options,

--- a/src/resources/Pipelines/Statements/tests/Statements.spec.ts
+++ b/src/resources/Pipelines/Statements/tests/Statements.spec.ts
@@ -147,7 +147,7 @@ describe('Statements', () => {
 
             expect(api.postForm).toHaveBeenCalledTimes(1);
             expect(api.postForm).toHaveBeenCalledWith(
-                '/rest/search/admin/pipelines/🥚/statements/import?mode=overwrite&feature=stop',
+                '/rest/search/v2/admin/pipelines/🥚/statements/import?mode=overwrite&feature=stop',
                 mockedFormData
             );
             expect(mockedFormData.append).toHaveBeenCalledTimes(1);
@@ -161,7 +161,7 @@ describe('Statements', () => {
 
             expect(api.postForm).toHaveBeenCalledTimes(1);
             expect(api.postForm).toHaveBeenCalledWith(
-                '/rest/search/admin/pipelines/🥚/statements/import?mode=overwrite&feature=thesaurus',
+                '/rest/search/v2/admin/pipelines/🥚/statements/import?mode=overwrite&feature=thesaurus',
                 mockedFormData
             );
             expect(mockedFormData.append).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
I removed the legacy URL from a call in the search API as requested by David Reisch 