### PR TITLE
feat(pipeline): update duplicate parameters

### DIFF
--- a/src/resources/Pipelines/Pipelines.ts
+++ b/src/resources/Pipelines/Pipelines.ts
@@ -1,4 +1,5 @@
 import API from '../../APICore';
+import {GranularResource} from '../BaseInterfaces';
 import Resource from '../Resource';
 import Condition from './Conditions/Condition';
 import FacetStateRules from './FacetStateRules/FacetStateRules';
@@ -73,11 +74,12 @@ export default class Pipelines extends Resource {
         );
     }
 
-    duplicate(pipelineId: string) {
+    duplicate(pipelineId: string, granularResource?: GranularResource) {
         return this.api.post<PipelineModel>(
             this.buildPath(`${Pipelines.searchUrlVersion1}/${pipelineId}/duplicate`, {
                 organizationId: this.api.organizationId,
-            })
+            }),
+            granularResource
         );
     }
 

--- a/src/resources/Pipelines/tests/Pipelines.spec.ts
+++ b/src/resources/Pipelines/tests/Pipelines.spec.ts
@@ -68,7 +68,18 @@ describe('Pipelines', () => {
             pipelines.duplicate('🔥');
 
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith('/rest/search/v1/admin/pipelines/🔥/duplicate');
+            expect(api.post).toHaveBeenCalledWith('/rest/search/v1/admin/pipelines/🔥/duplicate', undefined);
+        });
+
+        it('includes the granular resource if set on the POST call request body', () => {
+            const granularResource = {
+                groupsThatCanEdit: [{id: 'hello'}, {id: 'bonjour'}],
+                apiKeysThatCanEdit: [{id: 'bonne'}, {id: 'nuit'}],
+            };
+            pipelines.duplicate('yeah', granularResource);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith('/rest/search/v1/admin/pipelines/yeah/duplicate', granularResource);
         });
     });
 


### PR DESCRIPTION
This information is not documented on Swagger, but you can pass a request body to the `/duplicate` call for the pipelines. To resolve a bug, this request body will be useful.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
