### PR TITLE
feat(mlconfig)!: added support for ss config model preview calls

### DIFF
--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfiguration.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfiguration.ts
@@ -12,27 +12,27 @@ import {
 } from './SmartSnippetsConfigurationInterfaces';
 
 export default class SmartSnippetsConfiguration extends Resource {
-    static rootUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/smartsnippets`;
-    static baseUrl = `${SmartSnippetsConfiguration.rootUrl}/model`;
-    static contentFieldsUrl = `${SmartSnippetsConfiguration.rootUrl}/contentfields`;
-    static documentTypesUrl = `${SmartSnippetsConfiguration.rootUrl}/documenttypes`;
-    static previewUrl = `${SmartSnippetsConfiguration.rootUrl}/preview`;
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/smartsnippets`;
+    static modelUrl = `${SmartSnippetsConfiguration.baseUrl}/model`;
+    static contentFieldsUrl = `${SmartSnippetsConfiguration.baseUrl}/contentfields`;
+    static documentTypesUrl = `${SmartSnippetsConfiguration.baseUrl}/documenttypes`;
+    static previewUrl = `${SmartSnippetsConfiguration.baseUrl}/preview`;
 
     create(configModel: New<SmartSnippetsConfigurationModel, 'modelId'>) {
-        return this.api.post<SmartSnippetsConfigurationModel>(SmartSnippetsConfiguration.baseUrl, configModel);
+        return this.api.post<SmartSnippetsConfigurationModel>(SmartSnippetsConfiguration.modelUrl, configModel);
     }
 
     delete(modelId: string) {
-        return this.api.delete(`${SmartSnippetsConfiguration.baseUrl}/${modelId}`);
+        return this.api.delete(`${SmartSnippetsConfiguration.modelUrl}/${modelId}`);
     }
 
     get(modelId: string) {
-        return this.api.get<SmartSnippetsConfigurationModel>(`${SmartSnippetsConfiguration.baseUrl}/${modelId}`);
+        return this.api.get<SmartSnippetsConfigurationModel>(`${SmartSnippetsConfiguration.modelUrl}/${modelId}`);
     }
 
     update(configModel: SmartSnippetsConfigurationModel) {
         return this.api.put<SmartSnippetsConfigurationModel>(
-            `${SmartSnippetsConfiguration.baseUrl}/${configModel.modelId}`,
+            `${SmartSnippetsConfiguration.modelUrl}/${configModel.modelId}`,
             configModel
         );
     }

--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfiguration.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfiguration.ts
@@ -1,10 +1,22 @@
 import API from '../../../APICore';
 import {New} from '../../BaseInterfaces';
 import Resource from '../../Resource';
-import {SmartSnippetsConfigurationModel} from './SmartSnippetsConfigurationInterfaces';
+import {
+    SmartSnippetsConfigurationModel,
+    SmartSnippetsContentFields,
+    SmartSnippetsContentFieldsParams,
+    SmartSnippetsDocumentGroupPreview,
+    SmartSnippetsDocumentGroupPreviewParams,
+    SmartSnippetsDocumentTypes,
+    SmartSnippetsDocumentTypesParams,
+} from './SmartSnippetsConfigurationInterfaces';
 
 export default class SmartSnippetsConfiguration extends Resource {
-    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/smartsnippets/model`;
+    static rootUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/smartsnippets`;
+    static baseUrl = `${SmartSnippetsConfiguration.rootUrl}/model`;
+    static contentFieldsUrl = `${SmartSnippetsConfiguration.rootUrl}/contentfields`;
+    static documentTypesUrl = `${SmartSnippetsConfiguration.rootUrl}/documenttypes`;
+    static previewUrl = `${SmartSnippetsConfiguration.rootUrl}/preview`;
 
     create(configModel: New<SmartSnippetsConfigurationModel, 'modelId'>) {
         return this.api.post<SmartSnippetsConfigurationModel>(SmartSnippetsConfiguration.baseUrl, configModel);
@@ -23,5 +35,17 @@ export default class SmartSnippetsConfiguration extends Resource {
             `${SmartSnippetsConfiguration.baseUrl}/${configModel.modelId}`,
             configModel
         );
+    }
+
+    contentFields(params: SmartSnippetsContentFieldsParams) {
+        return this.api.post<SmartSnippetsContentFields>(SmartSnippetsConfiguration.contentFieldsUrl, params);
+    }
+
+    documentTypes(params: SmartSnippetsDocumentTypesParams) {
+        return this.api.post<SmartSnippetsDocumentTypes>(SmartSnippetsConfiguration.documentTypesUrl, params);
+    }
+
+    preview(params: SmartSnippetsDocumentGroupPreviewParams) {
+        return this.api.post<SmartSnippetsDocumentGroupPreview>(SmartSnippetsConfiguration.previewUrl, params);
     }
 }

--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
@@ -36,40 +36,85 @@ export interface SmartSnippetsConfigurationModel {
 export type DocumentRequirementStatus = 'OK' | 'INSUFFICIENT_DOCUMENTS';
 
 export interface SmartSnippetsDocumentGroupPreviewParams {
+    /**
+     * The sources to consider.
+     */
     sources: string[];
 }
 
 export interface SmartSnippetsDocumentGroupPreview {
+    /**
+     * The query that was used to fetch document information.
+     */
     query: string;
+    /**
+     * Status indicating whether there are enough candidates for learning.
+     */
     documentRequirementStatus: DocumentRequirementStatus;
+    /**
+     * The total number of documents in all sources.
+     */
     numberOfDocuments: number;
+    /**
+     * The number of documents that have a permanent id.
+     */
     numberOfDocumentsWithPermanentId: number;
+    /**
+     * The number of documents that are candidates for learning.
+     */
     numberOfValidDocuments: number;
 }
 
 export interface SmartSnippetsContentFieldsParams {
+    /**
+     * The type of documents to target.
+     */
     documentType: string;
+    /**
+     * The names of the sources to consider.
+     */
     sources: string[];
 }
 
 export interface SmartSnippetsContentField {
+    /**
+     * The name of the field.
+     */
     name: string;
 }
 
 export interface SmartSnippetsContentFields {
+    /**
+     * The query that was used to fetch document information.
+     */
     query: string;
+    /**
+     * The list of fields that are non-empty for at least one document.
+     */
     fields: SmartSnippetsContentField[];
 }
 
 export interface SmartSnippetsDocumentTypesParams {
+    /**
+     * The sources to use to consider.
+     */
     sources: string[];
 }
 
 export interface SmartSnippetsDocumentType {
+    /**
+     * The document type.
+     */
     documentType: string;
 }
 
 export interface SmartSnippetsDocumentTypes {
+    /**
+     * The query that was used to fetch document information.
+     */
     query: string;
+    /**
+     * The document types in all sources.
+     */
     documentTypes: SmartSnippetsDocumentType[];
 }

--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
@@ -32,3 +32,44 @@ export interface SmartSnippetsConfigurationModel {
      */
     documentTypes?: DocumentType[];
 }
+
+export type DocumentRequirementStatus = 'OK' | 'INSUFFICIENT_DOCUMENTS';
+
+export interface SmartSnippetsDocumentGroupPreviewParams {
+    sources: string[];
+}
+
+export interface SmartSnippetsDocumentGroupPreview {
+    query: string;
+    documentRequirementStatus: DocumentRequirementStatus;
+    numberOfDocuments: number;
+    numberOfDocumentsWithPermanentId: number;
+    numberOfValidDocuments: number;
+}
+
+export interface SmartSnippetsContentFieldsParams {
+    documentType: string;
+    sources: string[];
+}
+
+export interface SmartSnippetsContentField {
+    name: string;
+}
+
+export interface SmartSnippetsContentFields {
+    query: string;
+    fields: SmartSnippetsContentField[];
+}
+
+export interface SmartSnippetsDocumentTypesParams {
+    sources: string[];
+}
+
+export interface SmartSnippetsDocumentType {
+    documentType: string;
+}
+
+export interface SmartSnippetsDocumentTypes {
+    query: string;
+    documentTypes: SmartSnippetsDocumentType[];
+}

--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
@@ -20,7 +20,7 @@ export interface SmartSnippetsConfigurationModel {
      */
     modelDisplayName: string;
     /**
-     * The names of the sources containing the content to use for model building.
+     * The sources to consider.
      */
     sources: string[];
     /**
@@ -71,7 +71,7 @@ export interface SmartSnippetsContentFieldsParams {
      */
     documentType: string;
     /**
-     * The names of the sources to consider.
+     * The sources to consider.
      */
     sources: string[];
 }
@@ -96,7 +96,7 @@ export interface SmartSnippetsContentFields {
 
 export interface SmartSnippetsDocumentTypesParams {
     /**
-     * The sources to use to consider.
+     * The sources to consider.
      */
     sources: string[];
 }

--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/tests/SmartSnippetsConfiguration.spec.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/tests/SmartSnippetsConfiguration.spec.ts
@@ -81,4 +81,41 @@ describe('SmartSnippetsConfiguration', () => {
             });
         });
     });
