### PR TITLE
feat(search-interfaces): update models and calls

### DIFF
--- a/src/resources/SearchInterfaces/SearchInterfaces.model.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.model.ts
@@ -93,6 +93,28 @@ export interface ISearchInterfaceConfiguration {
     accesses: IAccesses;
 }
 
+export interface ISearchInterfaceConfigurationResponse extends ISearchInterfaceConfiguration {
+    /**
+     * The creation timestamp. (ISO 8601)
+     */
+    created: string;
+
+    /**
+     * The creator principal.
+     */
+    createdBy: string;
+
+    /**
+     * The last update timestamp. (ISO 8601)
+     */
+    updated: string;
+
+    /**
+     * The last updated principal.
+     */
+    updatedBy: string;
+}
+
 export interface IListSearchInterfacesParameters {
     /**
      * A substring that must appear in a search interface configuration name for this configuration to appear in results.

--- a/src/resources/SearchInterfaces/SearchInterfaces.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.ts
@@ -1,24 +1,29 @@
 import API from '../../APICore';
 import {New, PageModel} from '../../Entry';
 import Resource from '../Resource';
-import {IAccesses, IListSearchInterfacesParameters, ISearchInterfaceConfiguration} from './SearchInterfaces.model';
+import {
+    IAccesses,
+    IListSearchInterfacesParameters,
+    ISearchInterfaceConfiguration,
+    ISearchInterfaceConfigurationResponse,
+} from './SearchInterfaces.model';
 
 export default class SearchInterfaces extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/searchinterfaces`;
 
-    list(options: IListSearchInterfacesParameters): Promise<PageModel<ISearchInterfaceConfiguration>> {
+    list(options: IListSearchInterfacesParameters): Promise<PageModel<ISearchInterfaceConfigurationResponse>> {
         return this.api.get(this.buildPath(SearchInterfaces.baseUrl, options));
     }
 
-    create(searchInterfaceConfig: New<ISearchInterfaceConfiguration>): Promise<ISearchInterfaceConfiguration> {
+    create(searchInterfaceConfig: New<ISearchInterfaceConfiguration>): Promise<ISearchInterfaceConfigurationResponse> {
         return this.api.post(SearchInterfaces.baseUrl, searchInterfaceConfig);
     }
 
-    get(searchInterfaceConfigId: string): Promise<ISearchInterfaceConfiguration> {
+    get(searchInterfaceConfigId: string): Promise<ISearchInterfaceConfigurationResponse> {
         return this.api.get(`${SearchInterfaces.baseUrl}/${searchInterfaceConfigId}`);
     }
 
-    update(searchInterfaceConfig: ISearchInterfaceConfiguration): Promise<ISearchInterfaceConfiguration> {
+    update(searchInterfaceConfig: ISearchInterfaceConfiguration): Promise<ISearchInterfaceConfigurationResponse> {
         return this.api.put(`${SearchInterfaces.baseUrl}/${searchInterfaceConfig.id}`, searchInterfaceConfig);
     }
 
@@ -26,7 +31,19 @@ export default class SearchInterfaces extends Resource {
         return this.api.delete(`${SearchInterfaces.baseUrl}/${searchInterfaceConfigId}`);
     }
 
+    getAccesses(interfaceId: string): Promise<IAccesses> {
+        return this.api.get(`${SearchInterfaces.baseUrl}/${interfaceId}/accesses`);
+    }
+
     updateAccesses(searchInterfaceConfigId: string, accesses: IAccesses): Promise<IAccesses> {
         return this.api.put(`${SearchInterfaces.baseUrl}/${searchInterfaceConfigId}/accesses`, accesses);
+    }
+
+    getAccessesUsers(interfaceId: string): Promise<string[]> {
+        return this.api.get(`${SearchInterfaces.baseUrl}/${interfaceId}/accesses/users`);
+    }
+
+    updateAccessesUsers(interfaceId: string, users: string[]): Promise<string[]> {
+        return this.api.put(`${SearchInterfaces.baseUrl}/${interfaceId}/accesses/users`, users);
     }
 }

--- a/src/resources/SearchInterfaces/tests/SearchInterfaces.spec.ts
+++ b/src/resources/SearchInterfaces/tests/SearchInterfaces.spec.ts
@@ -105,6 +105,7 @@ describe('SearchInterfaces', () => {
     describe('get', () => {
         it('should make a GET call to the SearchInterfaces base url', () => {
             const id = 'SearchInterface-id-to-get';
+
             searchInterfaces.get(id);
 
             expect(api.get).toHaveBeenCalledTimes(1);
@@ -115,6 +116,7 @@ describe('SearchInterfaces', () => {
     describe('update', () => {
         it('should make a UPDATE call to the SearchInterfaces base url', () => {
             const id = 'SearchInterface-id-to-update';
+
             searchInterfaces.update({...config, id});
 
             expect(api.put).toHaveBeenCalledTimes(1);
@@ -125,10 +127,22 @@ describe('SearchInterfaces', () => {
     describe('delete', () => {
         it('should make a DELETE call to the SearchInterfaces base url', () => {
             const id = 'SearchInterface-id-to-delete';
+
             searchInterfaces.delete(id);
 
             expect(api.delete).toHaveBeenCalledTimes(1);
             expect(api.delete).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/${id}`);
+        });
+    });
+
+    describe('getAccesses', () => {
+        it('makes a GET call to the searchInterfaces accesses url based on the interfaceId', () => {
+            const id = 'search-interface-id';
+
+            searchInterfaces.getAccesses(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/${id}/accesses`);
         });
     });
 
@@ -141,10 +155,34 @@ describe('SearchInterfaces', () => {
                 sharingLinkEnabled: false,
             };
             const id = 'SearchInterface-id-to-update-accesses';
+
             searchInterfaces.updateAccesses(id, someAccesses);
 
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/${id}/accesses`, someAccesses);
+        });
+    });
+
+    describe('getAccessesUsers', () => {
+        it('makes a GET call to the searchInterfaces accesses users url based on the interfaceId', () => {
+            const id = 'search-interface-id';
+
+            searchInterfaces.getAccessesUsers(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/${id}/accesses/users`);
+        });
+    });
+
+    describe('updateAccessesUsers', () => {
+        it('makes a PUT call to the searchInterfaces accesses users url based on the interfaceId', () => {
+            const id = 'search-interface-id';
+            const someUsers = ['Tinky Winky', 'Dipsy', 'Laa-Laa', 'Po'];
+
+            searchInterfaces.updateAccessesUsers(id, someUsers);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/${id}/accesses/users`, someUsers);
         });
     });
 });


### PR DESCRIPTION
BREAKING CHANGE: Some interfaces has to be changed in the Admin-UI.
Because the response type changes, It could affect a few files in the Admin-UI (such as `SearchInterfaceReducer`, `SearchInterfacePreview`, `SearchInterfacesTableRow`, and so on)

### Acceptance Criteria

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
