### PR TITLE
feat(statement-groups): add `filter` param to listing endpoint

### DIFF
--- a/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
+++ b/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
@@ -36,8 +36,22 @@ export interface StatementGroupComposition {
 }
 
 export interface ListStatementGroupsOptions {
+    /**
+     * The 0-based number of the page of results to get.
+     */
     page?: number;
+
+    /**
+     * The number of results to include per page.
+     */
     perPage?: number;
+
+    /**
+     * The query filter to match.
+     *
+     * This allows you to search within group name, group user notes and condition definition.
+     */
+    filter?: string;
 }
 
 export interface CreateStatementGroupModel {

--- a/src/resources/Pipelines/StatementGroups/tests/StatementGroups.spec.ts
+++ b/src/resources/Pipelines/StatementGroups/tests/StatementGroups.spec.ts
@@ -25,6 +25,16 @@ describe('StatementGroups', () => {
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(StatementGroups.getBaseUrl(pipelineId));
         });
+
+        it('should make a GET call with a filter', () => {
+            const pipelineId = '️🍰';
+            const filter = 'nameOfCondition';
+            groups.list(pipelineId, {filter});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                '/rest/search/v2/admin/pipelines/️🍰/statementGroups?filter=nameOfCondition'
+            );
+        });
     });
 
     describe('create', () => {


### PR DESCRIPTION
Add a new `filter` param that allow to filter statement groups by searching for: group name,
condition content or user notes.

https://coveord.atlassian.net/browse/SEARCHAPI-5828

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
