### PR TITLE
feat(api-keys-interfaces): add missing additional configuration

### DIFF
--- a/src/resources/ApiKeys/ApiKeysInterfaces.ts
+++ b/src/resources/ApiKeys/ApiKeysInterfaces.ts
@@ -79,6 +79,8 @@ export interface ApiKeyModel extends GranularResource {
      * **Example:** t4hk287bfj5sg6wskg64ckk5a
      */
     resourceId?: string;
+
+    additionalConfiguration?: AdditionalConfigurationModel;
 }
 
 export interface CreateApiKeyOptions {
@@ -86,4 +88,33 @@ export interface CreateApiKeyOptions {
      * The unique identifier of the template on which to base the API key.
      */
     apiKeyTemplateId?: string;
+}
+
+interface AdditionalConfigurationModel {
+    commerce: CommerceConfigurationModel;
+    search: SearchConfigurationModel;
+}
+
+interface CommerceConfigurationModel {
+    catalogId: string;
+}
+
+interface SearchConfigurationModel {
+    apiKeyQueryAuthentication: QueryAuthenticationModel[];
+    enforcedQueryPipelineConfiguration: EnforceQueryPipelineConfigurationModel;
+    impersonationRestriction: ImpersonationRestrictionsModel;
+}
+
+interface QueryAuthenticationModel {
+    name: string;
+    provider: string;
+    type: string;
+}
+
+interface EnforceQueryPipelineConfigurationModel {
+    searchHub: string;
+}
+
+interface ImpersonationRestrictionsModel {
+    allowedUserIds: QueryAuthenticationModel[];
 }

--- a/src/resources/ApiKeys/ApiKeysInterfaces.ts
+++ b/src/resources/ApiKeys/ApiKeysInterfaces.ts
@@ -80,6 +80,9 @@ export interface ApiKeyModel extends GranularResource {
      */
     resourceId?: string;
 
+    /**
+     * Additional configuration to be included in an API key. [to be revised]
+     */
     additionalConfiguration?: AdditionalConfigurationModel;
 }
 
@@ -91,11 +94,17 @@ export interface CreateApiKeyOptions {
 }
 
 interface AdditionalConfigurationModel {
+    /**
+     * Configuration specific to commerce organization. [to be revised]
+     */
     commerce: CommerceConfigurationModel;
     search: SearchConfigurationModel;
 }
 
 interface CommerceConfigurationModel {
+    /**
+     * The catalog identifier to be linked to an API key. [to be revised]
+     */
     catalogId: string;
 }
 
@@ -106,12 +115,24 @@ interface SearchConfigurationModel {
 }
 
 interface QueryAuthenticationModel {
+    /**
+     * Authentication name. [to be revised]
+     */
     name: string;
+    /**
+     * Authentication provider. [to be revised]
+     */
     provider: string;
+    /**
+     * Authentication type. [to be revised]
+     */
     type: string;
 }
 
 interface EnforceQueryPipelineConfigurationModel {
+    /**
+     * Search hub name to be linked to an API key. [to be revised]
+     */
     searchHub: string;
 }
 


### PR DESCRIPTION
story: https://coveord.atlassian.net/browse/ADUI-7801

The purpose of this story is to add the additional configuration (optional) parameter to the ApiKeyModel.

I didn't export any of the new interfaces, I'm not sure it would be relevant to do so, but let me know if I should. Also, I didn't add any JSDoc (which is not ideal), because there is no description for the parameters on Swagger, so I was not comfortable to write some description that might not be accurate.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
