### PR TITLE
fix(migration-export-model): strongly type snapshot export model

### DIFF
--- a/src/resources/ResourceSnapshots/ResourceSnapshotsInterfaces.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshotsInterfaces.ts
@@ -92,31 +92,30 @@ export interface ResourceSnapshotsReportOperationModel {
     /**
      * The number of resources created by the operation.
      */
-    resourcesCreated: number
+    resourcesCreated: number;
     /**
      * The number of resources deleted by the operation.
      */
-    resourcesDeleted: number
+    resourcesDeleted: number;
     /**
      * The number of resources for which an error occurred during the operation.
      */
-    resourcesInError: number
+    resourcesInError: number;
     /**
      * The number of pre-existing resources recreated by the operation. This happens when a resource cannot be updated. For example, it is not possible to rename a query pipeline, so in such a case the pipeline would be deleted and created again with the desired name. This operation counts as one recreation.
      */
-    resourcesRecreated: number
+    resourcesRecreated: number;
     /**
      * The number of resources unchanged by the operation.
      */
-    resourcesUnchanged: number
+    resourcesUnchanged: number;
     /**
      * The number of resources updated by the operation.
      */
-    resourcesUpdated: number
+    resourcesUpdated: number;
 }
 
-
-export type ResourceSnapshotsReportOperationResults = Record<string, string[]>
+export type ResourceSnapshotsReportOperationResults = Record<string, string[]>;
 
 export interface ResourceSnapshotsReportModel {
     /**
@@ -199,7 +198,7 @@ export interface ResourceSnapshotsLinkModel {
 }
 
 export interface ResourceSnapshotExportConfigurationModel {
-    resourcesToExport: Record<string, unknown>;
+    resourcesToExport: Partial<Record<ResourceType, string[] | null>>;
 }
 
 export interface ResourceSnapshotUrlModel {
@@ -223,6 +222,7 @@ export interface CreateFromFileOptions {
 export interface GetSnapshotOptions {
     /**
      * Whether to include reports with the snapshot.
+     *
      * @default false
      */
     includeReports?: boolean;

--- a/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
+++ b/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
@@ -168,7 +168,7 @@ describe('ResourceSnapshots', () => {
     describe('createFromOrganization', () => {
         it('should make a POST call to the specific Resource Snapshots url', () => {
             const exportConfigurationModel: ResourceSnapshotExportConfigurationModel = {
-                resourcesToExport: {FIELD: ['*'], EXTENSIONS: ['🤖']},
+                resourcesToExport: {FIELD: ['*'], EXTENSION: ['🤖']},
             };
             const createFromOrganizationOptions: CreateFromOrganizationOptions = {
                 developerNotes: 'Cut my life into pieces! 🎵🎵🎵',
@@ -182,7 +182,7 @@ describe('ResourceSnapshots', () => {
                 api.post
             ).toHaveBeenCalledWith(
                 `${ResourceSnapshots.baseUrl}/self?developerNotes=Cut%20my%20life%20into%20pieces%21%20%F0%9F%8E%B5%F0%9F%8E%B5%F0%9F%8E%B5&includeChildrenResources=false`,
-                {resourcesToExport: {EXTENSIONS: ['🤖'], FIELD: ['*']}}
+                {resourcesToExport: {EXTENSION: ['🤖'], FIELD: ['*']}}
             );
         });
     });


### PR DESCRIPTION
According to the API, a property of an export model must adhere to the following condition:
 - Its key must be part of the `ResourceType` enum
 - Its value must either be `null` or an array of strings.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces.
    - No additions.
-   [x] The proposed changes are covered by unit tests.
    - No logic changes.
-   [x] Commits containing breaking changes a properly identified as such
    - IMHO, this is not a breaking change because even if you didn't adhere to the typing restrictions introduced here, the API would have denied the request. Therefore, I think it's a fix.
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
    - Irrelevant.
