### PR TITLE
feat(snowflake): +createsnowflakereaderaccount call

### DIFF
--- a/src/resources/UsageAnalytics/Read/Snowflake/Snowflake.ts
+++ b/src/resources/UsageAnalytics/Read/Snowflake/Snowflake.ts
@@ -76,14 +76,8 @@ export default class Snowflake extends Resource {
     }
 
     createSnowflakeReaderAccount() {
-        return new Promise<SnowflakeReaderAccountStatusModel>((resolve) =>
-            resolve({snowflakeReaderAccountStatus: SnowflakeReaderAccountStatus.creating})
+        return this.api.post<void>(
+            this.buildPath(`${Snowflake.baseUrl}/readeraccounts`, {org: this.api.organizationId})
         );
-        /*
-         * TODO uncomment when the API call is public
-         */
-        // return this.api.put<SnowflakeReaderAccountStatusModel>(
-        //     this.buildPath(`${Snowflake.baseUrl}/readeraccount`, {org: this.api.organizationId})
-        // );
     }
 }

--- a/src/resources/UsageAnalytics/Read/Snowflake/tests/Snowflake.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Snowflake/tests/Snowflake.spec.ts
@@ -121,14 +121,12 @@ describe('Snowflake', () => {
         });
     });
 
-    // TODO remove when api is ready
-    // eslint-disable-next-line jest/no-disabled-tests
-    describe.skip('putSnowflakeReaderAccount', () => {
+    describe('putSnowflakeReaderAccount', () => {
         it('makes a PUT call to the specific Snowflake url', () => {
             snowflake.createSnowflakeReaderAccount();
 
-            expect(api.put).toHaveBeenCalledTimes(1);
-            expect(api.put).toHaveBeenCalledWith(`${Snowflake.baseUrl}/readeraccount`);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Snowflake.baseUrl}/readeraccounts`);
         });
     });
 });


### PR DESCRIPTION
Backend post call for snowflake reader account creation is now available, so I'va added it up and will remove the _fake_ loading on the ui side

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
