### PR TITLE
fix(machine-learning)!: change param key

### DIFF
--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
@@ -50,7 +50,7 @@ export interface CaseClassificationConfigurationModel {
      * The time period for which to extract cases for model building.
      * Must contain an export period or a start time and end time.
      */
-    documentExtractionPeriod?: ExtractionPeriod;
+    caseExtractionPeriod?: ExtractionPeriod;
     /**
      * The case fields to use for model training.
      * Example: [subject, reason, category]

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
@@ -17,7 +17,7 @@ describe('CCConfiguration', () => {
             modelId: 'test-model-id',
             modelDisplayName: 'Model Name 1',
             sources: ['1st-source', '2nd-source'],
-            documentExtractionPeriod: {
+            caseExtractionPeriod: {
                 exportPeriod: 'test-export-period',
             },
             caseFilterConditions: [
@@ -43,7 +43,7 @@ describe('CCConfiguration', () => {
             modelId: 'test-model-id',
             modelDisplayName: 'Model Name 1',
             sources: ['1st-source', '2nd-source'],
-            documentExtractionPeriod: {
+            caseExtractionPeriod: {
                 startTime: 9876543210,
                 endTime: 1234567890,
             },


### PR DESCRIPTION
A breaking change was made in the dev api. See [here](https://github.com/coveo/ml-config-service/pull/576).
Break there means break here. monkey see monkey do, monkey pee all over you.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
