### PR TITLE
feat(search-interfaces): add updateAccesses

### DIFF
--- a/src/resources/SearchInterfaces/SearchInterfaces.model.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.model.ts
@@ -17,7 +17,7 @@ export interface IAccesses {
     sharingLinkEnabled?: boolean;
 
     /**
-     * When set to true, the domain sharing is enabled. Otherwise, all users have access to the search page.
+     * When set to true, the domain sharing is enabled. Otherwise, only users that have explicitly access to the search page can access it.
      */
     sharingDomainEnabled?: boolean;
 }

--- a/src/resources/SearchInterfaces/SearchInterfaces.model.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.model.ts
@@ -10,6 +10,10 @@ export interface IAccesses {
      * The list of domains that are allowed to access the search interface.
      */
     domains: string[];
+
+    sharingLinkEnabled?: boolean;
+
+    sharingDomainEnabled?: boolean;
 }
 
 export interface IFacet {

--- a/src/resources/SearchInterfaces/SearchInterfaces.model.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.model.ts
@@ -11,8 +11,14 @@ export interface IAccesses {
      */
     domains: string[];
 
+    /**
+     * When set to true, all users can share and see the search page.
+     */
     sharingLinkEnabled?: boolean;
 
+    /**
+     * When set to true, the domain sharing is enabled. Otherwise, all users have access to the search page.
+     */
     sharingDomainEnabled?: boolean;
 }
 

--- a/src/resources/SearchInterfaces/SearchInterfaces.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.ts
@@ -1,7 +1,7 @@
 import API from '../../APICore';
 import {New, PageModel} from '../../Entry';
 import Resource from '../Resource';
-import {IListSearchInterfacesParameters, ISearchInterfaceConfiguration} from './SearchInterfaces.model';
+import {IAccesses, IListSearchInterfacesParameters, ISearchInterfaceConfiguration} from './SearchInterfaces.model';
 
 export default class SearchInterfaces extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/searchinterfaces`;
@@ -24,5 +24,9 @@ export default class SearchInterfaces extends Resource {
 
     delete(searchInterfaceConfigId: string) {
         return this.api.delete(`${SearchInterfaces.baseUrl}/${searchInterfaceConfigId}`);
+    }
+
+    updateAccesses(searchInterfaceConfigId: string, accesses: IAccesses): Promise<IAccesses> {
+        return this.api.put(`${SearchInterfaces.baseUrl}/${searchInterfaceConfigId}/accesses`, accesses);
     }
 }

--- a/src/resources/SearchInterfaces/tests/SearchInterfaces.spec.ts
+++ b/src/resources/SearchInterfaces/tests/SearchInterfaces.spec.ts
@@ -2,7 +2,7 @@ import API from '../../../APICore';
 import {New} from '../../../Entry';
 import {SortingBy, SortingOrder} from '../../Enums';
 import SearchInterfaces from '../SearchInterfaces';
-import {ISearchInterfaceConfiguration} from '../SearchInterfaces.model';
+import {IAccesses, ISearchInterfaceConfiguration} from '../SearchInterfaces.model';
 
 jest.mock('../../../APICore');
 
@@ -129,6 +129,22 @@ describe('SearchInterfaces', () => {
 
             expect(api.delete).toHaveBeenCalledTimes(1);
             expect(api.delete).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/${id}`);
+        });
+    });
+
+    describe('updateAccesses', () => {
+        it('makes a PUT call to the SearchInterfaces accesses url', () => {
+            const someAccesses: IAccesses = {
+                users: [],
+                domains: [],
+                sharingDomainEnabled: false,
+                sharingLinkEnabled: false,
+            };
+            const id = 'SearchInterface-id-to-update-accesses';
+            searchInterfaces.updateAccesses(id, someAccesses);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/${id}/accesses`, someAccesses);
         });
     });
 });


### PR DESCRIPTION
This story is to add the PUT call to update a search interface's accesses. I've also updated the content of the `IAccesses` model.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
