### PR TITLE
feat(licenseconstants): added creationOrigin query parameter

### DIFF
--- a/src/resources/License/LicenseInterfaces.ts
+++ b/src/resources/License/LicenseInterfaces.ts
@@ -46,3 +46,78 @@ export interface LicenseExpirationDateOptions {
      */
     expirationDate: number;
 }
+
+/**
+ * Monitoring level determines the alerts raised when a problem is detected on an organization
+ */
+export enum LicenseMonitoringLevel {
+    /**
+     * The organization is completely ignored, no one will be alerted or try to save it if the search is down
+     */
+    NO_MONITORING = 'NO_MONITORING',
+    /**
+     * The organization is monitored but problems are raised as low level alerts
+     * People on maintenance will try to fix the organization if they happen to look at the low-level alerting channels
+     */
+    BASIC_MONITORING = 'BASIC_MONITORING',
+    /**
+     * The organization is actively monitored and problems raise pagers that would wake up on-duty developers at night
+     */
+    REGULAR_MONITORING = 'REGULAR_MONITORING',
+    /**
+     * The organization is actively monitored with an aggressive schedule so any potential problem
+     * is identified under a minute
+     */
+    STRATEGIC_MONITORING = 'STRATEGIC_MONITORING',
+}
+
+/**
+ * Back-up type determines which index data is backed-up periodically
+ */
+export enum LicenseIndexBackType {
+    /**
+     * The organization's index is not backed-up. If the organization is deleted all the data must be crawled again.
+     */
+    NONE = 'NONE',
+    /**
+     * The organization's index is backed-up periodically. If the organization is deleted all the data can be restored.
+     */
+    REGULAR = 'REGULAR',
+    /**
+     * The organization's index is backed-up periodically. If the organization is deleted all the data can be restored.
+     * Equivalent to REGULAR
+     */
+    FULL = 'FULL',
+}
+
+/**
+ * Configurability level of ML models
+ */
+export enum LicenseMlModelConfigurability {
+    /**
+     * No advanced configurability available
+     */
+    NONE = 'NONE',
+    /**
+     * All advanced configurability options available
+     */
+    FULL = 'FULL',
+}
+
+/**
+ * Usage analytics visualization levels
+ */
+export enum LicenseDataVisualizationAccessLevel {
+    /**
+     * Basic access
+     */
+    BASIC = 'BASIC',
+    /**
+     * Read access to Tableau data
+     */
+    TABLEAU_READ = 'TABLEAU_READ',
+    /**
+     * Write access to Tableau data
+     */
+    TABLEAU_WRITE = 'TABLEAU_WRITE',
+}

--- a/src/resources/Organizations/OrganizationInterfaces.ts
+++ b/src/resources/Organizations/OrganizationInterfaces.ts
@@ -48,9 +48,22 @@ export interface ListOrganizationOptions {
 }
 
 export interface CreateOrganizationOptions {
+    /*
+     * The human-readable display name to give to the organization
+     */
     name: string;
+    /*
+     * The name of the template to create the initial organization definition
+     */
     organizationTemplate?: string;
+    /*
+     * The owner of the organization, usually an email address
+     */
     owner?: string;
+    /*
+     * Metadata about the context where the organization creation request originated
+     */
+    creationOrigin?: OrganizationCreationOrigin;
 }
 
 export interface DefinitionModel {
@@ -82,4 +95,54 @@ export interface OverrideModel {
      * List of statements to apply when computing the resulting license
      */
     statements: ModifierStatementModel[];
+}
+
+/*
+ * Metadata about the context where the organization creation request originated
+ */
+export enum OrganizationCreationOrigin {
+    /*
+     * Created from the Coveo Administration Console
+     */
+    ADMIN_UI = 'ADMIN_UI',
+    /*
+     * Created from the API, default value in the backend if parameter is omitted
+     */
+    API = 'API',
+    /*
+     * Created when syncing from our CRM solution
+     */
+    BUSINESS_CRM = 'BUSINESS_CRM',
+    /*
+     * Created from a training portal
+     */
+    TRAINING = 'TRAINING',
+    /*
+     * Created by one of our partners
+     */
+    PARTNER_PROGRAM = 'PARTNER_PROGRAM',
+    /*
+     * Created as a scratch organization
+     */
+    TEST = 'TEST',
+    /*
+     * Created from the Coveo website
+     */
+    WEBSITE = 'WEBSITE',
+    /*
+     * Created from the Salesforce Coveo integration package
+     */
+    SALESFORCE_INTEGRATION_TRIAL = 'SALESFORCE_INTEGRATION_TRIAL',
+    /*
+     * Created from the ServiceNow Coveo integration package
+     */
+    SERVICENOW_INTEGRATION_TRIAL = 'SERVICENOW_INTEGRATION_TRIAL',
+    /*
+     * Created from the Sitecore Coveo integration package
+     */
+    SITECORE_INTEGRATION_TRIAL = 'SITECORE_INTEGRATION_TRIAL',
+    /*
+     * Unknown origin
+     */
+    UNKNOWN = 'UNKNOWN',
 }

--- a/src/resources/Organizations/tests/Organizations.spec.ts
+++ b/src/resources/Organizations/tests/Organizations.spec.ts
@@ -1,7 +1,7 @@
 import API from '../../../APICore';
 import Members from '../Members/Members';
 import Organization from '../Organization';
-import {DefinitionModel} from '../OrganizationInterfaces';
+import {DefinitionModel, OrganizationCreationOrigin} from '../OrganizationInterfaces';
 
 jest.mock('../../../APICore');
 
@@ -56,10 +56,13 @@ describe('Organization', () => {
     describe('create', () => {
         it('should make a POST call to the Organization base url with the parameters', () => {
             const name = 'OrgName';
+            const creationOrigin = OrganizationCreationOrigin.TEST;
 
-            organization.create({name});
+            organization.create({name, creationOrigin});
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(`${Organization.baseUrl}?name=${name}`);
+            expect(api.post).toHaveBeenCalledWith(
+                `${Organization.baseUrl}?name=${name}&creationOrigin=${creationOrigin}`
+            );
         });
     });
 


### PR DESCRIPTION
Added creationOrigin query parameter on organization creation call and license constants to avoid duplication and magic strings when manipulating the license properties

FOUND-3671

### Acceptance Criteria

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
