### PR TITLE
ci: fix the git credentials

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -21,8 +21,8 @@ pipeline {
 
   environment {
     NPM_TOKEN = credentials("npmjs_com_token")
-    GIT = credentials("github-coveobot")
-    GH_TOKEN = credentials("github-coveobot_token")
+    GIT = credentials("github-commit-token")
+    GH_TOKEN = credentials("github-commit-token")
   }
 
   options {
@@ -46,7 +46,7 @@ pipeline {
             $class: 'GitSCM',
             branches: scm.branches,
             extensions: scm.extensions + [[$class: "CleanCheckout"]] + [[$class: "LocalBranch", localBranch: "**"]] + [[$class: 'CloneOption', noTags: false, reference: '', shallow: false]],
-            userRemoteConfigs: [[credentialsId: "github-coveobot", url: "https://github.com/coveo/platform-client.git"]]
+            userRemoteConfigs: [[credentialsId: "github-app-dev", url: "https://github.com/coveo/platform-client.git"]]
           ])
 
           sh "git config --global user.email \"jenkins@coveo.com\""


### PR DESCRIPTION
### Proposed Changes

There was a rotation of credentials, and it seems the new token cannot publish anymore. I switched to the same credentials we use in admin-ui

I made the same changes that were made on the [ReactVapor](https://github.com/coveo/react-vapor/pull/2205) side.
@GermainBergeron is ok for you?

### Potential Breaking Changes

None
