### PR TITLE
feat(resource snapshots): export snapshot content

### DIFF
--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -49,13 +49,9 @@ export default class ResourceSnapshots extends Resource {
      * @returns
      */
     async export(snapshotId: string, options?: ExportSnapshotContentOptions) {
-        const blob = await this.api.getFile(
-            this.buildPath(`${ResourceSnapshots.baseUrl}/${snapshotId}/content`, options),
-            {
-                headers: {accept: 'application/zip'},
-            }
-        );
-        return blob.arrayBuffer();
+        return this.api.getFile(this.buildPath(`${ResourceSnapshots.baseUrl}/${snapshotId}/content`, options), {
+            headers: {accept: 'application/zip'},
+        });
     }
 
     async getContent(snapshotId: string, options: GenerateUrlOptions) {

--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -46,7 +46,7 @@ export default class ResourceSnapshots extends Resource {
      *
      * @param {string} snapshotId The unique identifier of the target snapshot.
      * @param {ExportSnapshotContentOptions} [options]
-     * @returns
+     * @returns {Promise<Blob>} A newly created Blob object which contains the zipped snapshot
      */
     export(snapshotId: string, options?: ExportSnapshotContentOptions) {
         return this.api.getFile(this.buildPath(`${ResourceSnapshots.baseUrl}/${snapshotId}/content`, options), {

--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -48,7 +48,7 @@ export default class ResourceSnapshots extends Resource {
      * @param {ExportSnapshotContentOptions} [options]
      * @returns
      */
-    async export(snapshotId: string, options?: ExportSnapshotContentOptions) {
+    export(snapshotId: string, options?: ExportSnapshotContentOptions) {
         return this.api.getFile(this.buildPath(`${ResourceSnapshots.baseUrl}/${snapshotId}/content`, options), {
             headers: {accept: 'application/zip'},
         });

--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -7,6 +7,7 @@ import {
     CreateFromOrganizationOptions,
     DryRunOptions,
     GenerateUrlOptions,
+    ExportSnapshotContentOptions,
     GetSnapshotOptions,
     PushSnapshotOptions,
     ResourceSnapshotExportConfigurationModel,
@@ -38,6 +39,23 @@ export default class ResourceSnapshots extends Resource {
         return this.api.get<SnapshotAccessModel>(
             this.buildPath(`${ResourceSnapshots.baseUrl}/${snapshotId}/access`, options)
         );
+    }
+
+    /**
+     * Retrieves a ZIP file holding the content of the target snapshot, in the target format.
+     *
+     * @param {string} snapshotId The unique identifier of the target snapshot.
+     * @param {ExportSnapshotContentOptions} [options]
+     * @returns
+     */
+    async export(snapshotId: string, options?: ExportSnapshotContentOptions) {
+        const blob = await this.api.getFile(
+            this.buildPath(`${ResourceSnapshots.baseUrl}/${snapshotId}/content`, options),
+            {
+                headers: {accept: 'application/zip'},
+            }
+        );
+        return blob.arrayBuffer();
     }
 
     async getContent(snapshotId: string, options: GenerateUrlOptions) {

--- a/src/resources/ResourceSnapshots/ResourceSnapshotsInterfaces.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshotsInterfaces.ts
@@ -265,6 +265,8 @@ export interface ExportSnapshotContentOptions {
      * The format of the snapshot content.
      * - FLAT: Content unified into a single file
      * - SPLIT_PER_TYPE: Content split into one file per resource type
+     *
+     * @default SnapshotExportContentFormat.Flat
      */
     contentFormat?: SnapshotExportContentFormat;
 }

--- a/src/resources/ResourceSnapshots/ResourceSnapshotsInterfaces.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshotsInterfaces.ts
@@ -72,6 +72,11 @@ export enum SnapshotAccessType {
     Write = 'WRITE',
 }
 
+export enum SnapshotExportContentFormat {
+    Flat = 'FLAT',
+    SplitPerType = 'SPLIT_PER_TYPE',
+}
+
 export enum ResourceSnapshotsReportResultCode {
     AccessDenied = 'ACCESS_DENIED',
     ResourcesInError = 'RESOURCES_IN_ERROR',
@@ -253,6 +258,15 @@ export interface GetSnapshotOptions {
      * @default false
      */
     includeReports?: boolean;
+}
+
+export interface ExportSnapshotContentOptions {
+    /**
+     * The format of the snapshot content.
+     * - FLAT: Content unified into a single file
+     * - SPLIT_PER_TYPE: Content split into one file per resource type
+     */
+    contentFormat?: SnapshotExportContentFormat;
 }
 
 export interface ValidateAccessOptions {

--- a/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
+++ b/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
@@ -5,6 +5,7 @@ import {
     CreateFromFileOptions,
     CreateFromOrganizationOptions,
     DryRunOptions,
+    ExportSnapshotContentOptions,
     PushSnapshotOptions,
     ResourceSnapshotContentType,
     ResourceSnapshotExportConfigurationModel,
@@ -13,6 +14,7 @@ import {
     ResourceSnapshotUrlModel,
     ResourceType,
     SnapshotAccessType,
+    SnapshotExportContentFormat,
     UpdateChildrenOptions,
     ValidateAccessOptions,
 } from '../ResourceSnapshotsInterfaces';
@@ -86,6 +88,36 @@ describe('ResourceSnapshots', () => {
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
                 `${ResourceSnapshots.baseUrl}/${snapshotToGetId}/access?snapshotAccessType=WRITE`
+            );
+        });
+    });
+
+    describe('export', () => {
+        it('should make a post call to the specific Resource Snapshots url and get snapshot content with default content format', () => {
+            const snapshotToGetId = 'snapshot-to-be-fetched';
+
+            resourceSnapshots.export(snapshotToGetId);
+
+            expect(api.getFile).toHaveBeenCalledTimes(1);
+            expect(api.getFile).toHaveBeenCalledWith(`${ResourceSnapshots.baseUrl}/${snapshotToGetId}/content`, {
+                headers: {accept: 'application/zip'},
+            });
+        });
+
+        it('should make a post call to the specific Resource Snapshots url and get snapshot content with specific content format', () => {
+            const snapshotToGetId = 'snapshot-to-be-fetched';
+            const exportSnapshotContentOptions: ExportSnapshotContentOptions = {
+                contentFormat: SnapshotExportContentFormat.SplitPerType,
+            };
+
+            resourceSnapshots.export(snapshotToGetId, exportSnapshotContentOptions);
+
+            expect(api.getFile).toHaveBeenCalledTimes(1);
+            expect(
+                api.getFile
+            ).toHaveBeenCalledWith(
+                `${ResourceSnapshots.baseUrl}/${snapshotToGetId}/content?contentFormat=SPLIT_PER_TYPE`,
+                {headers: {accept: 'application/zip'}}
             );
         });
     });


### PR DESCRIPTION
It is now possible to download the content of a snapshot in a ZIP file ([request](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Migration#/Snapshot/rest_organizations_paramId_snapshots_paramId_content_get)).
 
_p.s. The call is only available in platformdev at the moment._

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
