### PR TITLE
fix(datashare): params sent as body

### DIFF
--- a/src/resources/UsageAnalytics/Read/DataShare/DataShare.ts
+++ b/src/resources/UsageAnalytics/Read/DataShare/DataShare.ts
@@ -14,9 +14,10 @@ export default class DataShare extends Resource {
         );
     }
 
-    addSnowflakeAccount(params: SnowflakeAccountDataSharingParams) {
+    addSnowflakeAccount(snowflakeAccount: SnowflakeAccountDataSharingParams) {
         return this.api.post<void>(
-            this.buildPath(`${DataShare.baseUrl}/accounts`, {...params, org: this.api.organizationId})
+            this.buildPath(`${DataShare.baseUrl}/accounts`, {org: this.api.organizationId}),
+            snowflakeAccount
         );
     }
 

--- a/src/resources/UsageAnalytics/Read/DataShare/tests/DataShare.spec.ts
+++ b/src/resources/UsageAnalytics/Read/DataShare/tests/DataShare.spec.ts
@@ -31,9 +31,7 @@ describe('Dimensions', () => {
         it('should make a POST call to the snowflake data share accounts url', () => {
             dataShare.addSnowflakeAccount(dataShareParams);
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(
-                `${DataShare.baseUrl}/accounts?accountLocator=Soubane&snowflakeRegion=LOUBAME`
-            );
+            expect(api.post).toHaveBeenCalledWith(`${DataShare.baseUrl}/accounts`, dataShareParams);
         });
     });
 


### PR DESCRIPTION
same as https://github.com/coveo/platform-client/pull/420 but I sent the POST params as body, not as query params

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
