### PR TITLE
feat(filters): support for permission filters

### DIFF
--- a/src/resources/UsageAnalytics/Read/Filters/Filters.ts
+++ b/src/resources/UsageAnalytics/Read/Filters/Filters.ts
@@ -5,6 +5,7 @@ import {
     CreateReportingFilterModel,
     CreateReportingFilterResponse,
     FilterModel,
+    FilterResponse,
     FilterServiceHealthResponse,
     FilterServiceStatusResponse,
     FilterTargetsModel,
@@ -35,7 +36,7 @@ export default class Filters extends Resource {
      * Get a reporting filter
      */
     getReportFilter(id: string) {
-        return this.api.get<FilterModel>(
+        return this.api.get<FilterResponse>(
             this.buildPath(`${Filters.reportingBaseUrl}/${id}`, {org: this.api.organizationId})
         );
     }
@@ -80,7 +81,7 @@ export default class Filters extends Resource {
      * Get a permission filter
      */
     getPermissionFilter(id: string) {
-        return this.api.get<FilterModel>(
+        return this.api.get<FilterResponse>(
             this.buildPath(`${Filters.permissionsBaseUrl}/${id}`, {org: this.api.organizationId})
         );
     }

--- a/src/resources/UsageAnalytics/Read/Filters/Filters.ts
+++ b/src/resources/UsageAnalytics/Read/Filters/Filters.ts
@@ -1,9 +1,18 @@
 import Resource from '../../../Resource';
 import {
+    CreatePermissionsFilterModel,
+    CreatePermissionsFilterResponse,
     CreateReportingFilterModel,
     CreateReportingFilterResponse,
     FilterModel,
+    FilterServiceHealthResponse,
+    FilterServiceStatusResponse,
+    FilterTargetsModel,
+    FilterTargetsResponse,
     ListFiltersResponse,
+    PermissionsFilterUser,
+    UpdatePermissionsFilterModel,
+    UpdatePermissionsFilterResponse,
     UpdateReportingFilterModel,
     UpdateReportingFilterResponse,
 } from './FiltersInterfaces';
@@ -11,6 +20,7 @@ import {
 export default class Filters extends Resource {
     static baseUrl = '/rest/ua/v15/filters';
     static reportingBaseUrl = `${Filters.baseUrl}/reporting`;
+    static permissionsBaseUrl = `${Filters.baseUrl}/permissions`;
 
     /**
      * Get all reporting filters
@@ -35,7 +45,7 @@ export default class Filters extends Resource {
      */
     createReportFilter(filter: CreateReportingFilterModel) {
         return this.api.post<CreateReportingFilterResponse>(
-            this.buildPath(`${Filters.reportingBaseUrl}`, {org: this.api.organizationId}),
+            this.buildPath(Filters.reportingBaseUrl, {org: this.api.organizationId}),
             filter
         );
     }
@@ -55,5 +65,98 @@ export default class Filters extends Resource {
      */
     deleteReportFilter(id: string) {
         return this.api.delete(this.buildPath(`${Filters.reportingBaseUrl}/${id}`, {org: this.api.organizationId}));
+    }
+
+    /**
+     * Get all permission filters
+     */
+    listPermissionFilters() {
+        return this.api.get<ListFiltersResponse>(
+            this.buildPath(Filters.permissionsBaseUrl, {org: this.api.organizationId})
+        );
+    }
+
+    /**
+     * Get a permission filter
+     */
+    getPermissionFilter(id: string) {
+        return this.api.get<FilterModel>(
+            this.buildPath(`${Filters.permissionsBaseUrl}/${id}`, {org: this.api.organizationId})
+        );
+    }
+
+    /**
+     * Create a permission filter
+     */
+    createPermissionFilter(filter: CreatePermissionsFilterModel) {
+        return this.api.post<CreatePermissionsFilterResponse>(
+            this.buildPath(Filters.permissionsBaseUrl, {org: this.api.organizationId}),
+            filter
+        );
+    }
+
+    /**
+     * Update a permission filter
+     */
+    updatePermissionFilter(id: string, filter: UpdatePermissionsFilterModel) {
+        return this.api.put<UpdatePermissionsFilterResponse>(
+            this.buildPath(`${Filters.permissionsBaseUrl}/${id}`, {org: this.api.organizationId}),
+            filter
+        );
+    }
+
+    /**
+     * Delete a permission filter
+     */
+    deletePermissionFilter(id: string) {
+        return this.api.delete(this.buildPath(`${Filters.permissionsBaseUrl}/${id}`, {org: this.api.organizationId}));
+    }
+
+    /**
+     * Get the users of a permission filters
+     */
+    getPermissionFilterUsers(id: string) {
+        return this.api.get<PermissionsFilterUser[]>(this.buildPath(`${Filters.permissionsBaseUrl}/${id}/users`, {}));
+    }
+
+    /**
+     * Set the users of a permission filter
+     */
+    updatePermissionFilterUsers(id: string, users: string[]) {
+        return this.api.put(
+            this.buildPath(`${Filters.permissionsBaseUrl}/${id}/users`, {org: this.api.organizationId}),
+            users
+        );
+    }
+
+    /**
+     * Get the targets of a permission filters
+     */
+    getPermissionFilterTargets(id: string) {
+        return this.api.get<PermissionsFilterUser[]>(this.buildPath(`${Filters.permissionsBaseUrl}/${id}/targets`, {}));
+    }
+
+    /**
+     * Set the targets of a permission filter
+     */
+    updatePermissionFilterTargets(id: string, targets: FilterTargetsModel) {
+        return this.api.put<FilterTargetsResponse>(
+            this.buildPath(`${Filters.permissionsBaseUrl}/${id}/targets`, {org: this.api.organizationId}),
+            targets
+        );
+    }
+
+    /**
+     * Health check for the filter service
+     */
+    healthcheck() {
+        return this.api.get<FilterServiceHealthResponse>(`${Filters.baseUrl}/monitoring/health`);
+    }
+
+    /**
+     * Get the filter service status
+     */
+    status() {
+        return this.api.get<FilterServiceStatusResponse>(`${Filters.baseUrl}/status`);
     }
 }

--- a/src/resources/UsageAnalytics/Read/Filters/FiltersInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Filters/FiltersInterfaces.ts
@@ -1,3 +1,5 @@
+import {GroupResponse, UserResponse} from '../Reports';
+
 export interface FilterModel {
     /** The display name of the filter. */
     displayName: string;
@@ -29,7 +31,61 @@ export type CreateReportingFilterResponse = Pick<FilterResponse, 'id'>;
 export type UpdateReportingFilterModel = CreateReportingFilterModel;
 export type UpdateReportingFilterResponse = CreateReportingFilterResponse;
 
+export type CreatePermissionsFilterModel = FilterModel;
+export type CreatePermissionsFilterResponse = Pick<FilterResponse, 'id'>;
+
+export type UpdatePermissionsFilterModel = CreatePermissionsFilterModel;
+export type UpdatePermissionsFilterResponse = CreatePermissionsFilterResponse;
+
 export interface ListFiltersResponse {
     /** A list of filters */
     filters: FilterModel[];
+}
+
+export interface PermissionsFilterUser {
+    /** The user id. */
+    userId: string;
+
+    /** The account. */
+    account: string;
+
+    /** Permissions for the user */
+    permissions: PermissionsFilterUserPermissions[];
+
+    /** Related reports */
+    reportIds: unknown[];
+}
+
+export interface PermissionsFilterUserPermissions {
+    /** The permission filter. */
+    permission: string;
+
+    /** Whether the permission field is the unique ID. */
+    filterId: boolean;
+}
+
+export interface FilterTargetsModel {
+    /** The ids of the users targeted by the filter. */
+    targetedUsers: string[];
+
+    /** The ids of the groups targeted by the filter. */
+    targetedGroups: string[];
+}
+
+export interface FilterTargetsResponse {
+    /** The users targeted by the filter. */
+    targetedUsers: UserResponse[];
+
+    /** The groups targeted by the filter. */
+    targetedGroups: GroupResponse[];
+}
+
+export interface FilterServiceHealthResponse {
+    /** The health of the service */
+    status: 'UP' | 'DOWN';
+}
+
+export interface FilterServiceStatusResponse {
+    /** The status of the service */
+    status: 'online' | 'offline';
 }

--- a/src/resources/UsageAnalytics/Read/Filters/tests/Filters.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Filters/tests/Filters.spec.ts
@@ -1,6 +1,12 @@
 import API from '../../../../../APICore';
 import Filters from '../Filters';
-import {CreateReportingFilterModel, UpdateReportingFilterModel} from '../FiltersInterfaces';
+import {
+    CreatePermissionsFilterModel,
+    CreateReportingFilterModel,
+    FilterTargetsModel,
+    UpdatePermissionsFilterModel,
+    UpdateReportingFilterModel,
+} from '../FiltersInterfaces';
 
 jest.mock('../../../../../APICore');
 
@@ -65,6 +71,125 @@ describe('Filters', () => {
                 expect(api.delete).toHaveBeenCalledTimes(1);
                 expect(api.delete).toHaveBeenCalledWith(`${Filters.reportingBaseUrl}/${testFilterId}`);
             });
+        });
+    });
+
+    describe('Permission filters', () => {
+        describe('list', () => {
+            it('should make a GET call to the permission filter base url', () => {
+                filters.listPermissionFilters();
+
+                expect(api.get).toHaveBeenCalledTimes(1);
+                expect(api.get).toHaveBeenCalledWith(Filters.permissionsBaseUrl);
+            });
+        });
+
+        describe('get', () => {
+            it('should make a GET call to the permission filter base url for the specific ID', () => {
+                filters.getPermissionFilter(testFilterId);
+
+                expect(api.get).toHaveBeenCalledTimes(1);
+                expect(api.get).toHaveBeenCalledWith(`${Filters.permissionsBaseUrl}/${testFilterId}`);
+            });
+        });
+
+        describe('create', () => {
+            it('should make a POST call to the permission filter base url for the specific ID', () => {
+                const filter: CreatePermissionsFilterModel = {displayName: 'test', value: 'filter'};
+
+                filters.createPermissionFilter(filter);
+
+                expect(api.post).toHaveBeenCalledTimes(1);
+                expect(api.post).toHaveBeenCalledWith(`${Filters.permissionsBaseUrl}`, filter);
+            });
+        });
+
+        describe('update', () => {
+            it('should make a PUT call to the permission filter base url for the specific ID', () => {
+                const filter: UpdatePermissionsFilterModel = {displayName: 'test', value: 'filter'};
+
+                filters.updatePermissionFilter(testFilterId, filter);
+
+                expect(api.put).toHaveBeenCalledTimes(1);
+                expect(api.put).toHaveBeenCalledWith(`${Filters.permissionsBaseUrl}/${testFilterId}`, filter);
+            });
+        });
+
+        describe('delete', () => {
+            it('should make a DELETE call to the permission filter base url for the specific ID', () => {
+                filters.deletePermissionFilter(testFilterId);
+
+                expect(api.delete).toHaveBeenCalledTimes(1);
+                expect(api.delete).toHaveBeenCalledWith(`${Filters.permissionsBaseUrl}/${testFilterId}`);
+            });
+        });
+
+        describe('Filter users', () => {
+            describe('get', () => {
+                it('should make a GET call to the permission filter users url for the specific ID', () => {
+                    filters.getPermissionFilterUsers(testFilterId);
+
+                    expect(api.get).toHaveBeenCalledTimes(1);
+                    expect(api.get).toHaveBeenCalledWith(`${Filters.permissionsBaseUrl}/${testFilterId}/users`);
+                });
+            });
+
+            describe('update', () => {
+                it('should make a PUT call to the permission filter users url for the specific ID', () => {
+                    const users = ['user.one@example.com', 'user.two@example.com'];
+
+                    filters.updatePermissionFilterUsers(testFilterId, users);
+
+                    expect(api.put).toHaveBeenCalledTimes(1);
+                    expect(api.put).toHaveBeenCalledWith(`${Filters.permissionsBaseUrl}/${testFilterId}/users`, users);
+                });
+            });
+        });
+
+        describe('Filter targets', () => {
+            describe('get', () => {
+                it('should make a GET call to the permission filter targets url for the specific ID', () => {
+                    filters.getPermissionFilterTargets(testFilterId);
+
+                    expect(api.get).toHaveBeenCalledTimes(1);
+                    expect(api.get).toHaveBeenCalledWith(`${Filters.permissionsBaseUrl}/${testFilterId}/targets`);
+                });
+            });
+
+            describe('update', () => {
+                it('should make a PUT call to the permission filter targets url for the specific ID', () => {
+                    const filterTargets: FilterTargetsModel = {
+                        targetedUsers: [],
+                        targetedGroups: [],
+                    };
+
+                    filters.updatePermissionFilterTargets(testFilterId, filterTargets);
+
+                    expect(api.put).toHaveBeenCalledTimes(1);
+                    expect(api.put).toHaveBeenCalledWith(
+                        `${Filters.permissionsBaseUrl}/${testFilterId}/targets`,
+                        filterTargets
+                    );
+                });
+            });
+        });
+    });
+
+    describe('healthcheck', () => {
+        it('should make a GET call to the service healthcheck url', () => {
+            filters.healthcheck();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Filters.baseUrl}/monitoring/health`);
+        });
+    });
+
+    describe('status', () => {
+        it('should make a GET call to the service status url', () => {
+            filters.status();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Filters.baseUrl}/status`);
         });
     });
 });


### PR DESCRIPTION
functionality for the Filters API including permissions filters as well as healthcheck and status
calls

edit: also includes a fix commit for the return type of `getReportFilter`

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
