### PR TITLE
feat(dne-configuration): add parseDocumentExtractionQuery method

### DIFF
--- a/src/resources/MachineLearning/DNEConfiguration/DNEConfiguration.ts
+++ b/src/resources/MachineLearning/DNEConfiguration/DNEConfiguration.ts
@@ -32,7 +32,7 @@ export default class DNEConfiguration extends Resource {
 
     parseDocumentExtractionQuery(query: string) {
         return this.api.get<DocumentExtractionQueryModel>(
-            this.buildPath(`${DNEConfiguration.baseUrl}/documentextractionquery`, {query: query})
+            this.buildPath(`${DNEConfiguration.baseUrl}/documentextractionquery`, {query})
         );
     }
 

--- a/src/resources/MachineLearning/DNEConfiguration/DNEConfiguration.ts
+++ b/src/resources/MachineLearning/DNEConfiguration/DNEConfiguration.ts
@@ -30,6 +30,12 @@ export default class DNEConfiguration extends Resource {
         return this.api.post<string>(`${DNEConfiguration.baseUrl}/documentextractionquery`, model);
     }
 
+    parseDocumentExtractionQuery(query: string) {
+        return this.api.get<DocumentExtractionQueryModel>(
+            this.buildPath(`${DNEConfiguration.baseUrl}/documentextractionquery`, {query: query})
+        );
+    }
+
     async createWithoutQuery(
         newModel: DNENewConfigurationModel,
         documentExtractionQueryModel: DocumentExtractionQueryModel

--- a/src/resources/MachineLearning/DNEConfiguration/tests/DNEConfiguration.spec.ts
+++ b/src/resources/MachineLearning/DNEConfiguration/tests/DNEConfiguration.spec.ts
@@ -46,6 +46,16 @@ describe('DNEConfiguration', () => {
         });
     });
 
+    describe('parseDocumentExtractionQuery', () => {
+        it('should make a GET call to the specific DNEConfiguration url', () => {
+            const aString: string = 'lala';
+            dneConfig.parseDocumentExtractionQuery(aString);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/documentextractionquery?query=lala`);
+        });
+    });
+
     describe('createWithoutQuery', () => {
         it('should make a POST call to get documentExtractionQueryModel, then use this param to create a new DNE model ', async () => {
             const newModel: DNENewConfigurationModel = {modelDisplayName: '🐩'};

--- a/src/resources/MachineLearning/DNEConfiguration/tests/DNEConfiguration.spec.ts
+++ b/src/resources/MachineLearning/DNEConfiguration/tests/DNEConfiguration.spec.ts
@@ -48,8 +48,8 @@ describe('DNEConfiguration', () => {
 
     describe('parseDocumentExtractionQuery', () => {
         it('should make a GET call to the specific DNEConfiguration url', () => {
-            const aString: string = 'lala';
-            dneConfig.parseDocumentExtractionQuery(aString);
+            const query = 'lala';
+            dneConfig.parseDocumentExtractionQuery(query);
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/documentextractionquery?query=lala`);


### PR DESCRIPTION
Added a new method to parse a document extraction query of the DNE configuration to a the Document extraction query model (in which it would return an object with an array of fields and an array of sources based on the query received). 