### PR TITLE
fix(securityprovider): corrected cascading security provider interface

### DIFF
--- a/src/resources/SecurityCache/SecurityCacheInterfaces.ts
+++ b/src/resources/SecurityCache/SecurityCacheInterfaces.ts
@@ -28,7 +28,7 @@ export interface SecurityCacheIdentityModel {
 }
 
 export interface SecurityProviderModel {
-    cascadingSecurityProviders?: CascadingSecurityProvider;
+    cascadingSecurityProviders?: Record<string, CascadingSecurityProvider>;
     caseSensitive?: boolean;
     crawlingModuleId?: string;
     displayName?: string;


### PR DESCRIPTION
The SecurityProviderModel interface has been updated to match the OpenAPI definition.

The expected interface can be seen in the Coveo docs [here](https://docs.coveo.com/en/14/cloud-v2-api-reference/security-cache-api#operation/createOrUpdateSecurityProviderUsingPUT_2).

BREAKING CHANGE: Updated the cascadingSecurityProviders property on SecurityProviderModel