### PR TITLE
fix(privileges): fixing the types for privileges

### DIFF
--- a/src/resources/BaseInterfaces.ts
+++ b/src/resources/BaseInterfaces.ts
@@ -15,7 +15,7 @@ export interface IdAndDisplayNameModel {
 export interface PrivilegeModel {
     owner: string;
     targetDomain: string;
-    targetId: string;
+    targetId?: string;
     type?: string;
 }
 

--- a/src/resources/GlobalGroups/GlobalGroupInterfaces.ts
+++ b/src/resources/GlobalGroups/GlobalGroupInterfaces.ts
@@ -12,7 +12,6 @@ export interface GlobalGroupModel {
 }
 
 export interface GlobalPrivilegeModel extends PrivilegeModel {
-    global: boolean;
     level: string;
 }
 


### PR DESCRIPTION
- Global privileges don't have that `global` property. 
- `targetId` is optional