### PR TITLE
feat(limits): +historyLimits for react settigns

### DIFF
--- a/src/resources/Limits/Limits.ts
+++ b/src/resources/Limits/Limits.ts
@@ -1,11 +1,13 @@
 import API from '../../APICore';
 import {LicenseSection} from '../Enums';
 import Resource from '../Resource';
-import {AllLimitsModel, LimitsModel} from './LimitsInterfaces';
+import {AllLimitsModel, LimitHistoryDataPointModel, LimitsModel} from './LimitsInterfaces';
 
 export default class Limits extends Resource {
     static getBaseUrl = () => `/rest/organizations/${API.orgPlaceholder}/limits`;
     static getWithSection = (sectionName: LicenseSection) => `${Limits.getBaseUrl()}/${sectionName}`;
+    static getWithSectionAndHistory = (sectionName: LicenseSection, limitKey: string) =>
+        `${Limits.getWithSection(sectionName)}/${limitKey}/history`;
 
     get(sectionName: LicenseSection) {
         return this.api.get<LimitsModel>(Limits.getWithSection(sectionName));
@@ -13,5 +15,9 @@ export default class Limits extends Resource {
 
     getAll() {
         return this.api.get<AllLimitsModel>(Limits.getBaseUrl());
+    }
+
+    getHistoryLimit(sectionName: LicenseSection, limitKey: string) {
+        return this.api.get<LimitHistoryDataPointModel[]>(Limits.getWithSectionAndHistory(sectionName, limitKey));
     }
 }

--- a/src/resources/Limits/LimitsInterfaces.ts
+++ b/src/resources/Limits/LimitsInterfaces.ts
@@ -10,3 +10,16 @@ export interface LimitsModel {
 export interface AllLimitsModel {
     [name: string]: LimitsModel;
 }
+
+export interface LimitHistoryDataPointModel {
+    /**
+     * The date at which the limit value was set in number of milliseconds since UNIX epoch.
+       Example: 1511049600000
+     */
+    date: number;
+    /**
+     * The limit value for the given date.
+       Example: 49624
+     */
+    limitValue: number;
+}

--- a/src/resources/Limits/tests/Limits.spec.ts
+++ b/src/resources/Limits/tests/Limits.spec.ts
@@ -31,4 +31,12 @@ describe('Limits', () => {
             expect(api.get).toHaveBeenCalledWith(`/rest/organizations/{organizationName}/limits`);
         });
     });
+
+    describe('getHistoryLimit', () => {
+        it('should make a GET call to get specific history limit to the specific part of the limit', () => {
+            limits.getHistoryLimit(LicenseSection.content, '123');
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`/rest/organizations/{organizationName}/limits/content/123/history`);
+        });
+    });
 });


### PR DESCRIPTION
some calls were not implemented when creating settings section in react. This call should close the
loop, since some cards have history modal

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
