### PR TITLE
refactor(organizationmembers): +getall +delete member api calls

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -5,6 +5,7 @@ export enum AuthProvider {
     OFFICE365 = 'OFFICE365',
     SAML = 'SAML',
     EMAIL = 'EMAIL',
+    OTHER = 'OTHER',
 }
 
 export enum SecurityCacheStateOptions {

--- a/src/resources/Organizations/Members/Members.ts
+++ b/src/resources/Organizations/Members/Members.ts
@@ -1,0 +1,15 @@
+import API from '../../../APICore';
+import Resource from '../../Resource';
+import {OrganizationMemberModel} from './MembersInterface';
+
+export default class Members extends Resource {
+    static baseUrl = `/rest/organization/${API.orgPlaceholder}/members`;
+
+    getAll() {
+        return this.api.get<OrganizationMemberModel>(Members.baseUrl);
+    }
+
+    delete(username: string) {
+        return this.api.delete<void>(`${Members.baseUrl}/${username}`);
+    }
+}

--- a/src/resources/Organizations/Members/MembersInterface.ts
+++ b/src/resources/Organizations/Members/MembersInterface.ts
@@ -1,0 +1,39 @@
+import {AuthProvider} from '../../Enums';
+
+export interface OrganizationMemberModel {
+    /**
+     * The display name of the member
+     */
+    displayName: string;
+    /**
+     * The email address of the member
+     */
+    email: string;
+    /**
+     * The groups the member is a part of
+     */
+    groups: OrganizationMemberGroupModel[];
+    /**
+     * The provider of the member
+     */
+    provider: AuthProvider;
+    /**
+     * The username used for the assigned provider
+     */
+    providerUsername: string;
+    /**
+     * The username of the member
+     */
+    username: string;
+}
+
+export interface OrganizationMemberGroupModel {
+    /**
+     * The display name of the group
+     */
+    displayName: string;
+    /**
+     * The id of the group
+     */
+    id: string;
+}

--- a/src/resources/Organizations/Members/index.ts
+++ b/src/resources/Organizations/Members/index.ts
@@ -1,0 +1,2 @@
+export * from './Members';
+export * from './MembersInterface';

--- a/src/resources/Organizations/Members/tests/Members.spec.ts
+++ b/src/resources/Organizations/Members/tests/Members.spec.ts
@@ -1,0 +1,35 @@
+import API from '../../../../APICore';
+import Members from '../Members';
+
+jest.mock('../../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('Members', () => {
+    let members: Members;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        members = new Members(api, serverlessApi);
+    });
+
+    describe('getAll', () => {
+        it('makes a GET call to the specific members url', () => {
+            members.getAll();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(Members.baseUrl);
+        });
+    });
+
+    describe('delete', () => {
+        it('make a DELETE call to the specific member url', () => {
+            members.delete('Gael');
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${Members.baseUrl}/Gael`);
+        });
+    });
+});

--- a/src/resources/Organizations/Organization.ts
+++ b/src/resources/Organizations/Organization.ts
@@ -1,6 +1,7 @@
 import API from '../../APICore';
 import {PageModel, PrivilegeModel} from '../BaseInterfaces';
 import Resource from '../Resource';
+import Members from './Members/Members';
 import {
     CreateOrganizationOptions,
     DefinitionModel,
@@ -15,6 +16,13 @@ export type NoPagination = undefined | null;
 
 export default class Organization extends Resource {
     static baseUrl = '/rest/organizations';
+    members: Members;
+
+    constructor(protected api: API, protected serverlessApi: API) {
+        super(api, serverlessApi);
+
+        this.members = new Members(api, serverlessApi);
+    }
 
     list(noPagination?: NoPagination): Promise<OrganizationModel[]>;
     list<T extends ListOrganizationOptions>(

--- a/src/resources/Organizations/index.ts
+++ b/src/resources/Organizations/index.ts
@@ -1,2 +1,3 @@
 export * from './Organization';
 export * from './OrganizationInterfaces';
+export * from './Members';

--- a/src/resources/Organizations/tests/Organizations.spec.ts
+++ b/src/resources/Organizations/tests/Organizations.spec.ts
@@ -1,4 +1,5 @@
 import API from '../../../APICore';
+import Members from '../Members/Members';
 import Organization from '../Organization';
 import {DefinitionModel} from '../OrganizationInterfaces';
 
@@ -159,5 +160,10 @@ describe('Organization', () => {
                 );
             });
         });
+    });
+
+    it('registers the members resource', () => {
+        expect(organization.members).toBeDefined();
+        expect(organization.members).toBeInstanceOf(Members);
     });
 });

--- a/src/resources/SearchUsageMetrics/LicenseMetrics/LicenseMetricsInterface.ts
+++ b/src/resources/SearchUsageMetrics/LicenseMetrics/LicenseMetricsInterface.ts
@@ -1,18 +1,36 @@
 export interface RestListOfMetricsModel {
+    /**
+     * The list of metrics
+     */
     metrics: RestMetricsModel[];
 }
 
 export interface RestMetricsModel {
+    /**
+     * The id of the metric
+     */
     id: string;
-    label: string;
+    /**
+     * The display name of the metric
+     */
+    label?: string;
 }
 
 export interface RestListOfMetricValues {
+    /**
+     * The list of daily metric values
+     */
     values: RestMetricValueForDate[];
 }
 
 export interface RestMetricValueForDate {
+    /**
+     * The date for the usage metric value
+     */
     date: string;
+    /**
+     * The numeric metric value
+     */
     value: number;
 }
 

--- a/src/resources/SearchUsageMetrics/tests/SearchUsageMetrics.spec.ts
+++ b/src/resources/SearchUsageMetrics/tests/SearchUsageMetrics.spec.ts
@@ -16,7 +16,7 @@ describe('SearchUsageMetrics', () => {
         searchUsageMetrics = new SearchUsageMetrics(api, serverlessApi);
     });
 
-    it('registers the administration resource', () => {
+    it('registers the licenseMetrics resource', () => {
         expect(searchUsageMetrics.licenseMetrics).toBeDefined();
         expect(searchUsageMetrics.licenseMetrics).toBeInstanceOf(LicenseMetrics);
     });


### PR DESCRIPTION
Blocking a feature, this refactor (which is overdue anyway) will help us having a simpler and more
unified api

*** I've added JSDoc on previous pr that I forgot to add :shame: and change a param to an optional one 
https://github.com/coveo/platform-client/pull/318

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
