### PR TITLE
fix: create file from buffer

### DIFF
--- a/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
+++ b/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
@@ -159,7 +159,7 @@ describe('ResourceSnapshots', () => {
             const createFromFileOptions: CreateFromFileOptions = {developerNotes: 'Cut my life into pieces! 🎵🎵🎵'};
             const file = Buffer.from('');
 
-            resourceSnapshots.createFromFile(file, ResourceSnapshotSupportedFileTypes.JSON, createFromFileOptions);
+            resourceSnapshots.createFromBuffer(file, ResourceSnapshotSupportedFileTypes.JSON, createFromFileOptions);
 
             expect(api.postForm).toHaveBeenCalledTimes(1);
             expect(api.postForm).toHaveBeenCalledWith(
@@ -168,20 +168,37 @@ describe('ResourceSnapshots', () => {
             );
         });
 
-        it('should append the file content to the formData', () => {
+        it('should append the JSON buffer content to the formData', () => {
             const createFromFileOptions: CreateFromFileOptions = {developerNotes: 'Cut my life into pieces! 🎵🎵🎵'};
             const file = Buffer.from('file-data-content');
 
-            resourceSnapshots.createFromFile(file, ResourceSnapshotSupportedFileTypes.JSON, createFromFileOptions);
+            resourceSnapshots.createFromBuffer(file, ResourceSnapshotSupportedFileTypes.JSON, createFromFileOptions);
 
-            expect(mockedAppendToFormData).toHaveBeenCalledWith('file', 'file-data-content');
+            expect(mockedAppendToFormData).toHaveBeenCalledWith(
+                'file',
+                Buffer.from('file-data-content'),
+                'snapshot.json'
+            );
+        });
+
+        it('should append the ZIP buffer content to the formData', () => {
+            const createFromFileOptions: CreateFromFileOptions = {developerNotes: 'Cut my life into pieces! 🎵🎵🎵'};
+            const file = Buffer.from('file-data-content');
+
+            resourceSnapshots.createFromBuffer(file, ResourceSnapshotSupportedFileTypes.ZIP, createFromFileOptions);
+
+            expect(mockedAppendToFormData).toHaveBeenCalledWith(
+                'file',
+                Buffer.from('file-data-content'),
+                'snapshot.zip'
+            );
         });
 
         it('should make a post call to the specific Resource Snapshots url if ZIP buffer', () => {
             const createFromFileOptions: CreateFromFileOptions = {developerNotes: 'Cut my life into pieces! 🎵🎵🎵'};
             const file = Buffer.from('');
 
-            resourceSnapshots.createFromFile(file, ResourceSnapshotSupportedFileTypes.ZIP, createFromFileOptions);
+            resourceSnapshots.createFromBuffer(file, ResourceSnapshotSupportedFileTypes.ZIP, createFromFileOptions);
 
             expect(api.postForm).toHaveBeenCalledTimes(1);
             expect(api.postForm).toHaveBeenCalledWith(


### PR DESCRIPTION
Turns out it was not a great idea to add overloads (#349).
The native [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) and the [form-data](https://www.npmjs.com/package/form-data) package are too different to create an intersection of the 2 objects.

Keeping the overloads would have created multiple manual casts and probably some refactor in other methods.
Anyway, we now have 2 methods to create a snapshot:
1. From a file
2. From a buffer

> Note: I don't consider this PR as a breaking change since the `createFromFile` method never worked on Node (even before #349).

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
