### PR TITLE
feat(licenseapi): added call to list possible source types

### DIFF
--- a/src/resources/License/License.ts
+++ b/src/resources/License/License.ts
@@ -1,6 +1,6 @@
 import {LicenseSection} from '../Enums';
 import Resource from '../Resource';
-import {LicenseModel} from './LicenseInterfaces';
+import {LicenseModel, LicenseSourceTypeModel} from './LicenseInterfaces';
 import API from '../../APICore';
 
 export default class License extends Resource {
@@ -20,5 +20,9 @@ export default class License extends Resource {
 
     updateLicense(license: LicenseModel) {
         return this.api.put<LicenseModel>(License.baseUrl, license);
+    }
+
+    getPossibleSourceTypes() {
+        return this.api.get<LicenseSourceTypeModel[]>(`${License.baseUrl}/sourcetypes`);
     }
 }

--- a/src/resources/License/LicenseInterfaces.ts
+++ b/src/resources/License/LicenseInterfaces.ts
@@ -25,3 +25,14 @@ export interface LicenseModel {
     expirationDate: number;
     type: string;
 }
+
+/**
+ * Simplified version of a License's LicenseConnectorModel
+ * Mostly used to list what's possible, compared to a license who will itself only list what's enabled
+ */
+export interface LicenseSourceTypeModel {
+    /**
+     * Type of Source, e.g.CATALOG, PUSH, WEB, SALESFORCE etc.
+     */
+    type: string;
+}

--- a/src/resources/License/tests/License.spec.ts
+++ b/src/resources/License/tests/License.spec.ts
@@ -60,4 +60,12 @@ describe('License', () => {
             });
         });
     });
+
+    describe('getPossibleSourceTypes', () => {
+        it('should make a GET call to the specific License url', () => {
+            license.getPossibleSourceTypes();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith('/rest/organizations/{organizationName}/license/sourcetypes');
+        });
+    });
 });


### PR DESCRIPTION
added call to list possible source types

FOUND-3547

Juste pour être sûr, si j'ai bien compris:
* Les licenses sont déjà une ressource qui existe et on export * dans le index.ts faique pas besoin de faire de quoi de spécial pour un nouveau call/model
* ${API.orgPlaceholder} est magique et j'ai pas besoin de passer l'orgId en param

### Acceptance Criteria

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
