### PR TITLE
feat(search): handle viewAllContent parameter

### DIFF
--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -1,7 +1,6 @@
-import {PostSearchQueryStringParams} from '.';
 import API from '../../APICore';
 import Ressource from '../Resource';
-import {RestTokenParams, TokenModel} from './SearchInterfaces';
+import {PostSearchQueryStringParams, RestTokenParams, TokenModel} from './SearchInterfaces';
 
 export default class Search extends Ressource {
     static baseUrl = `/rest/search/v2`;

--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -13,9 +13,16 @@ export default class Search extends Ressource {
     // See: https://platform.cloud.coveo.com/docs?api=SearchApi#!/Search/post_rest_search_v2
     // or : https://docs.coveo.com/en/13/cloud-v2-api-reference/search-api#operation/searchUsingGet
     query(restQueryParameters: any) {
-        return this.api.post<any>(
-            this.buildPath(Search.baseUrl, {organizationId: this.api.organizationId}),
-            restQueryParameters
-        );
+        const {viewAllContent, ...bodyParameters} = restQueryParameters;
+
+        const queryParameters = {
+            organizationId: this.api.organizationId,
+            viewAllContent: undefined,
+        };
+        if (typeof viewAllContent !== 'undefined') {
+            queryParameters.viewAllContent = viewAllContent ? 1 : 0;
+        }
+
+        return this.api.post<any>(this.buildPath(Search.baseUrl, queryParameters), bodyParameters);
     }
 }

--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -14,15 +14,11 @@ export default class Search extends Ressource {
     // or : https://docs.coveo.com/en/13/cloud-v2-api-reference/search-api#operation/searchUsingGet
     query(restQueryParameters: any & PostSearchQueryStringParams) {
         const {viewAllContent, ...bodyParameters} = restQueryParameters;
-        const queryStringParameters: PostSearchQueryStringParams = {
-            organizationId: this.api.organizationId,
-            viewAllContent,
-        };
 
         return this.api.post<any>(
             this.buildPath(Search.baseUrl, {
-                ...queryStringParameters,
-                viewAllContent: queryStringParameters.viewAllContent ? 1 : undefined,
+                organizationId: this.api.organizationId,
+                viewAllContent: viewAllContent ? 1 : undefined,
             }),
             bodyParameters
         );

--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -1,3 +1,4 @@
+import {PostSearchQueryStringParams} from '.';
 import API from '../../APICore';
 import Ressource from '../Resource';
 import {RestTokenParams, TokenModel} from './SearchInterfaces';
@@ -12,17 +13,19 @@ export default class Search extends Ressource {
     // For more info about restQueryParameters values available
     // See: https://platform.cloud.coveo.com/docs?api=SearchApi#!/Search/post_rest_search_v2
     // or : https://docs.coveo.com/en/13/cloud-v2-api-reference/search-api#operation/searchUsingGet
-    query(restQueryParameters: any) {
+    query(restQueryParameters: any & PostSearchQueryStringParams) {
         const {viewAllContent, ...bodyParameters} = restQueryParameters;
-
-        const queryParameters = {
+        const queryStringParameters: PostSearchQueryStringParams = {
             organizationId: this.api.organizationId,
-            viewAllContent: undefined,
+            viewAllContent,
         };
-        if (typeof viewAllContent !== 'undefined') {
-            queryParameters.viewAllContent = viewAllContent ? 1 : 0;
-        }
 
-        return this.api.post<any>(this.buildPath(Search.baseUrl, queryParameters), bodyParameters);
+        return this.api.post<any>(
+            this.buildPath(Search.baseUrl, {
+                ...queryStringParameters,
+                viewAllContent: queryStringParameters.viewAllContent ? 1 : undefined,
+            }),
+            bodyParameters
+        );
     }
 }

--- a/src/resources/Search/SearchInterfaces.ts
+++ b/src/resources/Search/SearchInterfaces.ts
@@ -40,6 +40,5 @@ export interface TokenModel {
 }
 
 export interface PostSearchQueryStringParams {
-    organizationId: string;
     viewAllContent?: boolean;
 }

--- a/src/resources/Search/SearchInterfaces.ts
+++ b/src/resources/Search/SearchInterfaces.ts
@@ -26,7 +26,7 @@ export interface RestUserId {
     type?: RestUserIdType;
     infos?: any;
     authCookie?: string;
-    password?: string; // Depecrated: This property is exposed for backward compatibility reasons only.
+    password?: string; // Deprecated: This property is exposed for backward compatibility reasons only.
 }
 
 export interface RestCommerceParameters {
@@ -37,4 +37,9 @@ export interface RestCommerceParameters {
 
 export interface TokenModel {
     token: string;
+}
+
+export interface PostSearchQueryStringParams {
+    organizationId: string;
+    viewAllContent?: boolean;
 }

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -67,5 +67,26 @@ describe('Search', () => {
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(Search.baseUrl, queryParams);
         });
+
+        it('should not add viewAllContent parameter when not specified', () => {
+            const queryParams = {q: ''};
+            search.query(queryParams);
+
+            expect(api.post).toHaveBeenCalledWith(Search.baseUrl, {q: ''});
+        });
+
+        it('should add #viewAllContent=1 parameter when set to true', () => {
+            const queryParams = {q: '', viewAllContent: true};
+            search.query(queryParams);
+
+            expect(api.post).toHaveBeenCalledWith(`${Search.baseUrl}?viewAllContent=1`, {q: ''});
+        });
+
+        it('should add #viewAllContent=0 parameter when set to false', () => {
+            const queryParams = {q: '', viewAllContent: false};
+            search.query(queryParams);
+
+            expect(api.post).toHaveBeenCalledWith(`${Search.baseUrl}?viewAllContent=0`, {q: ''});
+        });
     });
 });

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -68,25 +68,25 @@ describe('Search', () => {
             expect(api.post).toHaveBeenCalledWith(Search.baseUrl, queryParams);
         });
 
-        it('should not add viewAllContent parameter when not specified', () => {
+        it('should not add #viewAllContent query string parameter when not specified', () => {
             const queryParams = {q: ''};
             search.query(queryParams);
 
             expect(api.post).toHaveBeenCalledWith(Search.baseUrl, {q: ''});
         });
 
-        it('should add #viewAllContent=1 parameter when set to true', () => {
+        it('should add #viewAllContent=1 to the query string when set to true', () => {
             const queryParams = {q: '', viewAllContent: true};
             search.query(queryParams);
 
             expect(api.post).toHaveBeenCalledWith(`${Search.baseUrl}?viewAllContent=1`, {q: ''});
         });
 
-        it('should add #viewAllContent=0 parameter when set to false', () => {
+        it('should not add #viewAllContent query string parameter when set to false', () => {
             const queryParams = {q: '', viewAllContent: false};
             search.query(queryParams);
 
-            expect(api.post).toHaveBeenCalledWith(`${Search.baseUrl}?viewAllContent=0`, {q: ''});
+            expect(api.post).toHaveBeenCalledWith(Search.baseUrl, {q: ''});
         });
     });
 });


### PR DESCRIPTION
[SVCC-336](https://coveord.atlassian.net/browse/SVCC-336)

In order to be able to implement an upcoming feature, an implementer has to be able to perform a search query with the "view all content" flag.

The proposed solution is to allow passing `viewAllContent` through the existing `restQueryParameters` argument. The `viewAllContent` property is then extracted and added to the query string when needed.

### Acceptance Criteria

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
