### PR TITLE
feat: overload #createFromFile to support buffer

### DIFF
--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -78,15 +78,9 @@ export default class ResourceSnapshots extends Resource {
             fileContent = file.toString();
             computedOptions = {developerNotes: options.developerNotes, snapshotFileType: typeOrOptions};
         } else {
-            const type = file.type;
+            fileContent = file;
             computedOptions.developerNotes = (typeOrOptions as CreateFromFileOptions).developerNotes;
-            if (type === 'application/zip') {
-                computedOptions.snapshotFileType = ResourceSnapshotSupportedFileTypes.ZIP;
-            } else if (type === 'application/json') {
-                computedOptions.snapshotFileType = ResourceSnapshotSupportedFileTypes.JSON;
-            } else {
-                throw new Error('The uploaded file must be either a ZIP or a JSON file.');
-            }
+            computedOptions.snapshotFileType = this.getSnapshotFileType(file);
         }
 
         const form: FormData = getFormData();
@@ -174,5 +168,16 @@ export default class ResourceSnapshots extends Resource {
                 options
             )
         );
+    }
+
+    private getSnapshotFileType(file: File) {
+        switch (file.type) {
+            case 'application/zip':
+                return ResourceSnapshotSupportedFileTypes.ZIP;
+            case 'application/json':
+                return ResourceSnapshotSupportedFileTypes.JSON;
+            default:
+                throw new Error('The uploaded file must be either a ZIP or a JSON file.');
+        }
     }
 }

