### PR TITLE
chore(codeowners): add dx gang into the fray

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,7 @@
 # see https://help.github.com/articles/about-codeowners/ for more details
 
 * @coveo/admin-console
+* @coveo/dx
 
 # Prevent PRs that only modify package.json from notifying everyone
 package.json @ghost


### PR DESCRIPTION
So, as discussed with @gdostie [here](https://coveo.slack.com/archives/C01M10DME91/p1625852537469200) because we aim to support NodeJS on the same level as a browser, and that, well, the @coveo/dx gang are the primary user of the project in a node environment, it makes sense for us to share the ownership with you to help you on that topic.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces: N.A.
-   [x] The proposed changes are covered by unit tests: N.A.
-   [x] Commits containing breaking changes a properly identified as such: N.A.
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant): N.A.
