### PR TITLE
feat(statement-groups): switch campaignStart & campaignEnd as mandatory

### DIFF
--- a/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
+++ b/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
@@ -36,17 +36,11 @@ interface StatementGroupModelBase {
 
     /**
      * The unique identifier of the condition that must be satisfied for a request to be processed by the statement group.
-     * A query cannot be routed through a query pipeline that does not have a condition unless:
-     * - That query pipeline is set as the default query pipeline.
-     * - That query pipeline is enforced through the pipeline parameter of the query itself, in which case the query pipeline condition is bypassed.
      */
     conditionId?: string;
 
     /**
      * The definition of the condition that must be satisfied for a request to be processed by the statement group.
-     * A query cannot be routed through a query pipeline that does not have a condition unless:
-     * - That query pipeline is set as the default query pipeline.
-     * - That query pipeline is enforced through the pipeline parameter of the query itself, in which case the query pipeline condition is bypassed.
      */
     conditionDefinition?: string;
 
@@ -209,9 +203,6 @@ interface CreateStatementGroupModelBase {
 
     /**
      * The unique identifier of the condition that must be satisfied for a request to be processed by the statement group.
-     * A query cannot be routed through a query pipeline that does not have a condition unless:
-     * - That query pipeline is set as the default query pipeline.
-     * - That query pipeline is enforced through the pipeline parameter of the query itself, in which case the query pipeline condition is bypassed.
      */
     conditionId?: string;
 }

--- a/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
+++ b/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
@@ -25,7 +25,7 @@ interface StatementGroupModelBase {
     id: string;
 
     /**
-     * The name of the statement groups.
+     * The name of the statement group.
      */
     name: string;
 
@@ -35,7 +35,7 @@ interface StatementGroupModelBase {
     description?: string;
 
     /**
-     * The id of the condition that must be met by a query in order to route that query through this query pipeline.
+     * The unique identifier of the condition that must be satisfied for a request to be processed by the statement group.
      * A query cannot be routed through a query pipeline that does not have a condition unless:
      * - That query pipeline is set as the default query pipeline.
      * - That query pipeline is enforced through the pipeline parameter of the query itself, in which case the query pipeline condition is bypassed.
@@ -43,7 +43,7 @@ interface StatementGroupModelBase {
     conditionId?: string;
 
     /**
-     * The id of the condition that must be met by a query in order to route that query through this query pipeline.
+     * The definition of the condition that must be satisfied for a request to be processed by the statement group.
      * A query cannot be routed through a query pipeline that does not have a condition unless:
      * - That query pipeline is set as the default query pipeline.
      * - That query pipeline is enforced through the pipeline parameter of the query itself, in which case the query pipeline condition is bypassed.
@@ -83,7 +83,7 @@ export interface PermanentStatementGroup extends StatementGroupModelBase {
     type: StatementGroupType.permanent;
 
     /**
-     * Whether or not the group is active.
+     * Whether the group is active.
      */
     isActive?: boolean;
 
@@ -198,7 +198,7 @@ export type CreateStatementGroupModel = CreatePermanentStatementGroupModel | Cre
 
 interface CreateStatementGroupModelBase {
     /**
-     * The name of the statement groups.
+     * The name of the statement group.
      */
     name: string;
 
@@ -208,7 +208,7 @@ interface CreateStatementGroupModelBase {
     description?: string;
 
     /**
-     * The id of the condition that must be met by a query in order to route that query through this query pipeline.
+     * The unique identifier of the condition that must be satisfied for a request to be processed by the statement group.
      * A query cannot be routed through a query pipeline that does not have a condition unless:
      * - That query pipeline is set as the default query pipeline.
      * - That query pipeline is enforced through the pipeline parameter of the query itself, in which case the query pipeline condition is bypassed.
@@ -221,7 +221,7 @@ export interface CreatePermanentStatementGroupModel extends CreateStatementGroup
     type: StatementGroupType.permanent;
 
     /**
-     * Whether or not the group is active.
+     * Whether the group is active.
      */
     isActive?: boolean;
 }

--- a/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
+++ b/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
@@ -7,17 +7,47 @@ import {
 
 export interface StatementGroupList {
     groups: StatementGroupModel[];
+
+    /**
+     * The total number of matching statements across all pages of results.
+     */
     totalCount: number;
+
     groupComposition: PipelineGroupsComposition;
 }
 
 export type StatementGroupModel = PermanentStatementGroup | CampaignStatementGroup;
 
 interface StatementGroupModelBase {
+    /**
+     * The unique identifier of the statement group.
+     */
     id: string;
+
+    /**
+     * The name of the statement groups.
+     */
     name: string;
+
+    /**
+     * The intented purpose of this statement group.
+     */
     description?: string;
+
+    /**
+     * The id of the condition that must be met by a query in order to route that query through this query pipeline.
+     * A query cannot be routed through a query pipeline that does not have a condition unless:
+     * - That query pipeline is set as the default query pipeline.
+     * - That query pipeline is enforced through the pipeline parameter of the query itself, in which case the query pipeline condition is bypassed.
+     */
     conditionId?: string;
+
+    /**
+     * The id of the condition that must be met by a query in order to route that query through this query pipeline.
+     * A query cannot be routed through a query pipeline that does not have a condition unless:
+     * - That query pipeline is set as the default query pipeline.
+     * - That query pipeline is enforced through the pipeline parameter of the query itself, in which case the query pipeline condition is bypassed.
+     */
     conditionDefinition?: string;
 
     /**
@@ -27,6 +57,10 @@ interface StatementGroupModelBase {
      * @example 2021-09-09T19:00:45.603-04:00
      */
     createdAt: string;
+
+    /**
+     * The creator principal.
+     */
     createdBy?: string;
 
     /**
@@ -36,6 +70,10 @@ interface StatementGroupModelBase {
      * @example 2021-09-09T19:00:45.603-04:00
      */
     modifiedAt?: string;
+
+    /**
+     * The last modified principal.
+     */
     modifiedBy?: string;
     statementComposition: StatementGroupComposition;
 }
@@ -44,7 +82,14 @@ export interface PermanentStatementGroup extends StatementGroupModelBase {
     // Discriminator
     type: StatementGroupType.permanent;
 
+    /**
+     * Whether or not the group is active.
+     */
     isActive?: boolean;
+
+    /**
+     * The status of the group.
+     */
     status: PermanentStatementGroupStatusType;
 }
 
@@ -58,7 +103,7 @@ export interface CampaignStatementGroup extends StatementGroupModelBase {
      *
      * @example 2020-09-09T19:00:45.603-04:00
      */
-    campaignStart?: string;
+    campaignStart: string;
 
     /**
      * The end date of the campaign.
@@ -66,8 +111,11 @@ export interface CampaignStatementGroup extends StatementGroupModelBase {
      *
      * @example 2021-09-09T19:00:45.603-04:00
      */
-    campaignEnd?: string;
+    campaignEnd: string;
 
+    /**
+     * The status of the campaign.
+     */
     status: CampaignStatementGroupStatusType;
 }
 
@@ -76,6 +124,7 @@ export interface PipelineGroupsComposition {
      * The number of active groups in the pipeline.
      */
     activeGroupCount: number;
+
     /**
      * The number of inactive groups in the pipeline.
      */
@@ -103,7 +152,14 @@ export interface PipelineGroupsComposition {
 }
 
 export interface StatementGroupComposition {
+    /**
+     * The number of result ranking statements in this group.
+     */
     resultRankingStatementCount: number;
+
+    /**
+     * The number of other types of statements in this group.
+     */
     otherStatementCount: number;
 }
 
@@ -138,9 +194,41 @@ export interface ListStatementGroupsOptions {
     types?: StatementGroupType[];
 }
 
-export interface CreateStatementGroupModel {
+export type CreateStatementGroupModel = CreatePermanentStatementGroupModel | CreateCampaignStatementGroupModel;
+
+interface CreateStatementGroupModelBase {
+    /**
+     * The name of the statement groups.
+     */
     name: string;
-    type: StatementGroupType;
+
+    /**
+     * The intented purpose of this statement group.
+     */
+    description?: string;
+
+    /**
+     * The id of the condition that must be met by a query in order to route that query through this query pipeline.
+     * A query cannot be routed through a query pipeline that does not have a condition unless:
+     * - That query pipeline is set as the default query pipeline.
+     * - That query pipeline is enforced through the pipeline parameter of the query itself, in which case the query pipeline condition is bypassed.
+     */
+    conditionId?: string;
+}
+
+export interface CreatePermanentStatementGroupModel extends CreateStatementGroupModelBase {
+    // Discriminator
+    type: StatementGroupType.permanent;
+
+    /**
+     * Whether or not the group is active.
+     */
+    isActive?: boolean;
+}
+
+export interface CreateCampaignStatementGroupModel extends CreateStatementGroupModelBase {
+    // Discriminator
+    type: StatementGroupType.campaign;
 
     /**
      * The start date of the campaign.
@@ -148,7 +236,7 @@ export interface CreateStatementGroupModel {
      *
      * @example 2020-09-09T19:00:45.603-04:00
      */
-    campaignStart?: string;
+    campaignStart: string;
 
     /**
      * The end date of the campaign.
@@ -156,13 +244,13 @@ export interface CreateStatementGroupModel {
      *
      * @example 2021-09-09T19:00:45.603-04:00
      */
-    campaignEnd?: string;
-    description?: string;
-    conditionId?: string;
-    isActive?: boolean;
+    campaignEnd: string;
 }
 
-export interface UpdateStatementGroupModel extends CreateStatementGroupModel {}
+export type UpdateStatementGroupModel = UpdatePermanentStatementGroupModel | UpdateCampaignStatementGroupsModel;
+
+export interface UpdatePermanentStatementGroupModel extends CreatePermanentStatementGroupModel {}
+export interface UpdateCampaignStatementGroupsModel extends CreateCampaignStatementGroupModel {}
 
 export interface UpdateStatementGroupRuleAssociationsRequest {
     /**


### PR DESCRIPTION
BREAKING CHANGE: because the campaign date parameters are now mandatory, it might create a breaking change on the actions used for the StatementGroups.

First part of this PR: https://coveord.atlassian.net/browse/SEARCHAPI-5990

set the campaignStart & campaignEnd parameters as mandatory for the creation/update of campaign.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
