### PR TITLE
feat(organization.ts): added support status change for an organization

### DIFF
--- a/src/resources/Organizations/Organization.ts
+++ b/src/resources/Organizations/Organization.ts
@@ -48,6 +48,10 @@ export default class Organization extends Resource {
         return this.api.put<OrganizationModel>(`${Organization.baseUrl}/${organization.id}`, organization);
     }
 
+    updateSupportActivated(organizationId: string, supportActivated: boolean) {
+        return this.api.put(`${Organization.baseUrl}/${organizationId}/support?activate=${supportActivated}`);
+    }
+
     status(organizationId: string = API.orgPlaceholder) {
         return this.api.get<OrganizationsStatusModel>(`${Organization.baseUrl}/${organizationId}/status`);
     }

--- a/src/resources/Organizations/tests/Organizations.spec.ts
+++ b/src/resources/Organizations/tests/Organizations.spec.ts
@@ -17,6 +17,28 @@ describe('Organization', () => {
         organization = new Organization(api, serverlessApi);
     });
 
+    describe('updateSupportActivated', () => {
+        it('should make a PUT call to the proper URL to activate support', () => {
+            const organizationToBeUpdated = 'Organization-to-be-updated';
+            const supportActivated = true;
+            organization.updateSupportActivated(organizationToBeUpdated, supportActivated);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `${Organization.baseUrl}/${organizationToBeUpdated}/support?activate=${supportActivated}`
+            );
+        });
+
+        it('should make a PUT call to the proper URL to disable support', () => {
+            const organizationToBeUpdated = 'Organization-to-be-updated';
+            const supportActivated = false;
+            organization.updateSupportActivated(organizationToBeUpdated, supportActivated);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `${Organization.baseUrl}/${organizationToBeUpdated}/support?activate=${supportActivated}`
+            );
+        });
+    });
+
     describe('list', () => {
         it('should make a GET call to the Organization base url', () => {
             organization.list();


### PR DESCRIPTION
Added a resource to change the support activated flag of an organization.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
