### PR TITLE
fix(organizationmodifier): fixed getter return signature

### DIFF
--- a/src/resources/License/License.ts
+++ b/src/resources/License/License.ts
@@ -1,6 +1,6 @@
 import {LicenseSection} from '../Enums';
 import Resource from '../Resource';
-import {LicenseModel, LicenseSourceTypeModel} from './LicenseInterfaces';
+import {LicenseExpirationDateOptions, LicenseModel, LicenseSourceTypeModel} from './LicenseInterfaces';
 import API from '../../APICore';
 
 export default class License extends Resource {
@@ -20,6 +20,10 @@ export default class License extends Resource {
 
     updateLicense(license: LicenseModel) {
         return this.api.put<LicenseModel>(License.baseUrl, license);
+    }
+
+    updateExpirationDate(options: LicenseExpirationDateOptions) {
+        return this.api.put<LicenseModel>(this.buildPath(`${License.baseUrl}/expiration`, options));
     }
 
     getPossibleSourceTypes() {

--- a/src/resources/License/LicenseInterfaces.ts
+++ b/src/resources/License/LicenseInterfaces.ts
@@ -36,3 +36,13 @@ export interface LicenseSourceTypeModel {
      */
     type: string;
 }
+
+/**
+ * Request parameters when updating an organization's expiration date
+ */
+export interface LicenseExpirationDateOptions {
+    /**
+     * Expiration date in epoch in milliseconds, e.g. 1625518417000
+     */
+    expirationDate: number;
+}

--- a/src/resources/License/tests/License.spec.ts
+++ b/src/resources/License/tests/License.spec.ts
@@ -61,6 +61,18 @@ describe('License', () => {
         });
     });
 
+    describe('updateExpirationDate', () => {
+        it('should make a PUT call to the specific License url', () => {
+            const now = new Date();
+
+            license.updateExpirationDate({expirationDate: now.getTime()});
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `/rest/organizations/{organizationName}/license/expiration?expirationDate=${now.getTime()}`
+            );
+        });
+    });
+
     describe('getPossibleSourceTypes', () => {
         it('should make a GET call to the specific License url', () => {
             license.getPossibleSourceTypes();

--- a/src/resources/ModifierTemplates/ModifierTemplates.ts
+++ b/src/resources/ModifierTemplates/ModifierTemplates.ts
@@ -5,7 +5,7 @@ export default class ModifierTemplates extends Resource {
     static baseUrl = `/rest/modifiertemplates`;
 
     list() {
-        return this.api.get<ModifierModel>(`${ModifierTemplates.baseUrl}`);
+        return this.api.get<ModifierModel[]>(`${ModifierTemplates.baseUrl}`);
     }
 
     listPossibleStatements() {


### PR DESCRIPTION
Fixed getter return signature, we are retrieving a list of models not only one.

I noticed the library's tests do not actually call and validate that the APIs work correctly and return the expected values. Why not call the real platform and have assertions on the results?

FOUND-3624

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
