### PR TITLE
feat(result-rankings): add copyTo method

### DIFF
--- a/src/resources/Catalogs/CatalogConfiguration.ts
+++ b/src/resources/Catalogs/CatalogConfiguration.ts
@@ -1,7 +1,11 @@
 import API from '../../APICore';
 import {New, PageModel} from '../BaseInterfaces';
 import Resource from '../Resource';
-import {CatalogConfigurationModel, CreateCatalogConfigurationModel, CatalogConfigurationsListOptions} from './CatalogInterfaces';
+import {
+    CatalogConfigurationModel,
+    CreateCatalogConfigurationModel,
+    CatalogConfigurationsListOptions,
+} from './CatalogInterfaces';
 
 export default class CatalogConfiguration extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/catalogconfigurations`;

--- a/src/resources/Pipelines/ResultRankings/ResultRankings.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankings.ts
@@ -1,5 +1,7 @@
 import Resource from '../../Resource';
 import {
+    CopyResultRankingRequest,
+    CopyResultRankingResponse,
     ListResultRankingParams,
     ListResultRankingResponse,
     ResultRanking,
@@ -82,6 +84,15 @@ export default class ResultRankings extends Resource {
             this.buildPath(`${ResultRankings.getBaseUrl(pipelineId)}/duplicate/${resultRankingsId}`, {
                 organizationId: this.api.organizationId,
             })
+        );
+    }
+
+    copyTo(pipelineId: string, copyResultRankingRequest: CopyResultRankingRequest) {
+        return this.api.post<CopyResultRankingResponse>(
+            this.buildPath(`${ResultRankings.getBaseUrl(pipelineId)}/copy`, {
+                organizationId: this.api.organizationId,
+            }),
+            copyResultRankingRequest
         );
     }
 }

--- a/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
@@ -147,3 +147,32 @@ export interface ListResultRankingParams {
     ruleTypes?: ResultRankingsRuleTypes[];
     ruleStatuses?: ResultRankingsStatuses[];
 }
+
+export interface CopyResultRankingRequest {
+    /**
+     * The unique identifier of the query pipeline to copy the statements to
+     */
+    destinationPipelineId: string;
+
+    /**
+     * The unique identifiers of the result ranking rules to copy.
+     */
+    resultRankingIds: string[];
+}
+
+export interface CopyResultRankingResponse {
+    /**
+     * The list of result rankings that were copied to the destination pipeline.
+     */
+    resultRankings: Array<{
+        /**
+         * The identifier of the result ranking rule
+         */
+        id: string;
+
+        /**
+         * The result ranking rule content.
+         */
+        resultRanking: ResultRankingProps;
+    }>;
+}

--- a/src/resources/Pipelines/ResultRankings/tests/ResultRankings.spec.ts
+++ b/src/resources/Pipelines/ResultRankings/tests/ResultRankings.spec.ts
@@ -7,7 +7,7 @@ import {
     ResultRankingsStatuses,
 } from '../../../Enums';
 import ResultRankings from '../ResultRankings';
-import {ListResultRankingParams, ResultRanking} from '../ResultRankingsInterfaces';
+import {CopyResultRankingRequest, ListResultRankingParams, ResultRanking} from '../ResultRankingsInterfaces';
 
 jest.mock('../../../../APICore');
 
@@ -178,7 +178,7 @@ describe('Result Rankings', () => {
     });
 
     describe('duplicate', () => {
-        it('should make a POST call to the specific Result Rankingsn duplicate url', () => {
+        it('should make a POST call to the specific Result Rankings duplicate url', () => {
             const pipelineId = '️a';
 
             resultRankings.duplicate(pipelineId, resultRanking.id);
@@ -186,6 +186,23 @@ describe('Result Rankings', () => {
             expect(api.post).toHaveBeenCalledWith(
                 `${ResultRankings.getBaseUrl(pipelineId)}/duplicate/${resultRanking.id}`
             );
+        });
+    });
+
+    describe('copy', () => {
+        it('should make a POST call to the specific Result Rankings copy url', () => {
+            const pipelineId = '️a';
+            const params: CopyResultRankingRequest = {
+                destinationPipelineId: 'target',
+                resultRankingIds: ['rule1', 'rule2'],
+            };
+
+            resultRankings.copyTo(pipelineId, params);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${ResultRankings.getBaseUrl(pipelineId)}/copy`, {
+                destinationPipelineId: 'target',
+                resultRankingIds: ['rule1', 'rule2'],
+            });
         });
     });
 });


### PR DESCRIPTION
Add the new `copyTo` method to allow copying a list of result rankings rules to another pipeline
https://coveord.atlassian.net/browse/SEARCHAPI-5970

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
