### PR TITLE
fix(result-rankings): make ResultRankingAssociatedGroupWithStatus.status mandatory

### DIFF
--- a/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
@@ -63,11 +63,10 @@ export interface ResultRankingAssociatedGroup {
 }
 
 export interface ResultRankingAssociatedGroupWithStatus extends ResultRankingAssociatedGroup {
-    // TODO: Make required: https://coveord.atlassian.net/browse/SEARCHAPI-6177
     /**
      * Activation status
      */
-    status?: CampaignStatementGroupStatusType | PermanentStatementGroupStatusType;
+    status: CampaignStatementGroupStatusType | PermanentStatementGroupStatusType;
 }
 
 export interface ResultRankingMatchOperator {

--- a/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
+++ b/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
@@ -197,7 +197,7 @@ interface CreateStatementGroupModelBase {
     name: string;
 
     /**
-     * The intented purpose of this statement group.
+     * The intended purpose of this statement group.
      */
     description?: string;
 


### PR DESCRIPTION
Now that the change is in production for good, we can make the field required.
https://coveord.atlassian.net/browse/SEARCHAPI-6177

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
