### PR TITLE
Allow bypassing catalog fields cache [COM-681]

### DIFF
--- a/src/resources/Catalogs/Catalog.ts
+++ b/src/resources/Catalogs/Catalog.ts
@@ -1,7 +1,13 @@
 import API from '../../APICore';
 import {New, PageModel} from '../BaseInterfaces';
 import Resource from '../Resource';
-import {CachedCatalogFieldsModel, CatalogModel, CatalogsListOptions, CreateCatalogModel} from './CatalogInterfaces';
+import {
+    CachedCatalogFieldsModel,
+    CatalogFieldsOptions,
+    CatalogModel,
+    CatalogsListOptions,
+    CreateCatalogModel,
+} from './CatalogInterfaces';
 
 export default class Catalog extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/catalogs`;
@@ -22,8 +28,10 @@ export default class Catalog extends Resource {
         return this.api.get<CatalogModel>(`${Catalog.baseUrl}/${catalogId}`);
     }
 
-    getFields(catalogId: string) {
-        return this.api.get<CachedCatalogFieldsModel>(`${Catalog.baseUrl}/${catalogId}/fields`);
+    getFields(catalogId: string, options?: CatalogFieldsOptions) {
+        return this.api.get<CachedCatalogFieldsModel>(
+            this.buildPath(`${Catalog.baseUrl}/${catalogId}/fields`, options)
+        );
     }
 
     /* eslint-disable @typescript-eslint/unified-signatures */

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -1,10 +1,14 @@
 export interface CatalogsListOptions {
-    filter?: string; 
+    filter?: string;
     page?: number;
     pageSize?: number;
 }
 
 export type CatalogConfigurationsListOptions = Omit<CatalogsListOptions, 'filter'>;
+
+export interface CatalogFieldsOptions {
+    bypassCache?: boolean;
+}
 
 export interface CatalogFieldsMapping {
     [name: string]: string;

--- a/src/resources/Catalogs/tests/Catalog.spec.ts
+++ b/src/resources/Catalogs/tests/Catalog.spec.ts
@@ -103,6 +103,15 @@ describe('Catalog', () => {
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Catalog.baseUrl}/${catalogOfFieldsToGetId}/fields`);
         });
+
+        it('should allow bypassing the cache', () => {
+            const catalogOfFieldsToGetId = 'catalog-of-fields';
+            catalog.getFields(catalogOfFieldsToGetId, {bypassCache: true});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Catalog.baseUrl}/${catalogOfFieldsToGetId}/fields?bypassCache=true`
+            );
+        });
     });
 
     describe('update', () => {


### PR DESCRIPTION
Add the `bypassCache` parameter which already exists on the catlalog api's `/fields` route.
[COM-681]

[COM-681]: https://coveord.atlassian.net/browse/COM-681