### PR TITLE
feat(fields-interfaces): add the facetsOnly parameter to the list call

### DIFF
--- a/src/resources/Fields/FieldsInterfaces.ts
+++ b/src/resources/Fields/FieldsInterfaces.ts
@@ -24,6 +24,7 @@ export interface FieldModel {
 }
 
 export interface ListFieldsParams {
+    facetsOnly?: boolean;
     filter?: string;
     order?: SortingOrder;
     origin?: FieldOrigin;

--- a/src/resources/Fields/tests/Fields.spec.ts
+++ b/src/resources/Fields/tests/Fields.spec.ts
@@ -106,5 +106,13 @@ describe('Field', () => {
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Indexes.baseUrl}/page/fields`);
         });
+
+        it('should make a GET call to the specific Field url with the facetsOnly parameter set as true', () => {
+            const params: ListFieldsParams = {facetsOnly: true};
+
+            field.list(params);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Indexes.baseUrl}/page/fields?facetsOnly=true`);
+        });
     });
 });


### PR DESCRIPTION
A parameter was missing for the ListFieldsParams interface, used for the GET call that fetch all the fields. It is now possible to set the `facetsOnly` parameter, that indicates if we want to received only the fields that can be converted as facets.

https://platformdev.cloud.coveo.com/docs/?urls.primaryName=Field#/Fields/rest_organizations_paramId_indexes_page_fields_get

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
