### PR TITLE
feat(pushapi): added Security Identity management to push API resource

### DIFF
--- a/src/resources/PlatformResources.ts
+++ b/src/resources/PlatformResources.ts
@@ -31,6 +31,7 @@ import UsageAnalytics from './UsageAnalytics/UsageAnalytics';
 import User from './Users/User';
 import Links from './Links/Links';
 import Connectivity from './Connectivity/Connectivity';
+import PushApi from './PushApi/PushApi';
 
 const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'apiKey', resource: ApiKey},
@@ -54,6 +55,7 @@ const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'logs', resource: Logs},
     {key: 'organization', resource: Organization},
     {key: 'pipeline', resource: Pipelines},
+    {key: 'pushApi', resource: PushApi},
     {key: 'resourceSnapshot', resource: ResourceSnapshots},
     {key: 'saml', resource: Saml},
     {key: 'schemaService', resource: SchemaService},
@@ -91,6 +93,7 @@ class PlatformResources {
     logs: Logs;
     organization: Organization;
     pipeline: Pipelines;
+    pushApi: PushApi;
     resourceSnapshot: ResourceSnapshots;
     saml: Saml;
     schemaService: SchemaService;

--- a/src/resources/PushApi/PushApi.ts
+++ b/src/resources/PushApi/PushApi.ts
@@ -1,0 +1,63 @@
+import API from '../../APICore';
+import Resource from '../Resource';
+import {
+    SecurityIdentityAliasModel,
+    SecurityIdentityBatchConfig,
+    SecurityIdentityDelete,
+    SecurityIdentityDeleteOptions,
+    SecurityIdentityModel,
+    SecurityIdentityOptions,
+} from './PushApiInterfaces';
+
+export default class PushApi extends Resource {
+    static baseUrl = `/push/v1/organizations/${API.orgPlaceholder}/providers`;
+
+    createOrUpdateSecurityIdentityAlias(
+        securityProviderId: string,
+        alias: SecurityIdentityAliasModel,
+        options?: SecurityIdentityOptions
+    ) {
+        return this.serverlessApi.put<void>(
+            this.buildPath(`${PushApi.baseUrl}/${securityProviderId}/mappings`, options),
+            alias
+        );
+    }
+
+    deleteSecurityIdentity(
+        securityProviderId: string,
+        securityIdentity: SecurityIdentityDelete,
+        options?: SecurityIdentityOptions
+    ) {
+        return this.serverlessApi.delete<void>(
+            this.buildPath(`${PushApi.baseUrl}/${securityProviderId}/permissions`, options),
+            {
+                method: 'delete',
+                body: JSON.stringify(securityIdentity),
+                headers: {'Content-Type': 'application/json'},
+            }
+        );
+    }
+
+    createOrUpdateSecurityIdentity(
+        securityProviderId: string,
+        securityIdentity: SecurityIdentityModel,
+        options?: SecurityIdentityOptions
+    ) {
+        return this.serverlessApi.put<void>(
+            this.buildPath(`${PushApi.baseUrl}/${securityProviderId}/permissions`, options),
+            securityIdentity
+        );
+    }
+
+    manageSecurityIdentities(securityProviderId: string, batchConfig: SecurityIdentityBatchConfig) {
+        return this.serverlessApi.put<void>(
+            this.buildPath(`${PushApi.baseUrl}/${securityProviderId}/permissions/batch`, batchConfig)
+        );
+    }
+
+    deleteOldSecurityIdentities(securityProviderId: string, batchDelete: SecurityIdentityDeleteOptions) {
+        return this.serverlessApi.delete<void>(
+            this.buildPath(`${PushApi.baseUrl}/${securityProviderId}/permissions/olderthan`, batchDelete)
+        );
+    }
+}

--- a/src/resources/PushApi/PushApiInterfaces.ts
+++ b/src/resources/PushApi/PushApiInterfaces.ts
@@ -1,0 +1,45 @@
+import {SinglePermissionResult, SinglePermissionIdentityType} from '../Enums';
+
+export interface SecurityIdentityAliasModel extends SecurityIdentityBase {
+    mappings: AliasMappings;
+}
+
+export interface SecurityIdentityModel extends SecurityIdentityBase {
+    members?: Identity[];
+}
+
+export interface SecurityIdentityDelete {
+    identity: Identity;
+}
+
+export interface SecurityIdentityDeleteOptions extends Required<SecurityIdentityOptions> {
+    queueDelay?: number;
+}
+
+export interface SecurityIdentityOptions {
+    orderingId?: number;
+}
+
+export interface SecurityIdentityBatchConfig {
+    fileId: string;
+    orderingId?: string;
+}
+
+interface SecurityIdentityBase {
+    Result?: {
+        errorDetails: string;
+        result: SinglePermissionResult;
+    };
+    identity?: Identity;
+    wellKnowns?: Identity[];
+}
+
+interface AliasMappings extends Identity {
+    provider: string;
+}
+
+interface Identity {
+    additionalInfo: Record<string, string>;
+    name: string;
+    type: SinglePermissionIdentityType;
+}

--- a/src/resources/PushApi/index.ts
+++ b/src/resources/PushApi/index.ts
@@ -1,0 +1,2 @@
+export * from './PushApi';
+export * from './PushApiInterfaces';

--- a/src/resources/PushApi/tests/PushApi.spec.ts
+++ b/src/resources/PushApi/tests/PushApi.spec.ts
@@ -1,0 +1,123 @@
+import API from '../../../APICore';
+import {SinglePermissionIdentityType} from '../../Enums';
+import PushApi from '../PushApi';
+import {SecurityIdentityAliasModel, SecurityIdentityOptions} from '../PushApiInterfaces';
+
+jest.mock('../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe(PushApi.name, () => {
+    let pushApi: PushApi;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+    const securityProviderId = 'testId';
+    const securityProviderOptions: SecurityIdentityOptions = {orderingId: 1506700606240};
+    const securityProviderAlias: SecurityIdentityAliasModel = {
+        mappings: {
+            additionalInfo: {},
+            name: 'MyAlias',
+            provider: 'Provider',
+            type: SinglePermissionIdentityType.GROUP,
+        },
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        pushApi = new PushApi(api, serverlessApi);
+    });
+
+    describe('Security Identity', () => {
+        describe('createOrUpdateSecurityIdentityAlias', () => {
+            test.each([
+                [`/push/v1/organizations/{organizationName}/providers/${securityProviderId}/mappings`, undefined],
+                [
+                    `/push/v1/organizations/{organizationName}/providers/${securityProviderId}/mappings?orderingId=1506700606240`,
+                    securityProviderOptions,
+                ],
+            ])('should make a PUT call to "%s"', (url, options) => {
+                pushApi.createOrUpdateSecurityIdentityAlias(securityProviderId, securityProviderAlias, options);
+                expect(serverlessApi.put).toHaveBeenCalledTimes(1);
+                expect(serverlessApi.put).toHaveBeenCalledWith(url, {
+                    mappings: {additionalInfo: {}, name: 'MyAlias', provider: 'Provider', type: 'GROUP'},
+                });
+            });
+        });
+
+        describe('deleteSecurityIdentity', () => {
+            test.each([
+                [`/push/v1/organizations/{organizationName}/providers/${securityProviderId}/permissions`, undefined],
+                [
+                    `/push/v1/organizations/{organizationName}/providers/${securityProviderId}/permissions?orderingId=1506700606240`,
+                    securityProviderOptions,
+                ],
+            ])('should make a DELETE call to "%s"', (url, options) => {
+                pushApi.deleteSecurityIdentity(
+                    securityProviderId,
+                    {
+                        identity: {
+                            name: 'Test Identity',
+                            additionalInfo: {},
+                            type: SinglePermissionIdentityType.GROUP,
+                        },
+                    },
+                    options
+                );
+
+                expect(serverlessApi.delete).toHaveBeenCalledTimes(1);
+                expect(serverlessApi.delete).toHaveBeenCalledWith(url, {
+                    body: '{"identity":{"name":"Test Identity","additionalInfo":{},"type":"GROUP"}}',
+                    headers: {'Content-Type': 'application/json'},
+                    method: 'delete',
+                });
+            });
+        });
+
+        describe('createOrUpdateSecurityIdentity', () => {
+            test.each([
+                [`/push/v1/organizations/{organizationName}/providers/${securityProviderId}/permissions`, undefined],
+                [
+                    `/push/v1/organizations/{organizationName}/providers/${securityProviderId}/permissions?orderingId=1506700606240`,
+                    securityProviderOptions,
+                ],
+            ])('should make a PUT call to "%s"', (url, options) => {
+                pushApi.createOrUpdateSecurityIdentity(
+                    securityProviderId,
+                    {
+                        identity: {
+                            name: 'Test Identity',
+                            additionalInfo: {},
+                            type: SinglePermissionIdentityType.GROUP,
+                        },
+                    },
+                    options
+                );
+
+                expect(serverlessApi.put).toHaveBeenCalledTimes(1);
+                expect(serverlessApi.put).toHaveBeenCalledWith(url, {
+                    identity: {additionalInfo: {}, name: 'Test Identity', type: 'GROUP'},
+                });
+            });
+        });
+
+        describe('manageSecurityIdentities', () => {
+            it('should make a PUT call to "/push/v1/organizations/{organizationName}/providers/{securityProviderId}/permissions/batch', () => {
+                pushApi.manageSecurityIdentities(securityProviderId, {fileId: 'testId'});
+                expect(serverlessApi.put).toHaveBeenCalledTimes(1);
+                expect(serverlessApi.put).toHaveBeenCalledWith(
+                    `/push/v1/organizations/{organizationName}/providers/${securityProviderId}/permissions/batch?fileId=testId`
+                );
+            });
+        });
+
+        describe('deleteOldSecurityIdentities', () => {
+            it('should make a DELETE call to "/push/v1/organizations/{organizationName}/providers/{securityProviderId}/permissions/olderthan', () => {
+                pushApi.deleteOldSecurityIdentities(securityProviderId, {orderingId: 123456789});
+                expect(serverlessApi.delete).toHaveBeenCalledTimes(1);
+                expect(serverlessApi.delete).toHaveBeenCalledWith(
+                    `/push/v1/organizations/{organizationName}/providers/${securityProviderId}/permissions/olderthan?orderingId=123456789`
+                );
+            });
+        });
+    });
+});


### PR DESCRIPTION
Added the push API resource based on [Coveo docs](https://docs.coveo.com/en/12/cloud-v2-api-reference/push-api). This only includes Security Identity support for now.