### PR TITLE
feat(mlconfig): added support for user action history calls

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -831,6 +831,7 @@ export enum ModelTypes {
     ECommerce = 'ecommerce',
     CaseClassification = 'caseclassification',
     SmartSnippets = 'mlquestionanswering',
+    UserActionHistory = 'useractionhistory',
 }
 
 export enum LicenseSection {

--- a/src/resources/MachineLearning/MachineLearning.ts
+++ b/src/resources/MachineLearning/MachineLearning.ts
@@ -8,6 +8,7 @@ import ModelConfiguration from './ModelConfiguration/ModelConfiguration';
 import ModelInformation from './ModelInformation/ModelInformation';
 import Models from './Models/Models';
 import PQSConfiguration from './PQSConfiguration/PQSConfiguration';
+import UserActionHistoryConfiguration from './UserActionHistoryConfiguration/UserActionHistoryConfiguration';
 
 export default class MachineLearning extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning`;
@@ -18,6 +19,7 @@ export default class MachineLearning extends Resource {
     dneConfig: DNEConfiguration;
     caseClassificationConfig: CaseClassificationConfiguration;
     smartSnippetsConfig: SmartSnippetsConfiguration;
+    userActionHistoryConfig: UserActionHistoryConfiguration;
     pqsConfig: PQSConfiguration;
 
     constructor(protected api: API, protected serverlessApi: API) {
@@ -30,6 +32,7 @@ export default class MachineLearning extends Resource {
         this.caseClassificationConfig = new CaseClassificationConfiguration(api, serverlessApi);
         this.smartSnippetsConfig = new SmartSnippetsConfiguration(api, serverlessApi);
         this.pqsConfig = new PQSConfiguration(api, serverlessApi);
+        this.userActionHistoryConfig = new UserActionHistoryConfiguration(api, serverlessApi);
     }
 
     register(registration: RegistrationModel) {

--- a/src/resources/MachineLearning/UserActionHistoryConfiguration/UserActionHistoryConfiguration.ts
+++ b/src/resources/MachineLearning/UserActionHistoryConfiguration/UserActionHistoryConfiguration.ts
@@ -1,0 +1,18 @@
+import API from '../../../APICore';
+import Resource from '../../Resource';
+
+export default class UserActionHistoryConfiguration extends Resource {
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/useractionhistory`;
+
+    create() {
+        return this.api.post<void>(UserActionHistoryConfiguration.baseUrl);
+    }
+
+    delete() {
+        return this.api.delete<void>(UserActionHistoryConfiguration.baseUrl);
+    }
+
+    get() {
+        return this.api.get<boolean>(UserActionHistoryConfiguration.baseUrl);
+    }
+}

--- a/src/resources/MachineLearning/UserActionHistoryConfiguration/index.ts
+++ b/src/resources/MachineLearning/UserActionHistoryConfiguration/index.ts
@@ -1,0 +1,1 @@
+export * from './UserActionHistoryConfiguration';

--- a/src/resources/MachineLearning/UserActionHistoryConfiguration/tests/UserActionHistoryConfiguration.spec.ts
+++ b/src/resources/MachineLearning/UserActionHistoryConfiguration/tests/UserActionHistoryConfiguration.spec.ts
@@ -1,0 +1,41 @@
+import API from '../../../../APICore';
+import UserActionHistoryConfiguration from '../UserActionHistoryConfiguration';
+
+jest.mock('../../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('UserActionHistoryConfiguration', () => {
+    let userActionHistoryConfiguration: UserActionHistoryConfiguration;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        userActionHistoryConfiguration = new UserActionHistoryConfiguration(api, serverlessApi);
+    });
+
+    describe('create', () => {
+        it('should make a POST call to the User Action History Configuration base url to enable', () => {
+            userActionHistoryConfiguration.create();
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('delete', () => {
+        it('should make a DELETE call to the User Action History Configuration base url', () => {
+            userActionHistoryConfiguration.delete();
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('get', () => {
+        it('should make a GET call to the User Action History Configuration base url', () => {
+            userActionHistoryConfiguration.get();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/src/resources/MachineLearning/index.ts
+++ b/src/resources/MachineLearning/index.ts
@@ -7,3 +7,4 @@ export * from './DNEConfiguration';
 export * from './CaseClassificationConfiguration';
 export * from './SmartSnippetsConfiguration';
 export * from './PQSConfiguration';
+export * from './UserActionHistoryConfiguration';

--- a/src/resources/MachineLearning/tests/MachineLearning.spec.ts
+++ b/src/resources/MachineLearning/tests/MachineLearning.spec.ts
@@ -8,6 +8,7 @@ import ModelInformation from '../ModelInformation/ModelInformation';
 import Models from '../Models/Models';
 import PQSConfiguration from '../PQSConfiguration/PQSConfiguration';
 import SmartSnippetsConfiguration from '../SmartSnippetsConfiguration/SmartSnippetsConfiguration';
+import UserActionHistoryConfiguration from '../UserActionHistoryConfiguration/UserActionHistoryConfiguration';
 
 jest.mock('../../../APICore');
 
@@ -67,5 +68,10 @@ describe('MachineLearning', () => {
     it('should register the pqsConfig resource', () => {
         expect(ml.pqsConfig).toBeDefined();
         expect(ml.pqsConfig).toBeInstanceOf(PQSConfiguration);
+    });
+
+    it('should register the userActionHistory resource', () => {
+        expect(ml.userActionHistoryConfig).toBeDefined();
+        expect(ml.userActionHistoryConfig).toBeInstanceOf(UserActionHistoryConfiguration);
     });
 });


### PR DESCRIPTION
[WIP] These calls are only available in DEV for now, in the process of being released to prod

Added support for the following calls to enable/disable/get status of the User Action History ML feature:

- GET /rest/organizations/{organizationId}/machinelearning/configuration/useractionhistory
- POST /rest/organizations/{organizationId}/machinelearning/configuration/useractionhistory
- DELETE /rest/organizations/{organizationId}/machinelearning/configuration/useractionhistory

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
