### PR TITLE
feat(search-interface): add new route for sharing

### DIFF
--- a/src/resources/SearchInterfaces/SearchInterfaces.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.ts
@@ -46,4 +46,12 @@ export default class SearchInterfaces extends Resource {
     updateAccessesUsers(interfaceId: string, users: string[]): Promise<string[]> {
         return this.api.put(`${SearchInterfaces.baseUrl}/${interfaceId}/accesses/users`, users);
     }
+
+    addAccessesUsers(interfaceId: string, users: string[], notify?: boolean, message?: string): Promise<string[]> {
+        const body = message ? {users, message} : {users};
+        return this.api.post(
+            `${SearchInterfaces.baseUrl}/${interfaceId}/accesses/users${notify ? '?notify=1' : ''}`,
+            body
+        );
+    }
 }

--- a/src/resources/SearchInterfaces/tests/SearchInterfaces.spec.ts
+++ b/src/resources/SearchInterfaces/tests/SearchInterfaces.spec.ts
@@ -185,4 +185,45 @@ describe('SearchInterfaces', () => {
             expect(api.put).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/${id}/accesses/users`, someUsers);
         });
     });
+
+    describe('addAccessesUsers', () => {
+        it('makes a POST call to the searchInterfaces accesses users url based on the interfaceId', () => {
+            const id = 'search-interface-id';
+            const someUsers = ['Tinky Winky', 'Dipsy', 'Laa-Laa', 'Po'];
+
+            searchInterfaces.addAccessesUsers(id, someUsers);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/${id}/accesses/users`, {
+                users: someUsers,
+            });
+        });
+
+        it('makes a POST with a notify query param when notify is true', () => {
+            const id = 'search-interface-id';
+            const someUsers = ['Tinky Winky', 'Dipsy', 'Laa-Laa', 'Po'];
+
+            searchInterfaces.addAccessesUsers(id, someUsers, true);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/${id}/accesses/users?notify=1`, {
+                users: someUsers,
+            });
+        });
+
+        it('makes a POST with a message body param when notify is true and a message is provided', () => {
+            const id = 'search-interface-id';
+            const someUsers = ['Tinky Winky', 'Dipsy', 'Laa-Laa', 'Po'];
+            const message =
+                'The oldest and strongest emotion of mankind is fear, and the oldest and strongest kind of fear is fear of the unknown.';
+
+            searchInterfaces.addAccessesUsers(id, someUsers, true, message);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/${id}/accesses/users?notify=1`, {
+                users: someUsers,
+                message,
+            });
+        });
+    });
 });


### PR DESCRIPTION
Added a new route for sharing a search to some users.

### Acceptance Criteria

-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
