### PR TITLE
Fix list conditions return type

### DIFF
--- a/src/resources/Pipelines/Conditions/Condition.ts
+++ b/src/resources/Pipelines/Conditions/Condition.ts
@@ -1,12 +1,12 @@
+import {PageModel} from '../../BaseInterfaces';
 import Resource from '../../Resource';
-import {StatementModelList} from '../Statements';
 import {ConditionModel, ListConditionsOptions, NewConditionModel} from './ConditionInterfaces';
 
 export default class Condition extends Resource {
     static baseUrl = `/rest/search/v1/admin/pipelines/statements`;
 
     list(options: ListConditionsOptions = {}) {
-        return this.api.get<StatementModelList>(
+        return this.api.get<PageModel<ConditionModel, 'statements'>>(
             this.buildPath(Condition.baseUrl, {feature: 'when', organizationId: this.api.organizationId, ...options})
         );
     }

--- a/src/resources/Pipelines/MLAssociations/MLAssociations.ts
+++ b/src/resources/Pipelines/MLAssociations/MLAssociations.ts
@@ -1,7 +1,7 @@
+import {PageModel} from '../../BaseInterfaces';
 import Resource from '../../Resource';
 import {
     AssociatedPipelinesData,
-    AssociationsListModel,
     CreateAssociation,
     EditAssociation,
     ListAssociationsParams,
@@ -12,7 +12,7 @@ export default class MLAssociations extends Resource {
     static getBaseUrl = (pipelineId: string) => `/rest/search/v2/admin/pipelines/${pipelineId}/ml/model/associations`;
 
     list(pipelineId: string, options?: ListAssociationsParams) {
-        return this.api.get<AssociationsListModel>(
+        return this.api.get<PageModel<MLAssociationModel, 'rules'>>(
             this.buildPath(MLAssociations.getBaseUrl(pipelineId), {organizationId: this.api.organizationId, ...options})
         );
     }

--- a/src/resources/Pipelines/MLAssociations/MLAssociationsInterfaces.ts
+++ b/src/resources/Pipelines/MLAssociations/MLAssociationsInterfaces.ts
@@ -1,5 +1,8 @@
 import {ModelTypes} from '../../Enums';
 
+/**
+ * @deprecated - Use `PageModel<MLAssociationModel, 'rules'>` instead.
+ */
 export interface AssociationsListModel {
     rules: MLAssociationModel[];
     totalEntries: number;

--- a/src/resources/Pipelines/Statements/Statements.ts
+++ b/src/resources/Pipelines/Statements/Statements.ts
@@ -1,4 +1,5 @@
 import {getFormData} from '../../../utils/FormData';
+import {PageModel} from '../../BaseInterfaces';
 import Resource from '../../Resource';
 import {
     CopyStatementModel,
@@ -7,7 +8,6 @@ import {
     ListStatementParams,
     MoveStatementModel,
     StatementModel,
-    StatementModelList,
 } from './StatementsInterfaces';
 
 export default class Statements extends Resource {
@@ -16,7 +16,7 @@ export default class Statements extends Resource {
         `${Statements.getBaseUrl(pipelineId)}/${statementId}`;
 
     list(pipelineId: string, options?: ListStatementParams) {
-        return this.api.get<StatementModelList>(
+        return this.api.get<PageModel<StatementModel, 'statements'>>(
             this.buildPath(Statements.getBaseUrl(pipelineId), {organizationId: this.api.organizationId, ...options})
         );
     }
@@ -62,7 +62,7 @@ export default class Statements extends Resource {
     }
 
     copy(pipelineId: string, model: CopyStatementModel) {
-        return this.api.post<StatementModelList>(
+        return this.api.post<PageModel<StatementModel, 'statements'>>(
             this.buildPath(`${Statements.getBaseUrl(pipelineId)}/copy`, {organizationId: this.api.organizationId}),
             model
         );
@@ -77,7 +77,7 @@ export default class Statements extends Resource {
     }
 
     move(pipelineId: string, statementId: string, model: MoveStatementModel) {
-        return this.api.put<StatementModelList>(
+        return this.api.put<PageModel<StatementModel, 'statements'>>(
             this.buildPath(`${Statements.getStatementUrl(pipelineId, statementId)}/move`, {
                 organizationId: this.api.organizationId,
             }),

--- a/src/resources/Pipelines/Statements/StatementsInterfaces.ts
+++ b/src/resources/Pipelines/Statements/StatementsInterfaces.ts
@@ -35,6 +35,9 @@ export interface CopyStatementModel {
     destinationPipelineId: string;
 }
 
+/**
+ * @deprecated - Use `PageModel<StatementModel, 'statements'>` instead.
+ */
 export interface StatementModelList {
     statements: StatementModel[];
     totalEntries: number;


### PR DESCRIPTION
Fixed `Condition.list` method return type.

before:

```ts
Promise<{
    statements: StatementModel[];
    totalEntries: number;
    totalPages: number;
}>
```

after:
```ts
Promise<{
    statements: ConditionModel[];
    totalEntries: number;
    totalPages: number;
}>
```

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