+
+    describe('contentFields', () => {
+        it('should make a POST call to retrieve valid content fields from the Smart Snippets Configuration contentfields url', () => {
+            const params = {
+                documentType: 'test-type',
+                sources: ['source1', 'source2'],
+            };
+            smartSnippetsConfig.contentFields(params);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(SmartSnippetsConfiguration.contentFieldsUrl, params);
+        });
+    });
+
+    describe('documentTypes', () => {
+        it('should make a POST call to retrieve valid document types from the Smart Snippets Configuration documenttypes url', () => {
+            const params = {
+                sources: ['source1', 'source2'],
+            };
+            smartSnippetsConfig.documentTypes(params);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(SmartSnippetsConfiguration.documentTypesUrl, params);
+        });
+    });
+
+    describe('preview', () => {
+        it('should make a POST call to retrieve document group preview info from the Smart Snippets Configuration preview url', () => {
+            const params = {
+                sources: ['source1', 'source2'],
+            };
+            smartSnippetsConfig.preview(params);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(SmartSnippetsConfiguration.previewUrl, params);
+        });
+    });
 });

--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/tests/SmartSnippetsConfiguration.spec.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/tests/SmartSnippetsConfiguration.spec.ts
@@ -43,7 +43,7 @@ describe('SmartSnippetsConfiguration', () => {
                 smartSnippetsConfig.create(newConfig);
 
                 expect(api.post).toHaveBeenCalledTimes(1);
-                expect(api.post).toHaveBeenCalledWith(SmartSnippetsConfiguration.baseUrl, newConfig);
+                expect(api.post).toHaveBeenCalledWith(SmartSnippetsConfiguration.modelUrl, newConfig);
             });
         });
     });
