### PR TITLE
Feature/ctinfra 1614 security provider

### DIFF
--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -105,7 +105,7 @@ export default class SecurityCache extends Ressource {
         );
     }
 
-    cancelRefresh(securityProviderId: string) {
-        return this.api.post(`${SecurityCache.providersUrl}/${securityProviderId}/refresh/cancel`);
+    cancelRefresh(providerId: string) {
+        return this.api.post(`${SecurityCache.providersUrl}/${providerId}/refresh/cancel`);
     }
 }

--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -104,4 +104,8 @@ export default class SecurityCache extends Ressource {
             member
         );
     }
+
+    cancelRefresh(securityProviderId: string) {
+        return this.api.post(`${SecurityCache.providersUrl}/${securityProviderId}/refresh/cancel`);
+    }
 }

--- a/src/resources/SecurityCache/tests/SecurityCache.spec.ts
+++ b/src/resources/SecurityCache/tests/SecurityCache.spec.ts
@@ -170,6 +170,13 @@ describe('securityCache', () => {
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${SecurityCache.cacheUrl}/refresh/entity`, identityModel);
         });
+
+        it('should make a POST when canceling a refresh operation', () => {
+            const PROVIDER_ID = 'OhnoOhNoNONo';
+            securityCache.cancelRefresh(PROVIDER_ID);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${SecurityCache.providersUrl}/${PROVIDER_ID}/refresh/cancel`);
+        });
     });
 
     describe('status', () => {


### PR DESCRIPTION
### Related Issue

[CTINFRA-1614](https://coveord.atlassian.net/browse/CTINFRA-1614)

### Proposed Changes

Adding a new call for the SecurityCache resource to cancel a refresh operation on a provider. 

### Scope

Security Cache resource

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The scope of the changes is clearly identified