### PR TITLE
feat(ml)!: added and updated Case Classification ML Config api calls

### DIFF
--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfiguration.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfiguration.ts
@@ -1,4 +1,9 @@
-import {CaseClassificationDocumentGroupPreview, CaseClassificationDocumentGroupPreviewParams} from '.';
+import {
+    CaseClassificationContentFields,
+    CaseClassificationContentFieldsParams,
+    CaseClassificationDocumentGroupPreview,
+    CaseClassificationDocumentGroupPreviewParams,
+} from '.';
 import API from '../../../APICore';
 import {New} from '../../BaseInterfaces';
 import Resource from '../../Resource';
@@ -7,6 +12,7 @@ import {CaseClassificationConfigurationModel} from './CaseClassificationConfigur
 export default class CaseClassificationConfiguration extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/caseclassif`;
     static modelUrl = `${CaseClassificationConfiguration.baseUrl}/model`;
+    static fieldsUrl = `${CaseClassificationConfiguration.baseUrl}/fields`;
     static previewUrl = `${CaseClassificationConfiguration.baseUrl}/preview`;
 
     create(configModel: New<CaseClassificationConfigurationModel, 'modelId'>) {
@@ -31,6 +37,10 @@ export default class CaseClassificationConfiguration extends Resource {
             `${CaseClassificationConfiguration.modelUrl}/${configModel.modelId}`,
             configModel
         );
+    }
+
+    fields(params: CaseClassificationContentFieldsParams) {
+        return this.api.post<CaseClassificationContentFields>(CaseClassificationConfiguration.fieldsUrl, params);
     }
 
     preview(params: CaseClassificationDocumentGroupPreviewParams) {

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfiguration.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfiguration.ts
@@ -1,13 +1,13 @@
+import API from '../../../APICore';
+import {New} from '../../BaseInterfaces';
+import Resource from '../../Resource';
 import {
+    CaseClassificationConfigurationModel,
     CaseClassificationContentFields,
     CaseClassificationContentFieldsParams,
     CaseClassificationDocumentGroupPreview,
     CaseClassificationDocumentGroupPreviewParams,
-} from '.';
-import API from '../../../APICore';
-import {New} from '../../BaseInterfaces';
-import Resource from '../../Resource';
-import {CaseClassificationConfigurationModel} from './CaseClassificationConfigurationInterfaces';
+} from './CaseClassificationConfigurationInterfaces';
 
 export default class CaseClassificationConfiguration extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/caseclassif`;

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfiguration.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfiguration.ts
@@ -1,32 +1,42 @@
+import {CaseClassificationDocumentGroupPreview, CaseClassificationDocumentGroupPreviewParams} from '.';
 import API from '../../../APICore';
 import {New} from '../../BaseInterfaces';
 import Resource from '../../Resource';
 import {CaseClassificationConfigurationModel} from './CaseClassificationConfigurationInterfaces';
 
 export default class CaseClassificationConfiguration extends Resource {
-    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/caseclassif/model`;
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/caseclassif`;
+    static modelUrl = `${CaseClassificationConfiguration.baseUrl}/model`;
+    static previewUrl = `${CaseClassificationConfiguration.baseUrl}/preview`;
 
     create(configModel: New<CaseClassificationConfigurationModel, 'modelId'>) {
         return this.api.post<CaseClassificationConfigurationModel>(
-            CaseClassificationConfiguration.baseUrl,
+            CaseClassificationConfiguration.modelUrl,
             configModel
         );
     }
 
     delete(modelId: string) {
-        return this.api.delete(`${CaseClassificationConfiguration.baseUrl}/${modelId}`);
+        return this.api.delete(`${CaseClassificationConfiguration.modelUrl}/${modelId}`);
     }
 
     get(modelId: string) {
         return this.api.get<CaseClassificationConfigurationModel>(
-            `${CaseClassificationConfiguration.baseUrl}/${modelId}`
+            `${CaseClassificationConfiguration.modelUrl}/${modelId}`
         );
     }
 
     update(configModel: CaseClassificationConfigurationModel) {
         return this.api.put<CaseClassificationConfigurationModel>(
-            `${CaseClassificationConfiguration.baseUrl}/${configModel.modelId}`,
+            `${CaseClassificationConfiguration.modelUrl}/${configModel.modelId}`,
             configModel
+        );
+    }
+
+    preview(params: CaseClassificationDocumentGroupPreviewParams) {
+        return this.api.post<CaseClassificationDocumentGroupPreview>(
+            CaseClassificationConfiguration.previewUrl,
+            params
         );
     }
 }

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
@@ -21,7 +21,36 @@ export interface FilterConditions {
     value: string;
 }
 
