### PR TITLE
fix(snowflake): update create user response body

### DIFF
--- a/src/resources/UsageAnalytics/Read/Snowflake/Snowflake.ts
+++ b/src/resources/UsageAnalytics/Read/Snowflake/Snowflake.ts
@@ -17,7 +17,10 @@ export default class Snowflake extends Resource {
     }
 
     createUser(model: SnowflakeUserModel) {
-        return this.api.post<void>(this.buildPath(`${Snowflake.baseUrl}/users`, {org: this.api.organizationId}), model);
+        return this.api.post<SnowflakeUserModel>(
+            this.buildPath(`${Snowflake.baseUrl}/users`, {org: this.api.organizationId}),
+            model
+        );
     }
 
     deleteUser(snowflakeUser: string) {


### PR DESCRIPTION
The POST call to create user returns an object `SnowflakeUserModel` instead of `void`.