### PR TITLE
Feat ad UI 6832 add a method to parse the document extraction query used for the dne configurations

### DIFF
--- a/src/resources/MachineLearning/DNEConfiguration/DNEConfiguration.ts
+++ b/src/resources/MachineLearning/DNEConfiguration/DNEConfiguration.ts
@@ -32,7 +32,7 @@ export default class DNEConfiguration extends Resource {
 
     parseDocumentExtractionQuery(query: string) {
         return this.api.get<DocumentExtractionQueryModel>(
-            this.buildPath(`${DNEConfiguration.baseUrl}/documentextractionquery`, {query: decodeURI(query)})
+            this.buildPath(`${DNEConfiguration.baseUrl}/documentextractionquerymodel`, {query})
         );
     }
 

--- a/src/resources/MachineLearning/DNEConfiguration/tests/DNEConfiguration.spec.ts
+++ b/src/resources/MachineLearning/DNEConfiguration/tests/DNEConfiguration.spec.ts
@@ -52,7 +52,7 @@ describe('DNEConfiguration', () => {
             dneConfig.parseDocumentExtractionQuery(query);
 
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/documentextractionquery?query=lala`);
+            expect(api.get).toHaveBeenCalledWith(`${DNEConfiguration.baseUrl}/documentextractionquerymodel?query=lala`);
         });
     });
 


### PR DESCRIPTION
I didn't includes the right URL (see [here ](https://platformdev.cloud.coveo.com/docs/?urls.primaryName=Machine%20Learning%20Configuration#/Dynamic%20Navigation%20Experience%20Configuration/rest_organizations_paramId_machinelearning_configuration_dne_documentextractionquerymodel_get)to confirm I did now include the expected route) for this method. Here's the correction