### PR TITLE
fix(filters): update return types on permission filter target endpoints

### DIFF
--- a/src/resources/UsageAnalytics/Read/Filters/Filters.ts
+++ b/src/resources/UsageAnalytics/Read/Filters/Filters.ts
@@ -117,7 +117,7 @@ export default class Filters extends Resource {
      * Get the users of a permission filters
      */
     getPermissionFilterUsers(id: string) {
-        return this.api.get<PermissionsFilterUser[]>(this.buildPath(`${Filters.permissionsBaseUrl}/${id}/users`, {}));
+        return this.api.get<PermissionsFilterUser[]>(`${Filters.permissionsBaseUrl}/${id}/users`);
     }
 
     /**
@@ -134,14 +134,14 @@ export default class Filters extends Resource {
      * Get the targets of a permission filters
      */
     getPermissionFilterTargets(id: string) {
-        return this.api.get<PermissionsFilterUser[]>(this.buildPath(`${Filters.permissionsBaseUrl}/${id}/targets`, {}));
+        return this.api.get<FilterTargetsResponse[]>(`${Filters.permissionsBaseUrl}/${id}/targets`);
     }
 
     /**
      * Set the targets of a permission filter
      */
     updatePermissionFilterTargets(id: string, targets: FilterTargetsModel) {
-        return this.api.put<FilterTargetsResponse>(
+        return this.api.put(
             this.buildPath(`${Filters.permissionsBaseUrl}/${id}/targets`, {org: this.api.organizationId}),
             targets
         );


### PR DESCRIPTION
return types for getPermissionFilterTargets and updatePermissionFilterTargets updated to reflect Swagger docs. getPermissionFilterTargets returns FilterTargetsResponse and updatePermissionFilterTargets returns only a status code without a body.

BREAKING CHANGE: incompatible type changes

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
