### PR TITLE
feat(exports resources): +download link export endpoint

### DIFF
--- a/src/resources/UsageAnalytics/Read/Exports/Exports.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/Exports.ts
@@ -3,6 +3,7 @@ import {
     CreateExportScheduleModel,
     EstimateExportParams,
     EstimateVisitExportParams,
+    ExportDownloadLink,
     ExportEstimateModel,
     ExportModel,
     ExportScheduleModel,
@@ -24,6 +25,12 @@ export default class Exports extends Resource {
     get(exportId: string, redirect = false) {
         return this.api.get<ExportModel>(
             this.buildPath(`${Exports.baseUrl}/${exportId}`, {redirect, org: this.api.organizationId})
+        );
+    }
+
+    getExportDownloadLink(exportId: string) {
+        return this.api.get<ExportDownloadLink>(
+            this.buildPath(`${Exports.baseUrl}/${exportId}/downloadlink`, {org: this.api.organizationId})
         );
     }
 

--- a/src/resources/UsageAnalytics/Read/Exports/ExportsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/ExportsInterfaces.ts
@@ -23,6 +23,16 @@ export interface ExportEstimateModel {
     estimates: Record<string, number>;
 }
 
+export interface ExportDownloadLink {
+    /**
+     * The export's unique identifier
+     */
+    id: string;
+    /**
+     * The export download link. Only appears when export is ready
+     */
+    downloadLink?: string;
+}
 interface EstimateExportCommonParams {
     from: string;
     to: string;

--- a/src/resources/UsageAnalytics/Read/Exports/tests/Exports.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/tests/Exports.spec.ts
@@ -55,6 +55,15 @@ describe('Exports', () => {
         });
     });
 
+    describe('getExportDownloadLink', () => {
+        it('makes a GET call to the specific Exports url', () => {
+            const exportId = 'Soubame';
+            exports.getExportDownloadLink(exportId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/${exportId}/downloadlink`);
+        });
+    });
+
     describe('delete', () => {
         it('makes a DELETE call to the specific Exports url', () => {
             const exportId = '🌞';


### PR DESCRIPTION
I've added the new api endpoint when a user wants to download an export. With this new endpoint, the access_token is no longer sent in the url

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