-export type ExtractionPeriod = FixedExtractionPeriod | IntervalExtractionPeriod;
+export interface DateField {
+    /**
+     * The field to use as date.
+     */
+    dateField: string;
+}
+
+export interface FixedExtractionPeriod {
+    /**
+     * Date in milliseconds that indicates the beginning of the time interval to include cases.
+     * The date format is the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
+     */
+    startTime: number;
+    /**
+     * Date in milliseconds that indicates the end of the time interval to include cases.
+     * The date format is the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
+     */
+    endTime: number;
+}
+
+export interface IntervalExtractionPeriod {
+    /**
+     * The period to export data from. The exportPeriod uses the moment when the model was generated as a base.
+     * Must be in the ISO8601 period format (i.e., PyYmMwWdDThHmMsS).
+     * Example: P3Y6M4DT12H30M5S Represents a duration of three years, six months, four days, twelve hours, thirty minutes, and five seconds.
+     */
+    exportPeriod: string;
+}
+
+export type ExtractionPeriod = DateField & (FixedExtractionPeriod | IntervalExtractionPeriod);
 
 export interface CaseClassificationConfigurationModel {
     /**
@@ -61,26 +90,8 @@ export interface CaseClassificationConfigurationModel {
      * Example: [subject, reason, category]
      */
     fieldsToPredict: string[];
-}
-
-export interface FixedExtractionPeriod {
     /**
-     * Date in milliseconds that indicates the beginning of the time interval to include cases.
-     * The date format is the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
+     * The field value to use as language.
      */
-    startTime: number;
-    /**
-     * Date in milliseconds that indicates the end of the time interval to include cases.
-     * The date format is the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
-     */
-    endTime: number;
-}
-
-export interface IntervalExtractionPeriod {
-    /**
-     * The period to export data from. The exportPeriod uses the moment when the model was generated as a base.
-     * Must be in the ISO8601 period format (i.e., PyYmMwWdDThHmMsS).
-     * Example: P3Y6M4DT12H30M5S Represents a duration of three years, six months, four days, twelve hours, thirty minutes, and five seconds.
-     */
-    exportPeriod: string;
+    languageField: string;
 }

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
@@ -1,7 +1,11 @@
+import {SmartSnippetsDocumentRequirementStatus} from '../SmartSnippetsConfiguration';
+
 export enum Operator {
     Equals = 'EQUALS',
     NotEquals = 'NOT_EQUALS',
 }
+
+export type CaseClassificationDocumentRequirementStatus = 'OK' | 'INSUFFICIENT_DOCUMENTS';
 
 export interface FilterConditions {
     /**
@@ -94,4 +98,51 @@ export interface CaseClassificationConfigurationModel {
      * The field value to use as language.
      */
     languageField: string;
+}
+
+export interface CaseClassificationDocumentGroupPreviewParams {
+    /**
+     * The time period for which to extract cases for model building.
+     * Must contain an export period or a start time and end time.
+     */
+    caseExtractionPeriod: ExtractionPeriod;
+    /**
+     * An array of filtering conditions.
+     */
+    caseFilterConditions: FilterConditions[];
+    /**
+     * The field value to use as language.
+     */
+    languageField: string;
+    /**
+     * The names of the sources containing the cases to use for model building.
+     */
+    sources: string[];
+}
+
+export interface CaseClassificationDocumentGroupPreview {
+    /**
+     * The query that was used to fetch document information.
+     */
+    query: string;
+    /**
+     * Status indicating whether there are enough candidates for learning.
+     */
+    documentRequirementStatus: CaseClassificationDocumentRequirementStatus;
+    /**
+     * The total number of documents in all sources.
+     */
+    numberOfDocuments: number;
+    /**
+     * The number of documents matching the configured conditions.
+     */
+    numberOfDocumentsMatchingConditions: number;
+    /**
+     * The number of English documents matching the configured conditions.
+     */
+    numberOfDocumentsMatchingConditionsAndInEnglish: number;
+    /**
+     * The number of documents that are candidates for learning.
+     */
+    numberOfValidDocuments: number;
 }

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
@@ -146,3 +146,32 @@ export interface CaseClassificationDocumentGroupPreview {
      */
     numberOfValidDocuments: number;
 }
