### PR TITLE
chore: allow named export of resources

### DIFF
--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -20,7 +20,7 @@ import {
     ValidateAccessOptions,
 } from './ResourceSnapshotsInterfaces';
 
-export default class ResourceSnapshots extends Resource {
+export class ResourceSnapshots extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/snapshots`;
 
     list() {
@@ -140,3 +140,5 @@ export default class ResourceSnapshots extends Resource {
         );
     }
 }
+
+export default ResourceSnapshots;


### PR DESCRIPTION
None of the resources can be imported using the following syntax
![image](https://user-images.githubusercontent.com/12199712/120224344-4a32ae00-c211-11eb-8db6-bada2d2066d3.png)
Instead, you need to import it from the definition file.
![image](https://user-images.githubusercontent.com/12199712/120224405-62a2c880-c211-11eb-87f0-cdbd4e4494b0.png)

I just added an extra export in the ResourceSnapshot class so the class can also be available directly from the `@coveord/platform-client`.
**If that's fine, I can apply the same logic to other resources.**

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
