### PR TITLE
fix(api-keys-interfaces): set some parameters as being optionals

### DIFF
--- a/src/resources/ApiKeys/ApiKeysInterfaces.ts
+++ b/src/resources/ApiKeys/ApiKeysInterfaces.ts
@@ -109,9 +109,9 @@ interface CommerceConfigurationModel {
 }
 
 interface SearchConfigurationModel {
-    apiKeyQueryAuthentication?: QueryAuthenticationModel[];
-    enforcedQueryPipelineConfiguration?: EnforceQueryPipelineConfigurationModel;
-    impersonationRestriction?: ImpersonationRestrictionsModel;
+    apiKeyQueryAuthentication?: QueryAuthenticationModel[]; // TODO: ADUI-7802 - complete this information when the documentation is complete or the initial team confirm the API implementation.
+    enforcedQueryPipelineConfiguration?: EnforceQueryPipelineConfigurationModel; // TODO: ADUI-7802 - complete this information when the documentation is complete or the initial team confirm the API implementation.
+    impersonationRestriction?: ImpersonationRestrictionsModel; // TODO: ADUI-7802 - complete this information when the documentation is complete or the initial team confirm the API implementation.
 }
 
 interface QueryAuthenticationModel {

--- a/src/resources/ApiKeys/ApiKeysInterfaces.ts
+++ b/src/resources/ApiKeys/ApiKeysInterfaces.ts
@@ -97,8 +97,8 @@ interface AdditionalConfigurationModel {
     /**
      * Configuration specific to commerce organization. [to be revised]
      */
-    commerce: CommerceConfigurationModel;
-    search: SearchConfigurationModel;
+    commerce?: CommerceConfigurationModel;
+    search?: SearchConfigurationModel;
 }
 
 interface CommerceConfigurationModel {
@@ -109,9 +109,9 @@ interface CommerceConfigurationModel {
 }
 
 interface SearchConfigurationModel {
-    apiKeyQueryAuthentication: QueryAuthenticationModel[];
-    enforcedQueryPipelineConfiguration: EnforceQueryPipelineConfigurationModel;
-    impersonationRestriction: ImpersonationRestrictionsModel;
+    apiKeyQueryAuthentication?: QueryAuthenticationModel[];
+    enforcedQueryPipelineConfiguration?: EnforceQueryPipelineConfigurationModel;
+    impersonationRestriction?: ImpersonationRestrictionsModel;
 }
 
 interface QueryAuthenticationModel {


### PR DESCRIPTION
Following this PR: https://github.com/coveo/platform-client/pull/417
It's not currently a breaking change, but I realized that some additional configuration are also optional, so I set them to be optional.

### Acceptance Criteria

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
