### PR TITLE
Feat ADUI 6832 add a method to parse the document extraction query used for the dne configurations

### DIFF
--- a/src/resources/MachineLearning/DNEConfiguration/DNEConfiguration.ts
+++ b/src/resources/MachineLearning/DNEConfiguration/DNEConfiguration.ts
@@ -32,7 +32,7 @@ export default class DNEConfiguration extends Resource {
 
     parseDocumentExtractionQuery(query: string) {
         return this.api.get<DocumentExtractionQueryModel>(
-            this.buildPath(`${DNEConfiguration.baseUrl}/documentextractionquery`, {query})
+            this.buildPath(`${DNEConfiguration.baseUrl}/documentextractionquery`, {query: decodeURI(query)})
         );
     }
 


### PR DESCRIPTION
Decode query to make sure the latter is formatted correctly. Otherwise, the API call will never work.