### PR TITLE
feat(statement-groups): update group model + add filters to listing

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -730,6 +730,28 @@ export enum StatementGroupType {
     permanent = 'permanent',
 }
 
+/**
+ * An union of all the possible status that you can filter on.
+ */
+export enum ListStatementGroupStatusType {
+    Active = 'active',
+    Inactive = 'inactive',
+    Expired = 'expired',
+    NotStarted = 'notStarted',
+}
+
+export enum CampaignStatementGroupStatusType {
+    Active = 'active',
+    Inactive = 'inactive',
+    Expired = 'expired',
+    NotStarted = 'notStarted',
+}
+
+export enum PermanentStatementGroupStatusType {
+    Active = 'active',
+    Inactive = 'inactive',
+}
+
 export enum DimensionType {
     TEXT = 'TEXT',
     NUMBER = 'NUMBER',

--- a/src/resources/Pipelines/StatementGroups/StatementGroups.ts
+++ b/src/resources/Pipelines/StatementGroups/StatementGroups.ts
@@ -1,6 +1,7 @@
 import Resource from '../../Resource';
 import {
     CreateStatementGroupModel,
+    UpdateStatementGroupModel,
     ListStatementGroupsOptions,
     StatementGroupList,
     StatementGroupModel,
@@ -18,6 +19,8 @@ export default class StatementGroups extends Resource {
             this.buildPath(StatementGroups.getBaseUrl(pipelineId), {
                 organizationId: this.api.organizationId,
                 ...options,
+                status: JSON.stringify(options?.status),
+                types: JSON.stringify(options?.types),
             })
         );
     }
@@ -37,7 +40,7 @@ export default class StatementGroups extends Resource {
         );
     }
 
