### PR TITLE
revert: "refactor(result-rankings): add associatedGroup.status to ListRR"

### DIFF
--- a/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
@@ -1,7 +1,5 @@
 import {
-    CampaignStatementGroupStatusType,
     ListStatementSortBy,
-    PermanentStatementGroupStatusType,
     ResultRankingLocales,
     ResultRankingMatchOperators,
     ResultRankingsKind,
@@ -10,25 +8,9 @@ import {
 } from '../../Enums';
 
 export interface ResultRanking {
-    /**
-     * The unique identifier of the result ranking rule.
-     */
     id: string;
-    /**
-     * The configuration of the result ranking rule.
-     */
     resultRanking: ResultRankingProps;
-    /**
-     * Associated statement group's information.
-     */
     associatedGroup?: ResultRankingAssociatedGroup;
-}
-
-export interface ListResultRanking extends ResultRanking {
-    /**
-     * Associated statement group's information.
-     */
-    associatedGroup?: ResultRankingAssociatedGroupWithStatus;
 }
 
 export interface ResultRankingProps {
@@ -60,14 +42,6 @@ export interface ResultRankingAssociatedGroup {
     id: string;
     name: string;
     isActive: boolean;
-}
-
-export interface ResultRankingAssociatedGroupWithStatus extends ResultRankingAssociatedGroup {
-    // TODO: Make required: https://coveord.atlassian.net/browse/SEARCHAPI-6177
-    /**
-     * Activation status
-     */
-    status?: CampaignStatementGroupStatusType | PermanentStatementGroupStatusType;
 }
 
 export interface ResultRankingMatchOperator {
@@ -144,7 +118,7 @@ export interface ResultRankingGroupBy {
 }
 
 export interface ListResultRankingResponse {
-    resultRankings: ListResultRanking[];
+    resultRankings: ResultRanking[];
     groupedBy: ResultRankingGroupBy;
     totalCount: number;
     totalPages: number;


### PR DESCRIPTION
This reverts commit 87d23288808bab3719537faa6630f7543fb8c471.

Since my previous commit was identified as a `refactor`, it didn't trigger a new version. 
I'm reverting the commit and I'll merge it back with the `feat()` type.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
