### PR TITLE
feat(organization): add pause and resume calls

### DIFF
--- a/src/resources/Organizations/Organization.ts
+++ b/src/resources/Organizations/Organization.ts
@@ -56,6 +56,22 @@ export default class Organization extends Resource {
         return this.api.get<OrganizationsStatusModel>(`${Organization.baseUrl}/${organizationId}/status`);
     }
 
+    /**
+     * Pauses an [organization](https://docs.coveo.com/en/222/).
+     * Required privilege: Organization - Edit
+     */
+    pause(organizationId: string = API.orgPlaceholder) {
+        return this.api.post(`${Organization.baseUrl}/${organizationId}/pause`);
+    }
+
+    /**
+     * Resumes a paused [organization](https://docs.coveo.com/en/222/).
+     * Required privilege: Organization - Edit
+     */
+    resume(organizationId: string = API.orgPlaceholder) {
+        return this.api.post(`${Organization.baseUrl}/${organizationId}/resume`);
+    }
+
     listPrivileges() {
         return this.api.get<PrivilegeModel[]>(`${Organization.baseUrl}/${API.orgPlaceholder}/privileges`);
     }

--- a/src/resources/Organizations/tests/Organizations.spec.ts
+++ b/src/resources/Organizations/tests/Organizations.spec.ts
@@ -131,6 +131,24 @@ describe('Organization', () => {
         });
     });
 
+    describe('pause', () => {
+        it('should make a POST call to the specific Organization url', () => {
+            organization.pause();
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Organization.baseUrl}/${API.orgPlaceholder}/pause`);
+        });
+    });
+
+    describe('resume', () => {
+        it('should make a POST call to the specific Organization url', () => {
+            organization.resume();
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Organization.baseUrl}/${API.orgPlaceholder}/resume`);
+        });
+    });
+
     describe('listPrivileges', () => {
         it('should make a GET call /rest/organizations/{organizationName}/privileges', () => {
             organization.listPrivileges();


### PR DESCRIPTION
Add `pause` and `resume` to `Organization`.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
