### PR TITLE
fix(modifiertemplates): added the modifier to the resource index

### DIFF
--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -32,3 +32,4 @@ export * from './Limits';
 export * from './Notification';
 export * from './Connectivity';
 export * from './SearchInterfaces';
+export * from './ModifierTemplates';


### PR DESCRIPTION
added the modifier to the resource index

FOUND-3517

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)

I'm having import issues when running tests and it was suggested that it might be because the ModifierTemplate files are only exported at the /resources/ModifierTemplates level but not the upper /resources/index.ts level.

```
@coveord/jsadmin-v2: ERROR in ./src/settings-react/license/details/tests/DetailsComponent.spec.tsx
@coveord/jsadmin-v2: Module not found: Error: Can't resolve '@coveord/platform-client/dist/definitions/resources/ModifierTemplates/ModifierTemplateInterfaces' in '/home/mcoulombe/projects/admin-ui/packages/v2/src/settings-react/license/details/tests'
```

