### PR TITLE
fix(organizations): fix return type for list organizations

### DIFF
--- a/src/resources/Organizations/Organization.ts
+++ b/src/resources/Organizations/Organization.ts
@@ -9,16 +9,16 @@ import {
     OrganizationsStatusModel,
 } from './OrganizationInterfaces';
 
-type ListDependingOnPagination<T> = T extends ListOrganizationOptions
-    ? PageModel<OrganizationModel>
-    : OrganizationModel[];
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type NoPagination = undefined | null | {};
+
 export default class Organization extends Resource {
     static baseUrl = '/rest/organizations';
 
-    list<PossiblyPaginated extends ListOrganizationOptions | null | undefined>(options?: PossiblyPaginated) {
-        return this.api.get<ListDependingOnPagination<PossiblyPaginated>>(
-            this.buildPath(Organization.baseUrl, options)
-        );
+    list(noPagination?: NoPagination): Promise<OrganizationModel[]>;
+    list(options: ListOrganizationOptions): Promise<PageModel<OrganizationModel>>;
+    list(...args: [] | [ListOrganizationOptions]): unknown {
+        return this.api.get<unknown>(this.buildPath(Organization.baseUrl, args[0]));
     }
 
     create(options: CreateOrganizationOptions) {

--- a/src/resources/Organizations/Organization.ts
+++ b/src/resources/Organizations/Organization.ts
@@ -9,11 +9,16 @@ import {
     OrganizationsStatusModel,
 } from './OrganizationInterfaces';
 
+type ListDependingOnPagination<T> = T extends ListOrganizationOptions
+    ? PageModel<OrganizationModel>
+    : OrganizationModel[];
 export default class Organization extends Resource {
     static baseUrl = '/rest/organizations';
 
-    list(options?: ListOrganizationOptions) {
-        return this.api.get<PageModel<OrganizationModel>>(this.buildPath(Organization.baseUrl, options));
+    list<PossiblyPaginated extends ListOrganizationOptions | null | undefined>(options?: PossiblyPaginated) {
+        return this.api.get<ListDependingOnPagination<PossiblyPaginated>>(
+            this.buildPath(Organization.baseUrl, options)
+        );
     }
 
     create(options: CreateOrganizationOptions) {

--- a/src/resources/Organizations/tests/Organizations.spec.ts
+++ b/src/resources/Organizations/tests/Organizations.spec.ts
@@ -21,6 +21,12 @@ describe('Organization', () => {
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(Organization.baseUrl);
         });
+
+        it('should make a paginated call when pagination parameters are passed', () => {
+            organization.list({page: 0, filter: 'foo'});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Organization.baseUrl}?page=0&filter=foo`);
+        });
     });
 
     describe('create', () => {


### PR DESCRIPTION
The list organization call return different types depending on if a `ListOrganizationOptions` is passed in or not as an argument.

When no `ListOrganizationOptions`, it does not return a `PageModel<OrganizationModel>`, it returns an `OrganizationModel[]` directly.

And since `ListOrganizationOptions` is optional, the final returned type was invalid.

I suspect this might be present for other API calls in the project... 🤔 

I did not do an exhaustive check of everything, though.