### PR TITLE
feat(result-rankings-interface): add missing attributes and jsdoc

### DIFF
--- a/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
@@ -176,7 +176,7 @@ export interface ResultRankingLocalizedContentLocale {
 export interface ResultRankingLocalizedContentLocaleAuto {
     auto: {
         /**
-         * The default locale of the knowledge article to default to if it's not available in the user's locale.
+         * The default locale of the knowledge article to default to if it's not available in the user's locale. (IETF BCP 47)
          */
         default: string;
     };
@@ -184,7 +184,7 @@ export interface ResultRankingLocalizedContentLocaleAuto {
 
 export interface ResultRankingLocalizedContentLocaleSpecific {
     /**
-     * The locale code of the knowledge article to show.
+     * The locale code of the knowledge article to show. (IETF BCP 47)
      */
     code: string;
 }


### PR DESCRIPTION
Story: https://coveord.atlassian.net/browse/SEARCHAPI-6408

This modifications is to include the missing attributes (`modifiedAt` and `modifiedBy`) for the `resultRanking` interface. I've also added the JSDoc for these interfaces that is available on Swagger.

### Acceptance Criteria

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
