### PR TITLE
feat(searchpages): support for headers (css/js) operations

### DIFF
--- a/src/resources/SearchPages/SearchPages.ts
+++ b/src/resources/SearchPages/SearchPages.ts
@@ -7,6 +7,10 @@ import {
     UpdateSearchPageModel,
     SearchPageVersionModel,
     MajorMinorVersion,
+    SearchPageHeadersModel,
+    ReorderSearchPageHeadersModel,
+    JavaScriptResourceModel,
+    CSSResourceModel,
 } from './SearchPagesInterfaces';
 
 export default class SearchPages extends Resource {
@@ -38,5 +42,43 @@ export default class SearchPages extends Resource {
 
     updateVersion(pageId: string, version: MajorMinorVersion) {
         return this.api.put(this.buildPath(`${SearchPages.baseUrl}/${pageId}/searchui`, version));
+    }
+
+    getHeaders(pageId: string) {
+        return this.api.get<SearchPageHeadersModel>(`${SearchPages.baseUrl}/${pageId}/header`);
+    }
+
+    reorderHeaders(pageId: string, resources: ReorderSearchPageHeadersModel) {
+        return this.api.put<SearchPageHeadersModel>(`${SearchPages.baseUrl}/${pageId}/header`, resources);
+    }
+
+    createCssResource(pageId: string, resource: CSSResourceModel) {
+        return this.api.post<SearchPageHeadersModel>(`${SearchPages.baseUrl}/${pageId}/header/css`, resource);
+    }
+
+    updateCssResource(pageId: string, resourceName: string, resource: CSSResourceModel) {
+        return this.api.put<SearchPageHeadersModel>(
+            `${SearchPages.baseUrl}/${pageId}/header/css/${resourceName}`,
+            resource
+        );
+    }
+
+    deleteCssResource(pageId: string, resourceName: string) {
+        return this.api.delete(`${SearchPages.baseUrl}/${pageId}/header/css/${resourceName}`);
+    }
+
+    createJsResource(pageId: string, resource: JavaScriptResourceModel) {
+        return this.api.post<SearchPageHeadersModel>(`${SearchPages.baseUrl}/${pageId}/header/javascript`, resource);
+    }
+
+    updateJsResource(pageId: string, resourceName: string, resource: JavaScriptResourceModel) {
+        return this.api.put<SearchPageHeadersModel>(
+            `${SearchPages.baseUrl}/${pageId}/header/javascript/${resourceName}`,
+            resource
+        );
+    }
+
+    deleteJsResource(pageId: string, resourceName: string) {
+        return this.api.delete(`${SearchPages.baseUrl}/${pageId}/header/javascript/${resourceName}`);
     }
 }

--- a/src/resources/SearchPages/SearchPagesInterfaces.ts
+++ b/src/resources/SearchPages/SearchPagesInterfaces.ts
@@ -48,3 +48,7 @@ export interface MajorMinorVersion {
     major: string;
     minor: string;
 }
+
+export type SearchPageHeadersModel = Pick<SearchPageModel, 'css' | 'javascript'>;
+
+export type ReorderSearchPageHeadersModel = Record<'css' | 'javascript', string[]>;

--- a/src/resources/SearchPages/tests/SearchPages.spec.ts
+++ b/src/resources/SearchPages/tests/SearchPages.spec.ts
@@ -1,6 +1,13 @@
 import API from '../../../APICore';
 import SearchPages from '../SearchPages';
-import {CreateSearchPageModel, UpdateSearchPageModel, MajorMinorVersion} from '../SearchPagesInterfaces';
+import {
+    CreateSearchPageModel,
+    UpdateSearchPageModel,
+    MajorMinorVersion,
+    CSSResourceModel,
+    ReorderSearchPageHeadersModel,
+    JavaScriptResourceModel,
+} from '../SearchPagesInterfaces';
 
 jest.mock('../../../APICore');
 
@@ -85,6 +92,129 @@ describe('SearchPages', () => {
             expect(api.put).toHaveBeenCalledWith(
                 `${SearchPages.baseUrl}/${searchPageId}/searchui?major=${versionOptions.major}&minor=${versionOptions.minor}`
             );
+        });
+    });
+
+    describe('headers', () => {
+        const searchPageId = '00000000-0000-0000-0000-000000000000';
+        describe('all', () => {
+            describe('get', () => {
+                it('should make a GET call to the specific Search Pages headers url', () => {
+                    searchPageService.getHeaders(searchPageId);
+                    expect(api.get).toHaveBeenCalledTimes(1);
+                    expect(api.get).toHaveBeenCalledWith(`${SearchPages.baseUrl}/${searchPageId}/header`);
+                });
+            });
+
+            describe('reorder', () => {
+                it('should make a PUT call to the specific Search Pages headers url', () => {
+                    const reorderHeaderModel: ReorderSearchPageHeadersModel = {
+                        css: ['👾', '🧟', '🤡'],
+                        javascript: ['👻', '💀', '👽'],
+                    };
+
+                    searchPageService.reorderHeaders(searchPageId, reorderHeaderModel);
+                    expect(api.put).toHaveBeenCalledTimes(1);
+                    expect(api.put).toHaveBeenCalledWith(
+                        `${SearchPages.baseUrl}/${searchPageId}/header`,
+                        reorderHeaderModel
+                    );
+                });
+            });
+        });
+        describe('css', () => {
+            describe('create', () => {
+                it('should make a POST call to the Search Pages CSS resource url', () => {
+                    const cssResourceModel: CSSResourceModel = {
+                        inlineContent: 'body { color: #e0e0e0; background-color: #2a2aa2; }',
+                        name: '👹',
+                        url: 'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css',
+                    };
+
+                    searchPageService.createCssResource(searchPageId, cssResourceModel);
+                    expect(api.post).toHaveBeenCalledTimes(1);
+                    expect(api.post).toHaveBeenCalledWith(
+                        `${SearchPages.baseUrl}/${searchPageId}/header/css`,
+                        cssResourceModel
+                    );
+                });
+            });
+
+            describe('delete', () => {
+                it('should make a DELETE call to the specific Search Pages CSS resource url', () => {
+                    const resourceName = '👹';
+                    searchPageService.deleteCssResource(searchPageId, resourceName);
+                    expect(api.delete).toHaveBeenCalledTimes(1);
+                    expect(api.delete).toHaveBeenCalledWith(
+                        `${SearchPages.baseUrl}/${searchPageId}/header/css/${resourceName}`
+                    );
+                });
+            });
+
+            describe('update', () => {
+                it('should make a PUT call to the specific Search Pages CSS resource url', () => {
+                    const resourceName = '👹';
+                    const cssResourceModel: CSSResourceModel = {
+                        inlineContent: 'body { color: #e0e0e0; background-color: #2a2aa2; }',
+                        name: resourceName,
+                        url: 'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css',
+                    };
+
+                    searchPageService.updateCssResource(searchPageId, resourceName, cssResourceModel);
+                    expect(api.put).toHaveBeenCalledTimes(1);
+                    expect(api.put).toHaveBeenCalledWith(
+                        `${SearchPages.baseUrl}/${searchPageId}/header/css/${resourceName}`,
+                        cssResourceModel
+                    );
+                });
+            });
+        });
+        describe('javascript', () => {
+            describe('create', () => {
+                it('should make a POST call to the Search Pages JS resource url', () => {
+                    const jsResourceModel: JavaScriptResourceModel = {
+                        inlineContent: "window.location = 'about:blank';",
+                        name: '👺',
+                        url: 'https://code.jquery.com/jquery-3.4.1.min.js',
+                    };
+
+                    searchPageService.createJsResource(searchPageId, jsResourceModel);
+                    expect(api.post).toHaveBeenCalledTimes(1);
+                    expect(api.post).toHaveBeenCalledWith(
+                        `${SearchPages.baseUrl}/${searchPageId}/header/javascript`,
+                        jsResourceModel
+                    );
+                });
+            });
+
+            describe('delete', () => {
+                it('should make a DELETE call to the specific Search Pages JS resource url', () => {
+                    const resourceName = '👺';
+                    searchPageService.deleteJsResource(searchPageId, resourceName);
+                    expect(api.delete).toHaveBeenCalledTimes(1);
+                    expect(api.delete).toHaveBeenCalledWith(
+                        `${SearchPages.baseUrl}/${searchPageId}/header/javascript/${resourceName}`
+                    );
+                });
+            });
+
+            describe('update', () => {
+                it('should make a PUT call to the specific Search Pages JS resource url', () => {
+                    const resourceName = '👺';
+                    const jsResourceModel: JavaScriptResourceModel = {
+                        inlineContent: "window.location = 'about:blank';",
+                        name: '👺',
+                        url: 'https://code.jquery.com/jquery-3.4.1.min.js',
+                    };
+
+                    searchPageService.updateJsResource(searchPageId, resourceName, jsResourceModel);
+                    expect(api.put).toHaveBeenCalledTimes(1);
+                    expect(api.put).toHaveBeenCalledWith(
+                        `${SearchPages.baseUrl}/${searchPageId}/header/javascript/${resourceName}`,
+                        jsResourceModel
+                    );
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
New methods include support for the headers endpoints:

- Get search page header
- Reorder resources in search page header
- Create CSS resource in a search page header
- Update CSS resource in search page header
- Delete CSS resource in search page header
- Append JavaScript resource to search page header
- Update JavaScript resource in search page header
- Delete JavaScript resource in search page header

See [Swagger documentation](https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20Pages#/Search%20pages) for more info