### PR TITLE
feat(catalog): fixed catalog configurations list parameter

### DIFF
--- a/src/resources/Catalogs/CatalogConfiguration.ts
+++ b/src/resources/Catalogs/CatalogConfiguration.ts
@@ -1,12 +1,12 @@
 import API from '../../APICore';
 import {New, PageModel} from '../BaseInterfaces';
 import Resource from '../Resource';
-import {CatalogConfigurationModel, CatalogsListOptions, CreateCatalogConfigurationModel} from './CatalogInterfaces';
+import {CatalogConfigurationModel, CreateCatalogConfigurationModel, ConfigurationsListOptions} from './CatalogInterfaces';
 
 export default class CatalogConfiguration extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/catalogconfigurations`;
 
-    list(options?: CatalogsListOptions) {
+    list(options?: ConfigurationsListOptions) {
         return this.api.get<PageModel<CatalogConfigurationModel>>(
             this.buildPath(CatalogConfiguration.baseUrl, options)
         );

--- a/src/resources/Catalogs/CatalogConfiguration.ts
+++ b/src/resources/Catalogs/CatalogConfiguration.ts
@@ -1,12 +1,12 @@
 import API from '../../APICore';
 import {New, PageModel} from '../BaseInterfaces';
 import Resource from '../Resource';
-import {CatalogConfigurationModel, CreateCatalogConfigurationModel, ConfigurationsListOptions} from './CatalogInterfaces';
+import {CatalogConfigurationModel, CreateCatalogConfigurationModel, CatalogConfigurationsListOptions} from './CatalogInterfaces';
 
 export default class CatalogConfiguration extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/catalogconfigurations`;
 
-    list(options?: ConfigurationsListOptions) {
+    list(options?: CatalogConfigurationsListOptions) {
         return this.api.get<PageModel<CatalogConfigurationModel>>(
             this.buildPath(CatalogConfiguration.baseUrl, options)
         );

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -4,6 +4,8 @@ export interface CatalogsListOptions {
     pageSize?: number;
 }
 
+export type ConfigurationsListOptions = Omit<CatalogsListOptions, 'filter'>;
+
 export interface CatalogFieldsMapping {
     [name: string]: string;
 }

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -4,7 +4,7 @@ export interface CatalogsListOptions {
     pageSize?: number;
 }
 
-export type ConfigurationsListOptions = Omit<CatalogsListOptions, 'filter'>;
+export type CatalogConfigurationsListOptions = Omit<CatalogsListOptions, 'filter'>;
 
 export interface CatalogFieldsMapping {
     [name: string]: string;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/COM-885

CatalogConfiguration::list takes a parameter CatalogsListOptions which itself contains a filter property. Changed list's parameter because we cannot filter configurations when we list them. 