### PR TITLE
feat(ml-stats): added interfaces for case classification model stats

### DIFF
--- a/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
+++ b/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
@@ -200,3 +200,65 @@ export interface ModelInformationSS {
     metaInfo: MetaInfoSS;
     modelBuildingStats: BuildingStatsSS;
 }
+
+export interface MetaInfoCC extends MetaInfo {
+    modelId: string;
+    engineName: string;
+    modelSize: string;
+}
+
+export interface DatasetFieldDetails {
+    numSamples: number;
+    facetsLabelsDistribution: Record<string, number>;
+}
+
+export interface DatasetDetails {
+    numRows: number;
+    dataDetails: Record<string, DatasetFieldDetails>;
+}
+
+export interface FacetPerformanceDetails {
+    hit1: number;
+    hit3: number;
+}
+
+export interface HyperParameterDetails {
+    learningRate: number;
+    warmUp: number;
+}
+
+export interface FacetDetails {
+    facetLabels: Record<string, string[]>;
+    defaultFacets: Partial<Record<string, string>>;
+    facetDisregardedLabels: Record<string, string[]>;
+}
+
+export interface PreparationConfigCC {
+    documentGroupId: number;
+    caseIdColumn: string;
+    facetFields: string[];
+    contextFields: string[];
+    minLen: number;
+    maxLen: number;
+    maxPortionDisregarded: number;
+    condensationMapPath?: string;
+    testPortion: number;
+}
+
+export interface PreparationDetailsCC {
+    preparationConfig: PreparationConfigCC;
+    facetsDetails: FacetDetails;
+    trainDatasetsDetails: DatasetDetails;
+    testDatasetsDetails: DatasetDetails;
+}
+
+export interface TrainingDetailsCC {
+    performanceDetails: Record<string, FacetPerformanceDetails>;
+    hyperParameterDetails: HyperParameterDetails;
+}
+
+export interface ModelInformationCC {
+    metaInfo: MetaInfoCC;
+    preparationDetails: PreparationDetailsCC;
+    trainingDetails: TrainingDetailsCC;
+}

--- a/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
+++ b/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
@@ -6,7 +6,8 @@ export interface MLModelInfo {
         | ModelInformationER
         | ModelInformationPR
         | ModelInformationQS
-        | ModelInformationSS;
+        | ModelInformationSS
+        | ModelInformationCC;
 }
 
 export interface MetaInfo {

--- a/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
+++ b/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
@@ -202,12 +202,6 @@ export interface ModelInformationSS {
     modelBuildingStats: BuildingStatsSS;
 }
 
-export interface MetaInfoCC extends MetaInfo {
-    modelId: string;
-    engineName: string;
-    modelSize: string;
-}
-
 export interface DatasetFieldDetails {
     numSamples: number;
     labelsDistribution: Record<string, number>;
@@ -244,6 +238,12 @@ export interface PreparationConfigCC {
     maxPortionDisregarded: number;
     condensationMapPath?: string;
     testPortion: number;
+}
+
+export interface MetaInfoCC extends MetaInfo {
+    modelId: string;
+    engineName: string;
+    modelSize: string;
 }
 
 export interface PreparationDetailsCC {

--- a/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
+++ b/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
@@ -210,7 +210,7 @@ export interface MetaInfoCC extends MetaInfo {
 
 export interface DatasetFieldDetails {
     numSamples: number;
-    facetsLabelsDistribution: Record<string, number>;
+    labelsDistribution: Record<string, number>;
 }
 
 export interface DatasetDetails {


### PR DESCRIPTION
I divided it up into several interfaces. This gives flexibility but also creates many exports. If the owners would prefer I just shove them all into one interface I can do that too.
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