-    update(pipelineId: string, groupId: string, groupModel: StatementGroupModel) {
+    update(pipelineId: string, groupId: string, groupModel: UpdateStatementGroupModel) {
         return this.api.put<void>(
             this.buildPath(StatementGroups.getStatementGroupUrl(pipelineId, groupId), {
                 organizationId: this.api.organizationId,

--- a/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
+++ b/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
@@ -1,4 +1,9 @@
-import {StatementGroupType} from '../../Enums';
+import {
+    CampaignStatementGroupStatusType,
+    ListStatementGroupStatusType,
+    PermanentStatementGroupStatusType,
+    StatementGroupType,
+} from '../../Enums';
 
 export interface StatementGroupList {
     groups: StatementGroupModel[];
@@ -6,21 +11,60 @@ export interface StatementGroupList {
     groupComposition: PipelineGroupsComposition;
 }
 
-export interface StatementGroupModel {
+export type StatementGroupModel = PermanentStatementGroup | CampaignStatementGroup;
+
+interface StatementGroupModelBase {
     id: string;
     name: string;
-    type: StatementGroupType;
-    isActive?: boolean;
-    campaignStart?: string;
-    campaignEnd?: string;
     description?: string;
     conditionId?: string;
     conditionDefinition?: string;
+
+    /**
+     * Date of creation
+     * Format: ISO-8601
+     * @example 2021-09-09T19:00:45.603-04:00
+     */
     createdAt: string;
     createdBy?: string;
+
+    /**
+     * Last date of modification
+     * Format: ISO-8601
+     * @example 2021-09-09T19:00:45.603-04:00
+     */
     modifiedAt?: string;
     modifiedBy?: string;
     statementComposition: StatementGroupComposition;
+}
+
+export interface PermanentStatementGroup extends StatementGroupModelBase {
+    // Discriminator
+    type: StatementGroupType.permanent;
+
+    isActive?: boolean;
+    status: PermanentStatementGroupStatusType;
+}
+
+export interface CampaignStatementGroup extends StatementGroupModelBase {
+    // Discriminator
+    type: StatementGroupType.campaign;
+
+    /**
+     * The start date of the campaign.
+     * Format: ISO-8601
+     * @example 2020-09-09T19:00:45.603-04:00
+     */
+    campaignStart?: string;
+
+    /**
+     * The end date of the campaign.
+     * Format: ISO-8601
+     * @example 2021-09-09T19:00:45.603-04:00
+     */
+    campaignEnd?: string;
+
+    status: CampaignStatementGroupStatusType;
 }
 
 export interface PipelineGroupsComposition {
@@ -52,20 +96,43 @@ export interface ListStatementGroupsOptions {
      * This allows you to search within group name, group user notes and condition definition.
      */
     filter?: string;
+
+    /**
+     * The list of group status allowed in the results.
+     * If you leave this parameter <em>undefined</em> or pass an empty array, all group's status will be allowed in the results.
+     */
+    status?: ListStatementGroupStatusType[];
+
+    /**
+     * The list of group types allowed in the results.
+     * If you leave this parameter <em>undefined</em> or pass an empty array, all group types will be allowed in the results.
+     */
+    types?: StatementGroupType[];
 }
 
 export interface CreateStatementGroupModel {
     name: string;
     type: StatementGroupType;
+
+    /**
+     * The start date of the campaign.
+     * Format: ISO-8601
+     * @example 2020-09-09T19:00:45.603-04:00
+     */
     campaignStart?: string;
+
+    /**
+     * The end date of the campaign.
+     * Format: ISO-8601
+     * @example 2021-09-09T19:00:45.603-04:00
+     */
     campaignEnd?: string;
     description?: string;
     conditionId?: string;
-}
-
-export interface UpdateStatementGroupModel extends CreateStatementGroupModel {
     isActive?: boolean;
 }
+
+export interface UpdateStatementGroupModel extends CreateStatementGroupModel {}
 
 export interface UpdateStatementGroupRuleAssociationsRequest {
     /**

--- a/src/resources/Pipelines/StatementGroups/tests/StatementGroups.spec.ts
+++ b/src/resources/Pipelines/StatementGroups/tests/StatementGroups.spec.ts
@@ -1,9 +1,9 @@
 import API from '../../../../APICore';
-import {StatementGroupType} from '../../../Enums';
+import {ListStatementGroupStatusType, StatementGroupType} from '../../../Enums';
 import StatementGroups from '../StatementGroups';
 import {
     CreateStatementGroupModel,
-    StatementGroupModel,
+    UpdateStatementGroupModel,
     StatementGroupRuleAssociationFeatureTypeEnum,
 } from '../StatementGroupsInterfaces';
 
@@ -39,6 +39,37 @@ describe('StatementGroups', () => {
                 '/rest/search/v2/admin/pipelines/️🍰/statementGroups?filter=nameOfCondition'
             );
         });
+
+        it('should make a GET call with a status filter', () => {
+            const pipelineId = '️🍰';
+            const status = [
+                ListStatementGroupStatusType.Active,
+                ListStatementGroupStatusType.Expired,
+                ListStatementGroupStatusType.Inactive,
+                ListStatementGroupStatusType.NotStarted,
+            ];
+            groups.list(pipelineId, {status});
+
+            const expectedUri = [
+                '/rest/search/v2/admin/pipelines/️🍰/statementGroups?status=',
+                encodeURIComponent(JSON.stringify(status)),
+            ].join('');
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(expectedUri);
+        });
+
+        it('should make a GET call with a status type filter', () => {
+            const pipelineId = '️🍰';
+            const types = [StatementGroupType.campaign, StatementGroupType.permanent];
+            groups.list(pipelineId, {types});
+
+            const expectedUri = [
+                '/rest/search/v2/admin/pipelines/️🍰/statementGroups?types=',
+                encodeURIComponent(JSON.stringify(types)),
+            ].join('');
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(expectedUri);
+        });
     });
 
     describe('create', () => {
@@ -47,6 +78,7 @@ describe('StatementGroups', () => {
             const model: CreateStatementGroupModel = {
                 name: '🥂',
                 type: StatementGroupType.permanent,
+                isActive: true,
             };
 
             groups.create(pipelineId, model);
@@ -67,15 +99,9 @@ describe('StatementGroups', () => {
     });
 
     describe('update', () => {
-        const group: StatementGroupModel = {
-            id: 'a',
+        const group: UpdateStatementGroupModel = {
             name: 'b',
             type: StatementGroupType.permanent,
-            createdAt: 'la',
-            statementComposition: {
-                resultRankingStatementCount: 1,
-                otherStatementCount: 2,
-            },
         };
 
         it('should make a PUT call to the specific StatementGroups url', () => {


### PR DESCRIPTION
Update the statement group model to include the status of the group. Change the update() signature
to use the updateGroupModel. Add status + types filters to the list groups endpoint

BREAKING CHANGE: groups.update() now takes a UpdateStatementGroupModel instead of a
StatementGroupModel
https://coveord.atlassian.net/browse/SEARCHAPI-6018

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
