### PR TITLE
fix(catalog): adding sourceId availabilitySourceId to associated catalog

### DIFF
--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -1,50 +1,131 @@
 export interface CatalogsListOptions {
+    /**
+     * Filter that will be matched against the catalog name, description and its configuration name.
+     */
     filter?: string;
+    /**
+     * The 0-based index number of the page of catalogs to retrieve.
+     */
     page?: number;
+    /**
+     * The number of catalogs to list per page.
+     */
     pageSize?: number;
 }
 
 export type CatalogConfigurationsListOptions = Omit<CatalogsListOptions, 'filter'>;
 
 export interface CatalogFieldsOptions {
+    /**
+     * If true, the database cache will be bypassed. This will resolve your fields once, and save them into the database.
+     */
     bypassCache?: boolean;
 }
 
 export interface CatalogFieldsMapping {
+    /**
+     * Mapping of index fields to standard commerce fields
+     */
     [name: string]: string;
 }
 
 export interface CreateCatalogConfigurationModel {
+    /**
+     * The unique identifier of the catalog configuration.
+     */
     id: string;
+    /**
+     * The name of the catalog configuration.
+     */
     name: string;
+    /**
+     * The configuration product structure
+     */
     product: Omit<CreateProductHierarchyModel, 'fields'>;
+    /**
+     * The configuration variant structure
+     */
     variant?: Omit<CreateVariantHierarchyModel, 'fields'>;
+    /**
+     * The configuration availability structure
+     */
     availability?: Omit<CreateAvailabilityHierarchyModel, 'fields'>;
+    /**
+     * The configuration mapping of index fields to standard commerce fields
+     */
     fieldsMapping: CatalogFieldsMapping;
 }
 
 export interface CatalogConfigurationModel {
+    /**
+     * The unique identifier of the catalog configuration.
+     */
     id: string;
+    /**
+     * The name of the catalog configuration.
+     */
     name: string;
+    /**
+     * The configuration product structure
+     */
     product: HierarchyWithFields<ProductHierarchyModel>;
+    /**
+     * The configuration variant structure
+     */
     variant?: HierarchyWithFields<VariantHierarchyModel>;
+    /**
+     * The configuration availability structure
+     */
     availability?: HierarchyWithFields<AvailabilityHierarchyModel>;
+    /**
+     * The configuration mapping of index fields to standard commerce fields
+     */
     fieldsMapping: CatalogFieldsMapping;
+    /**
+     * Catalogs associated to the configuration
+     */
     associatedCatalogs: IAssociatedCatalogModel[];
 }
 
 export interface IAssociatedCatalogModel {
+    /**
+     * The unique identifier of the catalog
+     */
     id: string;
+    /**
+     * The name of the catalog
+     */
     name: string;
+    /**
+     * The source containing catalog products
+     */
     sourceId?: string;
+    /**
+     * The source containing catalog availabilities
+     */
     availabilitySourceId?: string;
 }
 
 export interface BaseCatalogModel {
+    /**
+     * The unique identifier of the catalog
+     */
     id: string;
+    /**
+     * The name of the catalog
+     */
     name: string;
+    /**
+     * The description of the catalog
+     */
     description?: string;
+    /**
+     * The source containing catalog products
+     */
     sourceId?: string;
+    /**
+     * The source containing catalog availabilities
+     */
     availabilitySourceId?: string;
     /**
      * @deprecated use `sourceId` and `availabilitySourceId` instead.
@@ -53,18 +134,39 @@ export interface BaseCatalogModel {
 }
 
 export type HierarchyWithFields<T extends {fields?: string[]}> = Omit<T, 'fields'> & {
+    /**
+     * Fields for a specific object type
+     */
     fields: string[];
 };
 
 interface Cached<T> {
+    /**
+     * Cached items
+     */
     item: T;
+    /**
+     * Cache last updated timestamp
+     */
     lastUpdated: number;
+    /**
+     * Cache next update timestamp
+     */
     nextUpdate: number;
 }
 
 interface CatalogFieldsModel {
+    /**
+     * Fields for the product object type
+     */
     productFields: string[];
+    /**
+     * Fields for the variant object type
+     */
     variantFields: string[];
+    /**
+     * Fields for the availability object type
+     */
     availabilityFields: string[];
 }
 
@@ -85,7 +187,13 @@ export interface CatalogModel extends BaseCatalogModel {
     availability?: HierarchyWithFields<AvailabilityHierarchyModel>;
 
     // Have to be optional for backward compatibility.
+    /**
+     * The related catalog configuration id
+     */
     catalogConfigurationId?: string;
+    /**
+     * The catalog configuration
+     */
     configuration?: CatalogConfigurationModel;
 }
 
@@ -106,19 +214,43 @@ export type CreateCatalogModel = BaseCatalogModel &
     );
 
 export interface FieldsSuggestionsQueryModel {
+    /**
+     * Source names for which to retrieve product and variant field suggestions
+     */
     sourceNames: string[];
+    /**
+     * Source names for which to retrievee availability field suggestions
+     */
     availabilitySourceNames?: string[];
+    /**
+     * The product object type
+     */
     productObjectType: string;
+    /**
+     * The variant object type
+     */
     variantObjectType?: string;
+    /**
+     * The availability object type
+     */
     availabilityObjectType?: string;
 }
 
 export interface FieldsSuggestionsModel {
+    /**
+     * List of field suggestions
+     */
     fields: FieldSuggestions[];
 }
 
 export interface FieldSuggestions {
+    /**
+     * Suggested field name
+     */
     name: string;
+    /**
+     * Example values for the field
+     */
     examples: string[];
 }
 
@@ -127,7 +259,13 @@ export interface ProductHierarchyModel {
      * @deprecated `fields` will be ignored by the service on creation or update, but is kept for backward compatibility.
      */
     fields?: string[];
+    /**
+     * Field used as the unique product identifier
+     */
     idField: string;
+    /**
+     * Product object type
+     */
     objectType: string;
 }
 
@@ -138,24 +276,42 @@ export interface VariantHierarchyModel {
      * @deprecated `fields` will be ignored by the service on creation or update, but is kept for backward compatibility.
      */
     fields: string[];
+    /**
+     * Field used as the unique variant identifier
+     */
     idField: string;
+    /**
+     * Variant object type
+     */
     objectType: string;
 }
 
 export type CreateVariantHierarchyModel = VariantHierarchyModel;
 
 export interface AvailabilityHierarchyModel {
+    /**
+     * Field used to contain the list of SKUs for an availability
+     */
     availableSkusField: string;
     /**
      * @deprecated `fields` will be ignored by the service on creation or update, but is kept for backward compatibility.
      */
     fields: string[];
+    /**
+     * Field used as the unique availability identifier
+     */
     idField?: string;
+    /**
+     * Availability object type
+     */
     objectType: string;
 }
 
 export type CreateAvailabilityHierarchyModel = AvailabilityHierarchyModel & {
     // Override `idField` to make it required
+    /**
+     * Field used as the unique availability identifier
+     */
     idField: string;
 };
 

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -36,6 +36,8 @@ export interface CatalogConfigurationModel {
 export interface IAssociatedCatalogModel {
     id: string;
     name: string;
+    sourceId?: string;
+    availabilitySourceId?: string;
 }
 
 export interface BaseCatalogModel {


### PR DESCRIPTION
adding sourceId availabilitySourceId to catalog configuration associated models [COM-1052]

COM-1052

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-1052]: https://coveord.atlassian.net/browse/COM-1052