--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -71,11 +71,11 @@ export default class ResourceSnapshots extends Resource {
         typeOrOptions: ResourceSnapshotSupportedFileTypes | CreateFromFileOptions,
         options?: CreateFromFileOptions
     ) {
-        let value: File | string;
+        let fileContent: File | string;
         let computedOptions = {developerNotes: undefined, snapshotFileType: undefined};
 
         if (Buffer.isBuffer(file)) {
-            value = file.toString();
+            fileContent = file.toString();
             computedOptions = {developerNotes: options.developerNotes, snapshotFileType: typeOrOptions};
         } else {
             const type = file.type;
@@ -90,7 +90,7 @@ export default class ResourceSnapshots extends Resource {
         }
 
         const form: FormData = getFormData();
-        form.append('file', value);
+        form.append('file', fileContent);
 
         return this.api.postForm<ResourceSnapshotsModel>(
             this.buildPath(`${ResourceSnapshots.baseUrl}/file`, computedOptions),

--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -45,8 +45,21 @@ export default class ResourceSnapshots extends Resource {
         return await fetch(url, {method: 'get'});
     }
 
+    /**
+     * Creates a snapshot from a file containing the configuration.
+     *
+     * @param {File} file The file containing the configuration.
+     * @param {CreateFromFileOptions} options
+     */
     createFromFile(file: File, options: CreateFromFileOptions): Promise<ResourceSnapshotsModel>;
 
+    /**
+     * Creates a snapshot from a file buffer containing the configuration.
+     *
+     * @param {Buffer} file The file containing the configuration.
+     * @param {ResourceSnapshotSupportedFileTypes} fileType The type of the file containing the configuration.
+     * @param {CreateFromFileOptions} options
+     */
     createFromFile(
         file: Buffer,
         fileType: ResourceSnapshotSupportedFileTypes,

--- a/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
+++ b/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
@@ -10,6 +10,7 @@ import {
     ResourceSnapshotExportConfigurationModel,
     ResourceSnapshotsSynchronizationPlanModel,
     ResourceSnapshotsSynchronizationPlanStatus,
+    ResourceSnapshotSupportedFileTypes,
     ResourceSnapshotUrlModel,
     ResourceType,
     SnapshotAccessType,
@@ -119,6 +120,32 @@ describe('ResourceSnapshots', () => {
         beforeEach(() => {
             (global as any).FormData = jest.fn(() => mockedFormData);
             (global as any).File = jest.fn(() => mockedFile);
+        });
+
+        it('should make a post call to the specific Resource Snapshots url if JSON buffer', () => {
+            const createFromFileOptions: CreateFromFileOptions = {developerNotes: 'Cut my life into pieces! 🎵🎵🎵'};
+            const file = Buffer.from(['']);
+
+            resourceSnapshots.createFromFile(file, ResourceSnapshotSupportedFileTypes.JSON, createFromFileOptions);
+
+            expect(api.postForm).toHaveBeenCalledTimes(1);
+            expect(api.postForm).toHaveBeenCalledWith(
+                `${ResourceSnapshots.baseUrl}/file?developerNotes=Cut%20my%20life%20into%20pieces%21%20%F0%9F%8E%B5%F0%9F%8E%B5%F0%9F%8E%B5&snapshotFileType=JSON`,
+                mockedFormData
+            );
+        });
+
+        it('should make a post call to the specific Resource Snapshots url if ZIP buffer', () => {
+            const createFromFileOptions: CreateFromFileOptions = {developerNotes: 'Cut my life into pieces! 🎵🎵🎵'};
+            const file = Buffer.from(['']);
+
+            resourceSnapshots.createFromFile(file, ResourceSnapshotSupportedFileTypes.ZIP, createFromFileOptions);
+
+            expect(api.postForm).toHaveBeenCalledTimes(1);
+            expect(api.postForm).toHaveBeenCalledWith(
+                `${ResourceSnapshots.baseUrl}/file?developerNotes=Cut%20my%20life%20into%20pieces%21%20%F0%9F%8E%B5%F0%9F%8E%B5%F0%9F%8E%B5&snapshotFileType=ZIP`,
+                mockedFormData
+            );
         });
 
         it('should make a post call to the specific Resource Snapshots url if zip file', () => {

--- a/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
+++ b/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
@@ -110,8 +110,9 @@ describe('ResourceSnapshots', () => {
     });
 
     describe('createFromFile', () => {
+        const mockedAppendToFormData = jest.fn();
         const mockedFormData = {
-            append: jest.fn(),
+            append: mockedAppendToFormData,
         };
         const mockedFile = {
             type: 'application/zip',
@@ -124,7 +125,7 @@ describe('ResourceSnapshots', () => {
 
         it('should make a post call to the specific Resource Snapshots url if JSON buffer', () => {
             const createFromFileOptions: CreateFromFileOptions = {developerNotes: 'Cut my life into pieces! 🎵🎵🎵'};
-            const file = Buffer.from(['']);
+            const file = Buffer.from('');
 
             resourceSnapshots.createFromFile(file, ResourceSnapshotSupportedFileTypes.JSON, createFromFileOptions);
 
@@ -135,9 +136,18 @@ describe('ResourceSnapshots', () => {
             );
         });
 
+        it('should append the file content to the formData', () => {
+            const createFromFileOptions: CreateFromFileOptions = {developerNotes: 'Cut my life into pieces! 🎵🎵🎵'};
+            const file = Buffer.from('file-data-content');
+
+            resourceSnapshots.createFromFile(file, ResourceSnapshotSupportedFileTypes.JSON, createFromFileOptions);
+
+            expect(mockedAppendToFormData).toHaveBeenCalledWith('file', 'file-data-content');
+        });
+
         it('should make a post call to the specific Resource Snapshots url if ZIP buffer', () => {
             const createFromFileOptions: CreateFromFileOptions = {developerNotes: 'Cut my life into pieces! 🎵🎵🎵'};
-            const file = Buffer.from(['']);
+            const file = Buffer.from('');
 
             resourceSnapshots.createFromFile(file, ResourceSnapshotSupportedFileTypes.ZIP, createFromFileOptions);
 


### PR DESCRIPTION
The [File](https://developer.mozilla.org/en-US/docs/Web/API/File) object is not natively supported by Node, making the `ResourceSnapshots#createFromFile` method not available to Node users (at least without hacks).

Now, the `createFromFile` method has an additional overload. It accepts files as Buffers objects.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
