### PR TITLE
fix(members.ts): getAll returns an array, not a single object

### DIFF
--- a/src/resources/Organizations/Members/Members.ts
+++ b/src/resources/Organizations/Members/Members.ts
@@ -6,7 +6,7 @@ export default class Members extends Resource {
     static baseUrl = `/rest/organization/${API.orgPlaceholder}/members`;
 
     getAll() {
-        return this.api.get<OrganizationMemberModel>(Members.baseUrl);
+        return this.api.get<OrganizationMemberModel[]>(Members.baseUrl);
     }
 
     delete(username: string) {


### PR DESCRIPTION
there was an error on the implementation

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
