### PR TITLE
feat(statements.ts): support for raw string form data in importCSV

### DIFF
--- a/src/resources/Pipelines/Statements/Statements.ts
+++ b/src/resources/Pipelines/Statements/Statements.ts
@@ -31,9 +31,11 @@ export default class Statements extends Resource {
         );
     }
 
-    importCSV(pipelineId: string, csvFile: File, options?: ExportStatementParams) {
+    importCSV(pipelineId: string, csvFile: File | string, options?: ExportStatementParams) {
+        const fileName = typeof csvFile === 'string' ? 'raw-string' : csvFile.name;
         const formData = getFormData();
-        formData.append('file', csvFile);
+        formData.append('file', csvFile, fileName);
+
         return this.api.postForm(
             this.buildPath(`${Statements.getLegacyUrl(pipelineId)}/import`, {
                 mode: 'overwrite',

--- a/src/resources/Pipelines/Statements/tests/Statements.spec.ts
+++ b/src/resources/Pipelines/Statements/tests/Statements.spec.ts
@@ -151,7 +151,21 @@ describe('Statements', () => {
                 mockedFormData
             );
             expect(mockedFormData.append).toHaveBeenCalledTimes(1);
-            expect(mockedFormData.append).toHaveBeenCalledWith('file', myCSVFile);
+            expect(mockedFormData.append).toHaveBeenCalledWith('file', myCSVFile, myCSVFile.name);
+        });
+
+        it('should post the string content inside a form multi part data', async () => {
+            const content = `definition,condition,description,feature\n"alias ""CPU"", ""processor""",,Tech thesaurus,thesaurus\n"alias ""Television"", ""Televisions"", ""TV"", ""TVs""",,Basic thesaurus,thesaurus`;
+
+            statements.importCSV('🥚', content, {feature: StatementsFeature.Thesaurus});
+
+            expect(api.postForm).toHaveBeenCalledTimes(1);
+            expect(api.postForm).toHaveBeenCalledWith(
+                '/rest/search/admin/pipelines/🥚/statements/import?mode=overwrite&feature=thesaurus',
+                mockedFormData
+            );
+            expect(mockedFormData.append).toHaveBeenCalledTimes(1);
+            expect(mockedFormData.append).toHaveBeenCalledWith('file', content, 'raw-string');
         });
     });
 });


### PR DESCRIPTION
Strings can now be passed to the importCSV method on Statements. FormData supports the use of File
and string references, however the Coveo API requires a file name be set. This change provides a
file name in the case of string arguments.



**Background**: This resolves an issue I came across where not including the file name in the `multipart/form-data` request would cause the Coveo API to error with a 400. The client can immediately cover this case by providing a file name for CSV imports.