### PR TITLE
feat(sources): add a new field to form auth interface

### DIFF
--- a/src/resources/Sources/SourcesInterfaces.ts
+++ b/src/resources/Sources/SourcesInterfaces.ts
@@ -249,6 +249,7 @@ export interface FormAuthenticationConfig {
     addFoundInputs?: boolean;
     authenticationFailed?: FormAuthenticationFailedConfiguration;
     enableJavaScript?: boolean;
+    forceLogin?: boolean;
     formContentType?: string;
     formId?: string;
     formUrl?: string;


### PR DESCRIPTION
The `forceLogin` property is used in the **Automatic form authentication** of the edit source page. I can't find any information in Swagger or in the backbone model to add JSDoc annotation at this moment.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
