### PR TITLE
Feat/analytics reports

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -876,3 +876,8 @@ export enum ExportScheduleFrequency {
     monthly = 'MONTHLY',
     weekly = 'WEEKLY',
 }
+
+export enum ReportType {
+    Dashboard = 'dashboard',
+    Explorer = 'explorer',
+}

--- a/src/resources/UsageAnalytics/Read/Reports/Reports.ts
+++ b/src/resources/UsageAnalytics/Read/Reports/Reports.ts
@@ -1,0 +1,60 @@
+import Resource from '../../../Resource';
+import {
+    CreateReportModel,
+    CreateReportResponse,
+    GetReportOptions,
+    ListReportsOptions,
+    ListReportsResponse,
+    ReportModel,
+    UpdateReportModel,
+} from './ReportsInterfaces';
+
+export default class Reports extends Resource {
+    static baseUrl = '/rest/ua/v15/reports';
+
+    /**
+     * Get the persisted reports of one or all types
+     */
+    list(options: ListReportsOptions = {}) {
+        return this.api.get<ListReportsResponse>(
+            this.buildPath(Reports.baseUrl, {
+                org: this.api.organizationId,
+                type: options.type,
+                includeConfig: options.includeConfig,
+            })
+        );
+    }
+
+    get(id: string, options: GetReportOptions = {}) {
+        return this.api.get<ReportModel>(
+            this.buildPath(`${Reports.baseUrl}/${id}`, {org: this.api.organizationId, tz: options.tz})
+        );
+    }
+
+    /**
+     * Create a report
+     */
+    create(report: CreateReportModel) {
+        return this.api.post<CreateReportResponse>(
+            this.buildPath(Reports.baseUrl, {org: this.api.organizationId}),
+            report
+        );
+    }
+
+    /**
+     * Update a report
+     */
+    update(id: string, report: UpdateReportModel) {
+        return this.api.put<UpdateReportModel>(
+            this.buildPath(`${Reports.baseUrl}/${id}`, {org: this.api.organizationId}),
+            report
+        );
+    }
+
+    /**
+     * Delete a report
+     */
+    delete(id: string) {
+        return this.api.delete(this.buildPath(`${Reports.baseUrl}/${id}`, {org: this.api.organizationId}));
+    }
+}

--- a/src/resources/UsageAnalytics/Read/Reports/ReportsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Reports/ReportsInterfaces.ts
@@ -1,0 +1,41 @@
+import {ReportType} from '../../../Enums';
+
+export interface ReportModel {
+    // The report id
+    id: string;
+    // The report account
+    account: string;
+    // The display name of the report
+    displayName: string;
+    // The type of the report. Must be either 'explorer' or 'dashboard'.
+    type: ReportType;
+    // Whether the report should be available to all analytics viewer.
+    allAnalyticsViewer: boolean;
+    // The configuration of the report. Must be a json.
+    configuration: Record<string, unknown>;
+    // The ids of the persisted filters associated with the report.
+    filters: string[];
+}
+
+export type CreateReportModel = Omit<ReportModel, 'id' | 'account'>;
+export type CreateReportResponse = Pick<ReportModel, 'id'>;
+
+export interface GetReportOptions {
+    // Timezone used for calculations.
+    tz?: string;
+}
+
+export type UpdateReportModel = CreateReportModel;
+export type UpdateReportResponse = CreateReportResponse;
+
+export interface ListReportsOptions {
+    // The type of the report. Must be either 'explorer' or 'dashboard'.
+    type?: ReportType;
+    // Whether to include the detailed configuration of the report in the response.
+    includeConfig?: boolean;
+}
+
+export interface ListReportsResponse {
+    // A collection of report configurations
+    reports: ReportModel[];
+}

--- a/src/resources/UsageAnalytics/Read/Reports/index.ts
+++ b/src/resources/UsageAnalytics/Read/Reports/index.ts
@@ -1,0 +1,2 @@
+export * from './Reports';
+export * from './ReportsInterfaces';

