### PR TITLE
feat: add creationOrigin for CLI

### DIFF
--- a/src/resources/Organizations/OrganizationInterfaces.ts
+++ b/src/resources/Organizations/OrganizationInterfaces.ts
@@ -110,6 +110,10 @@ export enum OrganizationCreationOrigin {
      */
     API = 'API',
     /*
+     * Created from the Coveo CLI
+     */
+    CLI = 'CLI',
+    /*
      * Created when syncing from our CRM solution
      */
     BUSINESS_CRM = 'BUSINESS_CRM',


### PR DESCRIPTION
Added a new `creationOrigin` value to track org creation from the [Coveo CLI](https://docs.coveo.com/en/cli/). 
Jira: [CDX-638](https://coveord.atlassian.net/browse/CDX-638)

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