+
+export interface CaseClassificationContentFieldsParams {
+    /**
+     * The time period for which to extract cases for model building.
+     * Must contain an export period or a start time and end time.
+     */
+    caseExtractionPeriod: ExtractionPeriod;
+    /**
+     * An array of filtering conditions.
+     */
+    caseFilterConditions: FilterConditions[];
+    /**
+     * The field value to use as language.
+     */
+    languageField: string;
+    /**
+     * The names of the sources containing the cases to use for model building.
+     */
+    sources: string[];
+}
+
+export interface CaseClassificationContentField {
+    name: string;
+}
+
+export interface CaseClassificationContentFields {
+    fields: CaseClassificationContentField[];
+    query: string;
+}

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
@@ -1,5 +1,3 @@
-import {SmartSnippetsDocumentRequirementStatus} from '../SmartSnippetsConfiguration';
-
 export enum Operator {
     Equals = 'EQUALS',
     NotEquals = 'NOT_EQUALS',

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
@@ -27,7 +27,7 @@ export interface DateField {
     /**
      * The field to use as date.
      */
-    dateField: string;
+    dateField?: string;
 }
 
 export interface FixedExtractionPeriod {
@@ -95,7 +95,7 @@ export interface CaseClassificationConfigurationModel {
     /**
      * The field value to use as language.
      */
-    languageField: string;
+    languageField?: string;
 }
 
 export interface CaseClassificationDocumentGroupPreviewParams {

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
@@ -16,7 +16,9 @@ describe('CaseClassificationConfiguration', () => {
             modelId: 'test-model-id',
             modelDisplayName: 'Model Name 1',
             sources: ['1st-source', '2nd-source'],
+            languageField: 'English',
             caseExtractionPeriod: {
+                dateField: 'date',
                 exportPeriod: 'test-export-period',
             },
             caseFilterConditions: [
@@ -37,12 +39,15 @@ describe('CaseClassificationConfiguration', () => {
             caseIdField: 'test-case-id',
             fieldsForModelTraining: ['1st-field', '2nd-field'],
             fieldsToPredict: ['1st-field', '2nd-field'],
+            languageField: 'Gerudo',
         },
         {
             modelId: 'test-model-id',
             modelDisplayName: 'Model Name 1',
             sources: ['1st-source', '2nd-source'],
+            languageField: 'Klingon',
             caseExtractionPeriod: {
+                dateField: 'date',
                 startTime: 9876543210,
                 endTime: 1234567890,
             },

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
@@ -116,6 +116,30 @@ describe('CaseClassificationConfiguration', () => {
         });
     });
 
+    describe('fields', () => {
+        it('should make a POST call to retrieve valid content field candidates for the Case Classification Configuration', () => {
+            const params = {
+                sources: ['1st-source', '2nd-source'],
+                languageField: 'English',
+                caseExtractionPeriod: {
+                    dateField: 'date',
+                    exportPeriod: 'test-export-period',
+                },
+                caseFilterConditions: [
+                    {
+                        field: 'test-field',
+                        operator: Operator.Equals,
+                        value: 'test-value',
+                    },
+                ],
+            };
+            ccConfig.fields(params);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(CaseClassificationConfiguration.fieldsUrl, params);
+        });
+    });
+
     describe('preview', () => {
         it('should make a POST call to retrieve document group preview info from the Case Classification Configuration preview url', () => {
             const params = {

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
@@ -39,7 +39,6 @@ describe('CaseClassificationConfiguration', () => {
             caseIdField: 'test-case-id',
             fieldsForModelTraining: ['1st-field', '2nd-field'],
             fieldsToPredict: ['1st-field', '2nd-field'],
-            languageField: 'Gerudo',
         },
         {
             modelId: 'test-model-id',
@@ -47,7 +46,6 @@ describe('CaseClassificationConfiguration', () => {
             sources: ['1st-source', '2nd-source'],
             languageField: 'Klingon',
             caseExtractionPeriod: {
-                dateField: 'date',
                 startTime: 9876543210,
                 endTime: 1234567890,
             },

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
@@ -77,7 +77,7 @@ describe('CaseClassificationConfiguration', () => {
                 ccConfig.create(newConfig);
 
                 expect(api.post).toHaveBeenCalledTimes(1);
-                expect(api.post).toHaveBeenCalledWith(CaseClassificationConfiguration.baseUrl, newConfig);
+                expect(api.post).toHaveBeenCalledWith(CaseClassificationConfiguration.modelUrl, newConfig);
             });
         });
     });
@@ -88,7 +88,7 @@ describe('CaseClassificationConfiguration', () => {
             ccConfig.delete(configToDeleteId);
 
             expect(api.delete).toHaveBeenCalledTimes(1);
-            expect(api.delete).toHaveBeenCalledWith(`${CaseClassificationConfiguration.baseUrl}/${configToDeleteId}`);
+            expect(api.delete).toHaveBeenCalledWith(`${CaseClassificationConfiguration.modelUrl}/${configToDeleteId}`);
         });
     });
 
@@ -98,7 +98,7 @@ describe('CaseClassificationConfiguration', () => {
             ccConfig.get(configToGetId);
 
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${CaseClassificationConfiguration.baseUrl}/${configToGetId}`);
+            expect(api.get).toHaveBeenCalledWith(`${CaseClassificationConfiguration.modelUrl}/${configToGetId}`);
         });
     });
 
@@ -109,10 +109,34 @@ describe('CaseClassificationConfiguration', () => {
 
                 expect(api.put).toHaveBeenCalledTimes(1);
                 expect(api.put).toHaveBeenCalledWith(
-                    `${CaseClassificationConfiguration.baseUrl}/${config.modelId}`,
+                    `${CaseClassificationConfiguration.modelUrl}/${config.modelId}`,
                     config
                 );
             });
+        });
+    });
+
+    describe('preview', () => {
+        it('should make a POST call to retrieve document group preview info from the Case Classification Configuration preview url', () => {
+            const params = {
+                sources: ['1st-source', '2nd-source'],
+                languageField: 'English',
+                caseExtractionPeriod: {
+                    dateField: 'date',
+                    exportPeriod: 'test-export-period',
+                },
+                caseFilterConditions: [
+                    {
+                        field: 'test-field',
+                        operator: Operator.Equals,
+                        value: 'test-value',
+                    },
+                ],
+            };
+            ccConfig.preview(params);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(CaseClassificationConfiguration.previewUrl, params);
         });
     });
 });

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
@@ -115,7 +115,7 @@ describe('CaseClassificationConfiguration', () => {
     });
 
     describe('fields', () => {
-        it('should make a POST call to retrieve valid content field candidates for the Case Classification Configuration', () => {
+        it('should make a POST call to retrieve valid content field candidates for the Case Classification model configuration', () => {
             const params = {
                 sources: ['1st-source', '2nd-source'],
                 languageField: 'English',
@@ -139,7 +139,7 @@ describe('CaseClassificationConfiguration', () => {
     });
 
     describe('preview', () => {
-        it('should make a POST call to retrieve document group preview info from the Case Classification Configuration preview url', () => {
+        it('should make a POST call to retrieve document group preview info from the Case Classification model configuration preview url', () => {
             const params = {
                 sources: ['1st-source', '2nd-source'],
                 languageField: 'English',

--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
@@ -33,7 +33,7 @@ export interface SmartSnippetsConfigurationModel {
     documentTypes?: DocumentType[];
 }
 
-export type DocumentRequirementStatus = 'OK' | 'INSUFFICIENT_DOCUMENTS';
+export type SmartSnippetsDocumentRequirementStatus = 'OK' | 'INSUFFICIENT_DOCUMENTS';
 
 export interface SmartSnippetsDocumentGroupPreviewParams {
     /**
@@ -50,7 +50,7 @@ export interface SmartSnippetsDocumentGroupPreview {
     /**
      * Status indicating whether there are enough candidates for learning.
      */
-    documentRequirementStatus: DocumentRequirementStatus;
+    documentRequirementStatus: SmartSnippetsDocumentRequirementStatus;
     /**
      * The total number of documents in all sources.
      */


### PR DESCRIPTION
Added new API endpoints for Case Classification models

- Added `/fields` endpoint to get valid content field options
- Added `/preview` endpoint to get a preview of the document group validity
- Added new optional attributes to the model interface.

BREAKING CHANGES:
- renamed `DocumentRequirementStatus` to `SmartSnippetsDocumentRequirementStatus`
- changed `CaseClassificationConfiguration.baseUrl` value

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
