### PR TITLE
Feat/analytics report templates

### DIFF
--- a/src/resources/UsageAnalytics/Read/Reports/Reports.ts
+++ b/src/resources/UsageAnalytics/Read/Reports/Reports.ts
@@ -1,11 +1,19 @@
+import {ReportType} from '../../../Enums';
 import Resource from '../../../Resource';
 import {
     CreateReportModel,
     CreateReportResponse,
     GetReportOptions,
+    GetReportTemplateOptions,
     ListReportsOptions,
     ListReportsResponse,
+    ReportAccessRequest,
+    ReportAccessResponse,
     ReportModel,
+    TemplateResponse,
+    ReportUsersResponse,
+    StatusResponse,
+    TemplateMetadataResponse,
     UpdateReportModel,
 } from './ReportsInterfaces';
 
@@ -25,6 +33,9 @@ export default class Reports extends Resource {
         );
     }
 
+    /**
+     * Get a report
+     */
     get(id: string, options: GetReportOptions = {}) {
         return this.api.get<ReportModel>(
             this.buildPath(`${Reports.baseUrl}/${id}`, {org: this.api.organizationId, tz: options.tz})
@@ -56,5 +67,77 @@ export default class Reports extends Resource {
      */
     delete(id: string) {
         return this.api.delete(this.buildPath(`${Reports.baseUrl}/${id}`, {org: this.api.organizationId}));
+    }
+
+    /**
+     * Get the users and groups who can view a report
+     */
+    getAccess(reportId: string) {
+        return this.api.get<ReportAccessResponse>(
+            this.buildPath(`${Reports.baseUrl}/${reportId}/access`, {org: this.api.organizationId})
+        );
+    }
+
+    /**
+     * Set the users and groups who are allowed to view a report
+     */
+    setAccess(reportId: string, reportAccess: ReportAccessRequest) {
+        return this.api.put(
+            this.buildPath(`${Reports.baseUrl}/${reportId}/access`, {org: this.api.organizationId}),
+            reportAccess
+        );
+    }
+
+    /**
+     * Get the users who can view a report
+     */
+    getUsers(reportId: string) {
+        return this.api.get<ReportUsersResponse>(
+            this.buildPath(`${Reports.baseUrl}/${reportId}/users`, {org: this.api.organizationId})
+        );
+    }
+
+    /**
+     * Set the users who are allowed to view a report
+     */
+    setUsers(reportId: string, userIds: string[]) {
+        return this.api.put(
+            this.buildPath(`${Reports.baseUrl}/${reportId}/users`, {org: this.api.organizationId}),
+            userIds
+        );
+    }
+
+    /**
+     * Health check for the reports service
+     */
+    healthcheck() {
+        return this.api.get<StatusResponse>(
+            this.buildPath(`${Reports.baseUrl}/monitoring/health`, {org: this.api.organizationId})
+        );
+    }
+
+    /**
+     * Get a report template
+     */
+    getReportTemplate(templateId: string, options: GetReportTemplateOptions = {}) {
+        return this.api.get<TemplateResponse[]>(this.buildPath(`${Reports.baseUrl}/templates/${templateId}`, options));
+    }
+
+    /**
+     * Get metadata about available report templates
+     */
+    listReportTemplates(type: ReportType, options: GetReportTemplateOptions = {}) {
+        return this.api.get<TemplateMetadataResponse[]>(
+            this.buildPath(`${Reports.baseUrl}/templates`, {...options, type})
+        );
+    }
+
+    /**
+     * Get the reports service status
+     */
+    getServiceStatus() {
+        return this.api.get<StatusResponse>(
+            this.buildPath(`${Reports.baseUrl}/status`, {org: this.api.organizationId})
+        );
     }
 }

--- a/src/resources/UsageAnalytics/Read/Reports/ReportsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Reports/ReportsInterfaces.ts
@@ -39,3 +39,77 @@ export interface ListReportsResponse {
     // A collection of report configurations
     reports: ReportModel[];
 }
+
+export enum ReportAccessType {
+    Public = 'PUBLIC',
+    Private = 'PRIVATE',
+}
+
+export interface ReportAccessResponse {
+    // The access type of the report. Can be PUBLIC or PRIVATE.
+    accessType: ReportAccessType;
+    // The users allowed to access the specified report.
+    allowedUsers: UserResponse[];
+    // The groups allowed to access the specified report.
+    allowedGroups: GroupResponse[];
+}
+
+export interface ReportAccessRequest {
+    // Whether the report is public or private. Allowed values are 'PUBLIC', 'PRIVATE'.
+    accessType: ReportAccessType;
+    // The ids of the users allowed to access the report.
+    allowedUsers: string[];
+    // The ids of the groups allowed to access the report.
+    allowedGroups: string[];
+}
+
+export interface ReportUsersResponse {
+    // The access type of the report. Can be PUBLIC or PRIVATE.
+    access: ReportAccessType;
+    // The users allowed to access the specified report.
+    allowedUsers: UserResponse[];
+}
+
+interface AccountMetaModel {
+    // The filters that are applied to the user
+    filters: string[];
+    // The reports the user can view.
+    reports: string[];
+}
+
+export interface UserResponse extends AccountMetaModel {
+    // The user id
+    userId: string;
+    // The user account
+    account: string;
+}
+
+export interface GroupResponse extends AccountMetaModel {
+    // The group id
+    groupId: string;
+    // The group account
+    account: string;
+}
+
+export type StatusResponse = Record<string, unknown>;
+
+export interface GetReportTemplateOptions {
+    // Whether to include metadata about the report template
+    includeMetadata?: boolean;
+}
+
+export interface TemplateMetadataResponse {
+    // The template id.
+    id: string;
+    // The template title.
+    title: string;
+    // The template description.
+    description: string;
+    // The template category.
+    category: string;
+}
+
+export interface TemplateResponse extends TemplateMetadataResponse {
+    // The JSON report configuration of the template.
+    configuration: Record<string, unknown>;
+}

--- a/src/resources/UsageAnalytics/Read/Reports/tests/Reports.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Reports/tests/Reports.spec.ts
@@ -1,7 +1,7 @@
 import API from '../../../../../APICore';
 import {ReportType} from '../../../../Enums';
 import Reports from '../Reports';
-import {CreateReportModel, UpdateReportModel} from '../ReportsInterfaces';
+import {CreateReportModel, ReportAccessRequest, ReportAccessType, UpdateReportModel} from '../ReportsInterfaces';
 
 jest.mock('../../../../../APICore');
 
@@ -12,6 +12,7 @@ describe('Reports', () => {
     const api = new APIMock() as jest.Mocked<API>;
     const serverlessApi = new APIMock() as jest.Mocked<API>;
     const testReportId = 'test-report-id';
+    const testTemplateId = 'test-template-id';
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -76,6 +77,86 @@ describe('Reports', () => {
 
             expect(api.delete).toHaveBeenCalledTimes(1);
             expect(api.delete).toHaveBeenCalledWith(`${Reports.baseUrl}/${testReportId}`);
+        });
+    });
+
+    describe('getAccess', () => {
+        it('should make a GET call to the specific report ID url for access', () => {
+            reports.getAccess(testReportId);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Reports.baseUrl}/${testReportId}/access`);
+        });
+    });
+
+    describe('setAccess', () => {
+        it('should make a PUT call to the specific report ID url for access', () => {
+            const access: ReportAccessRequest = {
+                accessType: ReportAccessType.Public,
+                allowedGroups: [],
+                allowedUsers: [],
+            };
+
+            reports.setAccess(testReportId, access);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${Reports.baseUrl}/${testReportId}/access`, access);
+        });
+    });
+
+    describe('getUsers', () => {
+        it('should make a GET call to the specific report ID url for users', () => {
+            reports.getUsers(testReportId);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Reports.baseUrl}/${testReportId}/users`);
+        });
+    });
+
+    describe('setUsers', () => {
+        it('should make a PUT call to the specific report ID url for users', () => {
+            const users: string[] = [];
+
+            reports.setUsers(testReportId, users);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${Reports.baseUrl}/${testReportId}/users`, users);
+        });
+    });
+
+    describe('healthcheck', () => {
+        it('should make a GET call to the specific report endpoint for healthchecks', () => {
+            reports.healthcheck();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Reports.baseUrl}/monitoring/health`);
+        });
+    });
+
+    describe('getReportTemplate', () => {
+        it('should make a GET call to the Reports base url for the specific template ID', () => {
+            reports.getReportTemplate(testTemplateId);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Reports.baseUrl}/templates/${testTemplateId}`);
+        });
+    });
+
+    describe('listReportTemplates', () => {
+        it('should make a GET call to the Reports base url for templates', () => {
+            reports.listReportTemplates(ReportType.Dashboard);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Reports.baseUrl}/templates?type=${ReportType.Dashboard}`);
+        });
+    });
+
+    describe('status', () => {
+        it('should make a GET call to the specific report endpoint for service status', () => {
+            reports.getServiceStatus();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Reports.baseUrl}/status`);
         });
     });
 });


### PR DESCRIPTION
Includes remaining REST endpoints defined in [Reports V15 Swagger doc](https://platform.cloud.coveo.com/docs?urls.primaryName=Usage%20Analytics%20Read#/Reports%20API%20-%20Version%2015) with jsdocs where possible.

Tests have been implemented for all new endpoints.