### PR TITLE
feat(search-hubs): add requests and interfaces

### DIFF
--- a/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
@@ -3,7 +3,6 @@ import Resource from '../../Resource';
 import {
     SearchHubNameParams,
     RestSearchHub,
-    SearchHubModel,
     UpdateSearchHubParams,
     UpdateSearchHubBucketParams,
 } from './SearchHubsInterface';
@@ -15,7 +14,7 @@ export default class SearchHubs extends Resource {
         return this.api.get<{hubs: RestSearchHub[]}>(SearchHubs.baseUrl);
     }
 
-    create(params: SearchHubModel) {
+    create(params: RestSearchHub) {
         return this.api.post<void>(SearchHubs.baseUrl, params);
     }
 
@@ -28,7 +27,7 @@ export default class SearchHubs extends Resource {
     }
 
     update({hubName, hub}: UpdateSearchHubParams) {
-        return this.api.put<void>(`${SearchHubs.baseUrl}${hubName}`, {hub});
+        return this.api.put<void>(`${SearchHubs.baseUrl}${hubName}`, hub);
     }
 
     updateBucket({hubName, bucket}: UpdateSearchHubBucketParams) {

--- a/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
@@ -6,7 +6,6 @@ import {
     RestSearchHub,
     SearchHubModel,
     UpdateSearchHubParams,
-    DeleteSearchHubParams,
     UpdateSearchHubBucketParams,
 } from './SearchHubsInterface';
 
@@ -31,7 +30,7 @@ export default class SearchHubs extends Resource {
         );
     }
 
-    delete({hubName}: DeleteSearchHubParams) {
+    delete({hubName}: SearchHubNameParams) {
         return this.api.delete<void>(
             this.buildPath(`${SearchHubs.baseUrl}/${hubName}`, {organizationId: this.api.organizationId})
         );

--- a/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
@@ -1,0 +1,55 @@
+import API from '../../../APICore';
+import Resource from '../../Resource';
+import {
+    SearchHubsList,
+    SearchHubNameParams,
+    RestSearchHub,
+    SearchHubModel,
+    UpdateSearchHubParams,
+    DeleteSearchHubParams,
+    UpdateSearchHubBucketParams,
+} from './SearchHubsInterface';
+
+export default class SearchHubs extends Resource {
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/searchusagemetrics/hubs`;
+
+    list() {
+        return this.api.get<SearchHubsList>(
+            this.buildPath(SearchHubs.baseUrl, {organizationId: this.api.organizationId})
+        );
+    }
+
+    create(params: SearchHubModel) {
+        return this.api.post<void>(this.buildPath(SearchHubs.baseUrl, {organizationId: this.api.organizationId}), {
+            ...params,
+        });
+    }
+
+    get({hubName}: SearchHubNameParams) {
+        return this.api.get<RestSearchHub>(
+            this.buildPath(`${SearchHubs.baseUrl}/${hubName}`, {organizationId: this.api.organizationId})
+        );
+    }
+
+    delete({hubName}: DeleteSearchHubParams) {
+        return this.api.delete<void>(
+            this.buildPath(`${SearchHubs.baseUrl}/${hubName}`, {organizationId: this.api.organizationId})
+        );
+    }
+
+    update({hubName, hub}: UpdateSearchHubParams) {
+        return this.api.put<void>(
+            this.buildPath(`${SearchHubs.baseUrl}/${hubName}`, {organizationId: this.api.organizationId}),
+            {hub}
+        );
+    }
+
+    updateBucket({hubName, bucket}: UpdateSearchHubBucketParams) {
+        return this.api.put<void>(
+            this.buildPath(`${SearchHubs.baseUrl}/${hubName}`, {
+                bucket,
+                organizationId: this.api.organizationId,
+            })
+        );
+    }
+}

--- a/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
@@ -9,45 +9,32 @@ import {
 } from './SearchHubsInterface';
 
 export default class SearchHubs extends Resource {
-    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/searchusagemetrics/hubs`;
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/searchusagemetrics/hubs/`;
 
     list() {
-        return this.api.get<{hubs: RestSearchHub[]}>(
-            this.buildPath(SearchHubs.baseUrl, {organizationId: this.api.organizationId})
-        );
+        return this.api.get<{hubs: RestSearchHub[]}>(SearchHubs.baseUrl);
     }
 
     create(params: SearchHubModel) {
-        return this.api.post<void>(
-            this.buildPath(SearchHubs.baseUrl, {organizationId: this.api.organizationId}),
-            params
-        );
+        return this.api.post<void>(SearchHubs.baseUrl, params);
     }
 
     get({hubName}: SearchHubNameParams) {
-        return this.api.get<RestSearchHub>(
-            this.buildPath(`${SearchHubs.baseUrl}/${hubName}`, {organizationId: this.api.organizationId})
-        );
+        return this.api.get<RestSearchHub>(`${SearchHubs.baseUrl}${hubName}`);
     }
 
     delete({hubName}: SearchHubNameParams) {
-        return this.api.delete<void>(
-            this.buildPath(`${SearchHubs.baseUrl}/${hubName}`, {organizationId: this.api.organizationId})
-        );
+        return this.api.delete<void>(`${SearchHubs.baseUrl}${hubName}`);
     }
 
     update({hubName, hub}: UpdateSearchHubParams) {
-        return this.api.put<void>(
-            this.buildPath(`${SearchHubs.baseUrl}/${hubName}`, {organizationId: this.api.organizationId}),
-            {hub}
-        );
+        return this.api.put<void>(`${SearchHubs.baseUrl}${hubName}`, {hub});
     }
 
     updateBucket({hubName, bucket}: UpdateSearchHubBucketParams) {
         return this.api.put<void>(
-            this.buildPath(`${SearchHubs.baseUrl}/${hubName}`, {
+            this.buildPath(`${SearchHubs.baseUrl}${hubName}/bucket`, {
                 bucket,
-                organizationId: this.api.organizationId,
             })
         );
     }

--- a/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
@@ -1,7 +1,6 @@
 import API from '../../../APICore';
 import Resource from '../../Resource';
 import {
-    SearchHubsList,
     SearchHubNameParams,
     RestSearchHub,
     SearchHubModel,
@@ -13,15 +12,16 @@ export default class SearchHubs extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/searchusagemetrics/hubs`;
 
     list() {
-        return this.api.get<SearchHubsList>(
+        return this.api.get<{hubs: RestSearchHub[]}>(
             this.buildPath(SearchHubs.baseUrl, {organizationId: this.api.organizationId})
         );
     }
 
     create(params: SearchHubModel) {
-        return this.api.post<void>(this.buildPath(SearchHubs.baseUrl, {organizationId: this.api.organizationId}), {
-            ...params,
-        });
+        return this.api.post<void>(
+            this.buildPath(SearchHubs.baseUrl, {organizationId: this.api.organizationId}),
+            params
+        );
     }
 
     get({hubName}: SearchHubNameParams) {

--- a/src/resources/SearchUsageMetrics/SearchHubs/SearchHubsInterface.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/SearchHubsInterface.ts
@@ -15,18 +15,18 @@ export interface RestSearchHub {
     description?: string;
 }
 
-export interface SearchHubModel {
-    /**
-     * The search hub data
-     */
-    hub: RestSearchHub;
-}
-
 export interface SearchHubNameParams {
     /**
      * The search hub name
      */
     hubName: string;
+}
+
+interface SearchHubModel {
+    /**
+     * The search hub data
+     */
+    hub: RestSearchHub;
 }
 
 interface SearchHubBucketParams {

--- a/src/resources/SearchUsageMetrics/SearchHubs/SearchHubsInterface.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/SearchHubsInterface.ts
@@ -22,13 +22,6 @@ export interface SearchHubModel {
     hub: RestSearchHub;
 }
 
-export interface SearchHubsList {
-    /**
-     * List of search hub data
-     */
-    hubs: RestSearchHub[];
-}
-
 export interface SearchHubNameParams {
     /**
      * The search hub name

--- a/src/resources/SearchUsageMetrics/SearchHubs/SearchHubsInterface.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/SearchHubsInterface.ts
@@ -1,0 +1,50 @@
+export interface RestSearchHub {
+    /**
+     * The name of the search hub
+     */
+    name: string;
+
+    /**
+     * The usage bucket to count queries from this hub into
+     */
+    bucket?: string;
+
+    /**
+     * A description for the search hub
+     */
+    description?: string;
+}
+
+export interface SearchHubModel {
+    /**
+     * The search hub data
+     */
+    hub: RestSearchHub;
+}
+
+export interface SearchHubsList {
+    /**
+     * List of search hub data
+     */
+    hubs: RestSearchHub[];
+}
+
+export interface SearchHubNameParams {
+    /**
+     * The search hub name
+     */
+    hubName: string;
+}
+
+interface SearchHubBucketParams {
+    /**
+     * The search hub bucket
+     */
+    bucket: string;
+}
+
+export type DeleteSearchHubParams = SearchHubNameParams;
+
+export type UpdateSearchHubParams = SearchHubNameParams & SearchHubModel;
+
+export type UpdateSearchHubBucketParams = SearchHubNameParams & SearchHubBucketParams;

--- a/src/resources/SearchUsageMetrics/SearchHubs/SearchHubsInterface.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/SearchHubsInterface.ts
@@ -43,8 +43,6 @@ interface SearchHubBucketParams {
     bucket: string;
 }
 
-export type DeleteSearchHubParams = SearchHubNameParams;
-
 export type UpdateSearchHubParams = SearchHubNameParams & SearchHubModel;
 
 export type UpdateSearchHubBucketParams = SearchHubNameParams & SearchHubBucketParams;

--- a/src/resources/SearchUsageMetrics/SearchHubs/index.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/index.ts
@@ -1,0 +1,2 @@
+export * from './SearchHubs';
+export * from './SearchHubsInterface';

--- a/src/resources/SearchUsageMetrics/SearchHubs/tests/SearchHubs.spec.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/tests/SearchHubs.spec.ts
@@ -26,11 +26,11 @@ describe('SearchHubs', () => {
 
     describe('create', () => {
         it('makes a POST call to the SearchHub base url with the set hub', () => {
-            const newSearchHub = {hub: {name: 'hello', bucket: 'bonjour', description: 'hola'}};
+            const newSearchHub = {name: 'hello', bucket: 'bonjour', description: 'hola'};
             searchHubs.create(newSearchHub);
 
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(`${SearchHubs.baseUrl}`, {hub: newSearchHub.hub});
+            expect(api.post).toHaveBeenCalledWith(`${SearchHubs.baseUrl}`, newSearchHub);
         });
     });
 
@@ -61,9 +61,10 @@ describe('SearchHubs', () => {
             searchHubs.update(updateSearchHub);
 
             expect(api.put).toHaveBeenCalledTimes(1);
-            expect(api.put).toHaveBeenCalledWith(`${SearchHubs.baseUrl}${updateSearchHub.hubName}`, {
-                hub: updateSearchHubParams,
-            });
+            expect(api.put).toHaveBeenCalledWith(
+                `${SearchHubs.baseUrl}${updateSearchHub.hubName}`,
+                updateSearchHubParams
+            );
         });
     });
 

--- a/src/resources/SearchUsageMetrics/SearchHubs/tests/SearchHubs.spec.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/tests/SearchHubs.spec.ts
@@ -40,7 +40,7 @@ describe('SearchHubs', () => {
             searchHubs.get(getSearchHub);
 
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${SearchHubs.baseUrl}/${getSearchHub.hubName}`);
+            expect(api.get).toHaveBeenCalledWith(`${SearchHubs.baseUrl}${getSearchHub.hubName}`);
         });
     });
 
@@ -50,7 +50,7 @@ describe('SearchHubs', () => {
             searchHubs.delete(deleteSearchHub);
 
             expect(api.delete).toHaveBeenCalledTimes(1);
-            expect(api.delete).toHaveBeenCalledWith(`${SearchHubs.baseUrl}/${deleteSearchHub.hubName}`);
+            expect(api.delete).toHaveBeenCalledWith(`${SearchHubs.baseUrl}${deleteSearchHub.hubName}`);
         });
     });
 
@@ -61,7 +61,7 @@ describe('SearchHubs', () => {
             searchHubs.update(updateSearchHub);
 
             expect(api.put).toHaveBeenCalledTimes(1);
-            expect(api.put).toHaveBeenCalledWith(`${SearchHubs.baseUrl}/${updateSearchHub.hubName}`, {
+            expect(api.put).toHaveBeenCalledWith(`${SearchHubs.baseUrl}${updateSearchHub.hubName}`, {
                 hub: updateSearchHubParams,
             });
         });
@@ -74,7 +74,7 @@ describe('SearchHubs', () => {
 
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(
-                `${SearchHubs.baseUrl}/${updateBucketSearchHub.hubName}?bucket=${updateBucketSearchHub.bucket}`
+                `${SearchHubs.baseUrl}${updateBucketSearchHub.hubName}/bucket?bucket=${updateBucketSearchHub.bucket}`
             );
         });
     });

--- a/src/resources/SearchUsageMetrics/SearchHubs/tests/SearchHubs.spec.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/tests/SearchHubs.spec.ts
@@ -1,0 +1,81 @@
+import API from '../../../../APICore';
+import SearchHubs from '../SearchHubs';
+
+jest.mock('../../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('SearchHubs', () => {
+    let searchHubs: SearchHubs;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        searchHubs = new SearchHubs(api, serverlessApi);
+    });
+
+    describe('list', () => {
+        it('makes a GET call to the SearchHub base url', () => {
+            searchHubs.list();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(SearchHubs.baseUrl);
+        });
+    });
+
+    describe('create', () => {
+        it('makes a POST call to the SearchHub base url with the set hub', () => {
+            const newSearchHub = {hub: {name: 'hello', bucket: 'bonjour', description: 'hola'}};
+            searchHubs.create(newSearchHub);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${SearchHubs.baseUrl}`, {hub: newSearchHub.hub});
+        });
+    });
+
+    describe('get', () => {
+        it('makes a GET call to the specific SearchHub url', () => {
+            const getSearchHub = {hubName: 'hello'};
+            searchHubs.get(getSearchHub);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${SearchHubs.baseUrl}/${getSearchHub.hubName}`);
+        });
+    });
+
+    describe('delete', () => {
+        it('makes a DELETE call to the specific SearchHub url', () => {
+            const deleteSearchHub = {hubName: 'hello'};
+            searchHubs.delete(deleteSearchHub);
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${SearchHubs.baseUrl}/${deleteSearchHub.hubName}`);
+        });
+    });
+
+    describe('update', () => {
+        it('makes a PUT call to the specific SearchHub url', () => {
+            const updateSearchHubParams = {name: 'hello', bucket: 'bonjour', description: 'hola'};
+            const updateSearchHub = {hubName: 'hello', hub: updateSearchHubParams};
+            searchHubs.update(updateSearchHub);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${SearchHubs.baseUrl}/${updateSearchHub.hubName}`, {
+                hub: updateSearchHubParams,
+            });
+        });
+    });
+
+    describe('updateBucket', () => {
+        it('makes a PUT call to the bucket SearchHub url', () => {
+            const updateBucketSearchHub = {hubName: 'hello', bucket: 'bonjour'};
+            searchHubs.updateBucket(updateBucketSearchHub);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `${SearchHubs.baseUrl}/${updateBucketSearchHub.hubName}?bucket=${updateBucketSearchHub.bucket}`
+            );
+        });
+    });
+});

--- a/src/resources/SearchUsageMetrics/SearchUsageMetrics.ts
+++ b/src/resources/SearchUsageMetrics/SearchUsageMetrics.ts
@@ -1,13 +1,16 @@
 import API from '../../APICore';
 import Resource from '../Resource';
 import LicenseMetrics from './LicenseMetrics/LicenseMetrics';
+import SearchHubs from './SearchHubs/SearchHubs';
 
 export default class SearchUsageMetrics extends Resource {
     licenseMetrics: LicenseMetrics;
+    searchHubs: SearchHubs;
 
     constructor(protected api: API, protected serverlessApi: API) {
         super(api, serverlessApi);
 
         this.licenseMetrics = new LicenseMetrics(api, serverlessApi);
+        this.searchHubs = new SearchHubs(api, serverlessApi);
     }
 }

--- a/src/resources/SearchUsageMetrics/index.ts
+++ b/src/resources/SearchUsageMetrics/index.ts
@@ -1,2 +1,3 @@
 export * from './SearchUsageMetrics';
 export * from './LicenseMetrics';
+export * from './SearchHubs';


### PR DESCRIPTION
Story: https://coveord.atlassian.net/browse/SEARCHAPI-6437
Based on that section on Swagger: https://platformdev.cloud.coveo.com/docs/?urls.primaryName=Search%20Usage%20Metrics#/

Added the SearchHubs interfaces and requests to be used in the Admin-UI after

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
