### PR TITLE
feat(ml): added modelactivenessstate to interface

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -423,6 +423,11 @@ export enum ModelStatus {
     UPDATE_FAILED = 'UPDATE_FAILED',
 }
 
+export enum ModelActivenessState {
+    ACTIVE = 'ACTIVE',
+    INACTIVE = 'INACTIVE',
+}
+
 export enum ModelConfigFileType {
     ADVANCED_CONFIGURATION = 'ADVANCED_CONFIGURATION',
     STOPWORDS = 'STOPWORDS',

--- a/src/resources/MachineLearning/Models/ModelsInterfaces.ts
+++ b/src/resources/MachineLearning/Models/ModelsInterfaces.ts
@@ -1,5 +1,5 @@
 import {GranularResource} from '../../BaseInterfaces';
-import {IntervalUnit, ModelStatus} from '../../Enums';
+import {IntervalUnit, ModelActivenessState, ModelStatus} from '../../Enums';
 import {AssociatedPipelineModel} from '../../Pipelines';
 import {MLModelInfo} from '../ModelInformation/ModelInformationInterfaces';
 
@@ -28,6 +28,7 @@ export interface MLModel extends MLModelInfo, ModelAttributes, GranularResource 
     searchEventFilter?: string;
     viewEventFilter?: string;
     modelSizeStatistic?: number;
+    modelActivenessState?: ModelActivenessState;
 }
 
 export interface ModelErrorDescription {


### PR DESCRIPTION
Added modelActivenessState to MLModel interface. the value is already being returned by the API. Set as optional so nothing breaking

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