@@ -54,7 +54,7 @@ describe('SmartSnippetsConfiguration', () => {
             smartSnippetsConfig.delete(configToDeleteId);
 
             expect(api.delete).toHaveBeenCalledTimes(1);
-            expect(api.delete).toHaveBeenCalledWith(`${SmartSnippetsConfiguration.baseUrl}/${configToDeleteId}`);
+            expect(api.delete).toHaveBeenCalledWith(`${SmartSnippetsConfiguration.modelUrl}/${configToDeleteId}`);
         });
     });
 
@@ -64,7 +64,7 @@ describe('SmartSnippetsConfiguration', () => {
             smartSnippetsConfig.get(configToGetId);
 
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${SmartSnippetsConfiguration.baseUrl}/${configToGetId}`);
+            expect(api.get).toHaveBeenCalledWith(`${SmartSnippetsConfiguration.modelUrl}/${configToGetId}`);
         });
     });
 
@@ -75,7 +75,7 @@ describe('SmartSnippetsConfiguration', () => {
 
                 expect(api.put).toHaveBeenCalledTimes(1);
                 expect(api.put).toHaveBeenCalledWith(
-                    `${SmartSnippetsConfiguration.baseUrl}/${modelConfig.modelId}`,
+                    `${SmartSnippetsConfiguration.modelUrl}/${modelConfig.modelId}`,
                     modelConfig
                 );
             });


### PR DESCRIPTION
Added support for the following calls:
- ​/rest​/organizations​/{organizationId}​/machinelearning​/configuration​/smartsnippets​/contentfields
- ​/rest​/organizations​/{organizationId}​/machinelearning​/configuration​/smartsnippets​/documenttypes
- ​/rest​/organizations​/{organizationId}​/machinelearning​/configuration​/smartsnippets​/preview

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
