### PR TITLE
feat(apicore): configurable fetch requests in APICore

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,35 @@ coveoPlatform.source
     });
 ```
 
+### Global Configuration
+
+It is also possible to provide global request settings for all requests made by the client; Simply provide the configuration in the `globalRequestSettings` property of the options. This can be useful for applying necessary headers or configurations for network requests. For example, you might include a proxy authorization header for requests routed through a proxy server using the [`Proxy-Authorization` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authorization):
+
+#### Node.js example
+
+```js
+require('isomorphic-fetch');
+require('abortcontroller-polyfill');
+const PlatformClient = require('@coveord/platform-client').default;
+
+const coveoPlatform = new PlatformClient({
+    globalRequestSettings: {
+        headers: {
+            'Proxy-Authorization': 'Basic YWxhZGRpbjpvcGVuc2VzYW1l',
+        },
+    },
+});
+
+coveoPlatform.source
+    .list()
+    .then((res) => {
+        console.log(JSON.stringify(res));
+    })
+    .catch((e) => {
+        console.error(e);
+    });
+```
+
 ## Documentation
 
 This project is built using TypeScript and automatically generates relevant type declarations. Most IDEs with TypeScript integration will display those type declarations as autocompletions, so that you typically will not need to refer to external documentation. Hence, the decision has been made not to document any option, resource, or action, except for the main configuration options. For in-depth documentation on the APIs exposed by this package, please consult our [official documentation portal](https://docs.coveo.com/en/151/cloud-v2-developers/coveo-cloud-v2-for-developers).

--- a/src/APICore.ts
+++ b/src/APICore.ts
@@ -122,15 +122,21 @@ export default class API {
         return retrieve(this.config.accessToken);
     }
 
+    private get globalRequestSettings(): RequestInit {
+        return this.config.globalRequestSettings || {};
+    }
+
     private getUrlFromRoute(route: string): string {
         return `${this.endpoint}${route}`.replace(API.orgPlaceholder, this.organizationId);
     }
 
     private async request<T>(route: string, args: RequestInit): Promise<T> {
         const init: RequestInit = {
+            ...this.globalRequestSettings,
             ...args,
             headers: {
                 Authorization: `Bearer ${this.accessToken}`,
+                ...(this.globalRequestSettings.headers || {}),
                 ...(args.headers || {}),
             },
         };
@@ -149,9 +155,11 @@ export default class API {
 
     private async requestFile(route: string, args: RequestInit): Promise<Blob> {
         const init: RequestInit = {
+            ...this.globalRequestSettings,
             ...args,
             headers: {
                 Authorization: `Bearer ${this.accessToken}`,
+                ...(this.globalRequestSettings.headers || {}),
                 ...(args.headers || {}),
             },
         };

--- a/src/ConfigurationInterfaces.ts
+++ b/src/ConfigurationInterfaces.ts
@@ -11,4 +11,5 @@ export interface PlatformClientOptions {
     environment?: Environment;
     region?: Region;
     responseHandlers?: ResponseHandler[];
+    globalRequestSettings?: RequestInit;
 }


### PR DESCRIPTION
PlatformClientOptions includes new optional property for fetch request configuration (RequestInit)
to allow various features such as global headers and HTTP(S) proxy agents