### PR TITLE
fix(exports.ts): changed the return from ExportModel to void

### DIFF
--- a/src/resources/UsageAnalytics/Read/Exports/Exports.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/Exports.ts
@@ -84,7 +84,7 @@ export default class Exports extends Resource {
     }
 
     deleteSchedule(exportScheduleId: string) {
-        return this.api.delete<ExportModel>(
+        return this.api.delete<void>(
             this.buildPath(`${Exports.baseUrl}/schedules/${exportScheduleId}`, {org: this.api.organizationId})
         );
     }


### PR DESCRIPTION
There was an error in swagger. The ua call to delete a schedule should return void, not an ExportModel