--- a/src/resources/UsageAnalytics/Read/Reports/tests/Reports.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Reports/tests/Reports.spec.ts
@@ -1,0 +1,81 @@
+import API from '../../../../../APICore';
+import {ReportType} from '../../../../Enums';
+import Reports from '../Reports';
+import {CreateReportModel, UpdateReportModel} from '../ReportsInterfaces';
+
+jest.mock('../../../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('Reports', () => {
+    let reports: Reports;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+    const testReportId = 'test-report-id';
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        reports = new Reports(api, serverlessApi);
+    });
+
+    describe('list', () => {
+        it('should make a GET call to the Reports base url', () => {
+            reports.list();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(Reports.baseUrl);
+        });
+    });
+
+    describe('get', () => {
+        it('should make a GET call to the Reports base url for the specific ID', () => {
+            reports.get(testReportId);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Reports.baseUrl}/${testReportId}`);
+        });
+    });
+
+    describe('create', () => {
+        it('should make a POST call to the Reports base url for the specific ID', () => {
+            const report: CreateReportModel = {
+                allAnalyticsViewer: false,
+                configuration: {},
+                displayName: 'test-report',
+                filters: [],
+                type: ReportType.Dashboard,
+            };
+
+            reports.create(report);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(Reports.baseUrl, report);
+        });
+    });
+
+    describe('update', () => {
+        it('should make a PUT call to the Reports base url for the specific ID', () => {
+            const report: UpdateReportModel = {
+                allAnalyticsViewer: false,
+                configuration: {},
+                displayName: 'test-report',
+                filters: [],
+                type: ReportType.Dashboard,
+            };
+
+            reports.update(testReportId, report);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${Reports.baseUrl}/${testReportId}`, report);
+        });
+    });
+
+    describe('delete', () => {
+        it('should make a DELETE call to the Reports base url for the specific ID', () => {
+            reports.delete(testReportId);
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${Reports.baseUrl}/${testReportId}`);
+        });
+    });
+});

--- a/src/resources/UsageAnalytics/Read/index.ts
+++ b/src/resources/UsageAnalytics/Read/index.ts
@@ -3,3 +3,4 @@ export * from './Dimensions';
 export * from './Exports';
 export * from './Snowflake';
 export * from './Statistics';
+export * from './Reports';

--- a/src/resources/UsageAnalytics/UsageAnalytics.ts
+++ b/src/resources/UsageAnalytics/UsageAnalytics.ts
@@ -3,6 +3,7 @@ import Resource from '../Resource';
 import Administration from './Read/Administration/Administration';
 import Dimensions from './Read/Dimensions/Dimensions';
 import Exports from './Read/Exports/Exports';
+import Reports from './Read/Reports/Reports';
 import Snowflake from './Read/Snowflake/Snowflake';
 import Statistics from './Read/Statistics/Statistics';
 
@@ -12,6 +13,7 @@ export default class UsageAnalytics extends Resource {
     exports: Exports;
     administration: Administration;
     snowflake: Snowflake;
+    reports: Reports;
 
     constructor(protected api: API, protected serverlessApi: API) {
         super(api, serverlessApi);
@@ -21,5 +23,6 @@ export default class UsageAnalytics extends Resource {
         this.statistics = new Statistics(api, serverlessApi);
         this.administration = new Administration(api, serverlessApi);
         this.snowflake = new Snowflake(api, serverlessApi);
+        this.reports = new Reports(api, serverlessApi);
     }
 }

--- a/src/resources/UsageAnalytics/tests/UsageAnalytics.spec.ts
+++ b/src/resources/UsageAnalytics/tests/UsageAnalytics.spec.ts
@@ -2,6 +2,7 @@ import API from '../../../APICore';
 import Administration from '../Read/Administration/Administration';
 import Dimensions from '../Read/Dimensions/Dimensions';
 import Exports from '../Read/Exports/Exports';
+import Reports from '../Read/Reports/Reports';
 import Snowflake from '../Read/Snowflake/Snowflake';
 import Statistics from '../Read/Statistics/Statistics';
 import UsageAnalytics from '../UsageAnalytics';
@@ -43,5 +44,10 @@ describe('UsageAnalytics', () => {
     it('registers the snowflake resource', () => {
         expect(ua.snowflake).toBeDefined();
         expect(ua.snowflake).toBeInstanceOf(Snowflake);
+    });
+
+    it('registers the reports resource', () => {
+        expect(ua.reports).toBeDefined();
+        expect(ua.reports).toBeInstanceOf(Reports);
     });
 });


### PR DESCRIPTION
This pull request introduces support for the [Usage Analytics Read endpoints for Reports (v15)](https://platform.cloud.coveo.com/docs?urls.primaryName=Usage%20Analytics%20Read#/Reports%20API%20-%20Version%2015).

Docstrings were included in interfaces to reflect documentation available from Swagger.

Updates include both the client implementation and test cases for `Reports.ts` and `UsageAnalytics.ts`.