### PR TITLE
feat(search-interfaces): add sortCriteria interface

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -43,6 +43,12 @@ export enum SortingOrder {
     DESC = 'DESC',
 }
 
+export enum SortingBy {
+    RELEVANCY = 'relevancy',
+    DATE = 'date',
+    FIELD = 'field',
+}
+
 export enum OperationType {
     REBUILD = 'REBUILD',
     FULL_REFRESH = 'FULL_REFRESH',

--- a/src/resources/SearchInterfaces/SearchInterfaces.model.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.model.ts
@@ -1,3 +1,5 @@
+import {SortingBy, SortingOrder} from '../Enums';
+
 export interface IAccesses {
     /**
      * The list of users that are allowed to access the search interface.
@@ -22,6 +24,32 @@ export interface IFacet {
     label: string;
 }
 
+export interface ISortCriteria {
+    /**
+     * Indicates the kind of sort criterion.
+     */
+    by: SortingBy;
+
+    /**
+     * Label of the sort criterion.
+     */
+    label: string;
+
+    /**
+     * Specify the sort order if applicable.
+     * Default value when sorting by date is descending.
+     * Default value when sorting by field is ascending.
+     * No sort order value is applicable when sorting by relevancy.
+     */
+    sort?: SortingOrder;
+
+    /**
+     * The [field](https://docs.coveo.com/en/200) on which the sort is based on.
+     * Required when sorting by field.
+     */
+    field?: string;
+}
+
 export interface ISearchInterfaceConfiguration {
     /**
      * The configuration identifier.
@@ -42,6 +70,11 @@ export interface ISearchInterfaceConfiguration {
      * The List of facets to display in the search interface.
      */
     facets: IFacet[];
+
+    /**
+     * The list of sorts to display in the search interface.
+     */
+    sortCriteria: ISortCriteria[];
 
     /**
      * The public access configuration.

--- a/src/resources/SearchInterfaces/SearchInterfaces.model.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.model.ts
@@ -44,8 +44,9 @@ export interface ISortCriteria {
     order?: SortingOrder;
 
     /**
-     * The [field](https://docs.coveo.com/en/200) on which the sort is based on.
+     * The [field](https://docs.coveo.com/en/200) on which the sort is based on. For example: filetype.
      * Required when sorting by field.
+     * This property is ignored unless you are sorting by field.
      */
     field?: string;
 }

--- a/src/resources/SearchInterfaces/SearchInterfaces.model.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.model.ts
@@ -41,7 +41,7 @@ export interface ISortCriteria {
      * Default value when sorting by field is ascending.
      * No sort order value is applicable when sorting by relevancy.
      */
-    sort?: SortingOrder;
+    order?: SortingOrder;
 
     /**
      * The [field](https://docs.coveo.com/en/200) on which the sort is based on.

--- a/src/resources/SearchInterfaces/tests/SearchInterfaces.spec.ts
+++ b/src/resources/SearchInterfaces/tests/SearchInterfaces.spec.ts
@@ -1,5 +1,6 @@
 import API from '../../../APICore';
 import {New} from '../../../Entry';
+import {SortingBy, SortingOrder} from '../../Enums';
 import SearchInterfaces from '../SearchInterfaces';
 import {ISearchInterfaceConfiguration} from '../SearchInterfaces.model';
 
@@ -23,6 +24,23 @@ describe('SearchInterfaces', () => {
             {
                 field: 'someotherfield',
                 label: 'Some Other Field',
+            },
+        ],
+        sortCriteria: [
+            {
+                by: SortingBy.RELEVANCY,
+                label: 'label',
+            },
+            {
+                by: SortingBy.DATE,
+                label: 'labelx',
+                order: SortingOrder.DESC,
+            },
+            {
+                by: SortingBy.FIELD,
+                label: 'fieldlabel',
+                order: SortingOrder.ASC,
+                field: 'field',
             },
         ],
         accesses: {


### PR DESCRIPTION
Story: https://coveord.atlassian.net/browse/ADUI-7033

Update the interfaces to includes now a `ISortCriteria` interface, a `SortingBy `enum and update the `ISearchInterfaceConfiguration` interface to include the `ISortCriteria[]` parameter. 

This change should be included in this [story](https://coveord.atlassian.net/browse/SPAAS-698) before merging.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
