### PR TITLE
ci: use token github in writing

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -22,9 +22,9 @@ pipeline {
   environment {
     NPM_TOKEN = credentials("npmjs_com_token")
     GIT = credentials("github-coveobot")
-    GH_TOKEN = credentials("github-coveobot_token")
-  }
+    GH_TOKEN = credentials("github-commit-token")
 
+  }
   options {
     ansiColor("xterm")
     timestamps()


### PR DESCRIPTION
After discussion with the `dev_tooling` team, the token we use has been modified in read-only mode, this change is made to have the token in writing.