### PR TITLE
feat(snowflake.ts): +daystoexpiry attribute to the snowflake user model

### DIFF
--- a/src/resources/UsageAnalytics/Read/Snowflake/SnowflakeInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Snowflake/SnowflakeInterfaces.ts
@@ -5,8 +5,18 @@ export interface SnowflakeUsersModel {
 }
 
 export interface SnowflakeUserModel {
+    /**
+     * The username of the user
+     */
     username: string;
+    /**
+     * The email of the user
+     */
     email: string;
+    /**
+     * The number of days that the user has access to the reader account, ranging from 0 (indefinitely) to 90 days)
+     */
+    daysToExpiry?: number;
 }
 
 export interface SnowflakeNetworkPolicyModel {

--- a/src/resources/UsageAnalytics/Read/Snowflake/tests/Snowflake.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Snowflake/tests/Snowflake.spec.ts
@@ -30,6 +30,7 @@ describe('Snowflake', () => {
             const model: SnowflakeUserModel = {
                 username: 'ross.blais',
                 email: 'ross.blais@gmail.com',
+                daysToExpiry: 66,
             };
             snowflake.createUser(model);
 


### PR DESCRIPTION
This new attributes will let the admin manage the timelapse that the user has access to his snowflake reader account (view it as a temporary access, but it's possible for indefinite access

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
