### PR TITLE
WORK-108 add record count to schema interface

### DIFF
--- a/src/resources/SchemaService/SchemaService.ts
+++ b/src/resources/SchemaService/SchemaService.ts
@@ -9,7 +9,9 @@ import {
     CreateSchemaSourceOptions,
     ObjectsToGet,
     OffsetOrLimit,
+    Filter,
     SchemaEntityFields,
+    SimpleSchemaEntity,
 } from './SchemaServiceInterfaces';
 import {SourceType} from '../Enums';
 
@@ -23,6 +25,12 @@ export default class SchemaService extends Ressource {
     getEntities(sourceType: SourceType, parameters?: SchemaServiceQueryParams & OffsetOrLimit) {
         return this.api.get<SchemaEntities>(
             this.buildPath(`${SchemaService.baseUrl}/${sourceType}/entities`, parameters)
+        );
+    }
+
+    getEntity(sourceType: SourceType, entityId: string, parameters?: SchemaServiceQueryParams & Filter) {
+        return this.api.get<SimpleSchemaEntity>(
+            this.buildPath(`${SchemaService.baseUrl}/${sourceType}/entities/${entityId}`, parameters)
         );
     }
 

--- a/src/resources/SchemaService/SchemaService.ts
+++ b/src/resources/SchemaService/SchemaService.ts
@@ -8,10 +8,10 @@ import {
     CreateSchemaSourceModel,
     CreateSchemaSourceOptions,
     ObjectsToGet,
-    OffsetOrLimit,
-    Filter,
     SchemaEntityFields,
     SimpleSchemaEntity,
+    GetEntitiesQueryParams,
+    GetEntityQueryParams,
 } from './SchemaServiceInterfaces';
 import {SourceType} from '../Enums';
 
@@ -22,13 +22,13 @@ export default class SchemaService extends Ressource {
         super(api, serverlessApi);
     }
 
-    getEntities(sourceType: SourceType, parameters?: SchemaServiceQueryParams & OffsetOrLimit) {
+    getEntities(sourceType: SourceType, parameters?: GetEntitiesQueryParams) {
         return this.api.get<SchemaEntities>(
             this.buildPath(`${SchemaService.baseUrl}/${sourceType}/entities`, parameters)
         );
     }
 
-    getEntity(sourceType: SourceType, entityId: string, parameters?: SchemaServiceQueryParams & Filter) {
+    getEntity(sourceType: SourceType, entityId: string, parameters?: GetEntityQueryParams) {
         return this.api.get<SimpleSchemaEntity>(
             this.buildPath(`${SchemaService.baseUrl}/${sourceType}/entities/${entityId}`, parameters)
         );

--- a/src/resources/SchemaService/SchemaServiceInterfaces.ts
+++ b/src/resources/SchemaService/SchemaServiceInterfaces.ts
@@ -31,12 +31,12 @@ export interface SchemaServiceQueryParams {
     username?: string;
 }
 
-export interface OffsetOrLimit {
+export interface GetEntitiesQueryParams extends SchemaServiceQueryParams {
     offset?: number;
     limit?: number;
 }
 
-export interface Filter {
+export interface GetEntityQueryParams extends SchemaServiceQueryParams {
     filter?: string;
 }
 

--- a/src/resources/SchemaService/SchemaServiceInterfaces.ts
+++ b/src/resources/SchemaService/SchemaServiceInterfaces.ts
@@ -36,6 +36,10 @@ export interface OffsetOrLimit {
     limit?: number;
 }
 
+export interface Filter {
+    filter?: string;
+}
+
 export interface GenericObjectField {
     name?: string;
 }

--- a/src/resources/SchemaService/test/SchemaService.spec.ts
+++ b/src/resources/SchemaService/test/SchemaService.spec.ts
@@ -42,13 +42,24 @@ describe('SchemaService', () => {
         });
     });
 
-    describe('getFields', () => {
+    describe('getEntity', () => {
         it('should make a GET call to the specific SchemaService url with the correct params', () => {
-            const entityName = 'miaowouioui';
-            schemaService.getFields(sourceType, entityName, params);
+            const entityId = '🆔';
+            schemaService.getEntity(sourceType, entityId, {...params, filter: 'filter'});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entities/${entityName}/fields?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`
+                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entities/${entityId}?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}&filter=filter`
+            );
+        });
+    });
+
+    describe('getFields', () => {
+        it('should make a GET call to the specific SchemaService url with the correct params', () => {
+            const entityId = 'miaowouioui';
+            schemaService.getFields(sourceType, entityId, params);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entities/${entityId}/fields?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}`
             );
         });
     });


### PR DESCRIPTION
Add the `getEntity` method to the SchemaService class.
This method is mainly used to resolve the `recordCount` of a given entity when given a `filter`.

Unit tests were updated.
Manually tested as part of the WORK-108 PR in admin-ui