### PR TITLE
ci(jenkinsfile): make sure sh config is set for npm before release

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -112,6 +112,7 @@ pipeline {
             withCredentials([usernamePassword(credentialsId: 'github-commit-token',
                                               usernameVariable: 'GITHUB_APP',
                                               passwordVariable: 'GH_TOKEN')]) {
+              sh "npm config set //registry.npmjs.org/:_authToken=${env.NPM_TOKEN}"
               sh "npm run release"
             }
           } else {


### PR DESCRIPTION
Following dblanchette recommendation to make the the shell as the right npm config before trying to publish the package to NPM

:crossed_fingers: 

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
