### PR TITLE
feat(result-rankings): add group status to ListResultRanking

### DIFF
--- a/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
@@ -1,5 +1,7 @@
 import {
+    CampaignStatementGroupStatusType,
     ListStatementSortBy,
+    PermanentStatementGroupStatusType,
     ResultRankingLocales,
     ResultRankingMatchOperators,
     ResultRankingsKind,
@@ -8,9 +10,25 @@ import {
 } from '../../Enums';
 
 export interface ResultRanking {
+    /**
+     * The unique identifier of the result ranking rule.
+     */
     id: string;
+    /**
+     * The configuration of the result ranking rule.
+     */
     resultRanking: ResultRankingProps;
+    /**
+     * Associated statement group's information.
+     */
     associatedGroup?: ResultRankingAssociatedGroup;
+}
+
+export interface ListResultRanking extends ResultRanking {
+    /**
+     * Associated statement group's information.
+     */
+    associatedGroup?: ResultRankingAssociatedGroupWithStatus;
 }
 
 export interface ResultRankingProps {
@@ -42,6 +60,14 @@ export interface ResultRankingAssociatedGroup {
     id: string;
     name: string;
     isActive: boolean;
+}
+
+export interface ResultRankingAssociatedGroupWithStatus extends ResultRankingAssociatedGroup {
+    // TODO: Make required: https://coveord.atlassian.net/browse/SEARCHAPI-6177
+    /**
+     * Activation status
+     */
+    status?: CampaignStatementGroupStatusType | PermanentStatementGroupStatusType;
 }
 
 export interface ResultRankingMatchOperator {
@@ -118,7 +144,7 @@ export interface ResultRankingGroupBy {
 }
 
 export interface ListResultRankingResponse {
-    resultRankings: ResultRanking[];
+    resultRankings: ListResultRanking[];
     groupedBy: ResultRankingGroupBy;
     totalCount: number;
     totalPages: number;


### PR DESCRIPTION
When listing all the result ranking rules available, the group status may be returned for rules
associated to a group.

The change is now a `feature` so it will bump the version accordingly and I will be able to leverage it in the admin ui.

https://coveord.atlassian.net/browse/SEARCHAPI-6170

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
