### PR TITLE
fix!: send usePageModel=true for method as it is deprecated on API 

### DIFF
--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -18,9 +18,13 @@ export default class SecurityCache extends Ressource {
     static cacheUrl = `/${SecurityCache.baseUrl}/securitycache`;
     static providersUrl = `/${SecurityCache.baseUrl}/securityproviders`;
 
-    listMembers(providerId: string, options?: SecurityCacheListOptions) {
+    listMembers(
+        providerId: string,
+        options: SecurityCacheListOptions = {}
+    ): Promise<PageModel<DetailedSecurityCacheMemberModel>> {
+        // TODO: SECCACHE-710 remove `usePageModel` once API has removed this parameter
         return this.api.get<PageModel<DetailedSecurityCacheMemberModel>>(
-            this.buildPath(`${SecurityCache.cacheUrl}/entities/${providerId}/members`, options)
+            this.buildPath(`${SecurityCache.cacheUrl}/entities/${providerId}/members`, {...options, usePageModel: true})
         );
     }
 

--- a/src/resources/SecurityCache/SecurityCacheInterfaces.ts
+++ b/src/resources/SecurityCache/SecurityCacheInterfaces.ts
@@ -128,7 +128,6 @@ export interface SecurityCacheListOptions {
     securityProviderId?: string;
     states?: SecurityCacheStateOptions;
     to?: string;
-    usePageModel?: boolean;
 }
 
 export interface SecurityCacheListRelationshipsOptions {

--- a/src/resources/SecurityCache/tests/SecurityCache.spec.ts
+++ b/src/resources/SecurityCache/tests/SecurityCache.spec.ts
@@ -23,7 +23,9 @@ describe('securityCache', () => {
         it('should make a GET call to the securityCache correct url with listMembers', () => {
             securityCache.listMembers(providerId);
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${SecurityCache.cacheUrl}/entities/${providerId}/members`);
+            expect(api.get).toHaveBeenCalledWith(
+                `${SecurityCache.cacheUrl}/entities/${providerId}/members?usePageModel=true`
+            );
         });
 
         it('should make a GET call to the securityCache correct url with listEntities', () => {


### PR DESCRIPTION
After some discussion and to future proof.  The `usePageModel` parameter should be marked as required, true (to prevent confusion), and as deprecated, as it will be removed.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] JSDoc annotates each property added in the exported interfaces
-   [] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
