### PR TITLE
Feat/work 1008 add entity ids query param to get entities

### DIFF
--- a/src/resources/SchemaService/SchemaServiceInterfaces.ts
+++ b/src/resources/SchemaService/SchemaServiceInterfaces.ts
@@ -82,13 +82,17 @@ export interface GetEntitiesQueryParams extends SchemaServiceQueryParams {
     offset?: number;
     /**
      * The number of entities to fetch
-     * (user for server-side pagination)
+     * (used for server-side pagination)
      */
     limit?: number;
     /**
      * A query to fetch matching entity names and ids
      */
     query?: string;
+    /**
+     * IDs of the entities to retrieve, as a comma-separated list
+     */
+    entityIds?: string;
 }
 
 export interface GetEntityQueryParams extends SchemaServiceQueryParams {

--- a/src/resources/SchemaService/test/SchemaService.spec.ts
+++ b/src/resources/SchemaService/test/SchemaService.spec.ts
@@ -34,10 +34,16 @@ describe('SchemaService', () => {
 
     describe('getEntities', () => {
         it('should make a GET call to the specific SchemaService url with the correct params', () => {
-            schemaService.getEntities(sourceType, {...params, offset: 100, limit: 100, query: 'toTheMoon'});
+            schemaService.getEntities(sourceType, {
+                ...params,
+                offset: 100,
+                limit: 100,
+                query: 'toTheMoon',
+                entityIds: 'sys_dictionary,sys_user',
+            });
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entities?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}&offset=100&limit=100&query=toTheMoon`
+                `/rest/organizations/${API.orgPlaceholder}/schema/sources/${sourceType}/entities?clientId=${params.clientId}&instanceUrl=${params.instanceUrl}&clientSecretGuid=${params.clientSecretGuid}&oauthRefreshTokenGuid=${params.oauthRefreshTokenGuid}&offset=100&limit=100&query=toTheMoon&entityIds=sys_dictionary%2Csys_user`
             );
         });
     });


### PR DESCRIPTION
[WORK-1008](https://coveord.atlassian.net/browse/WORK-1008)

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->
### Proposed Changes:
Add entityIds parameter to GetEntitiesQueryParams, following this addition to the schema-service: https://github.com/coveo/schema-service/pull/490

The parameter is a string because it accepts a comma-separated list of entity IDs: `entityIds=id1,id2,id3`

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
