### PR TITLE
feat(raw-metrics): add interfaces, calls and enums

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -876,8 +876,8 @@ export enum SearchHubLicenseMetrics {
 }
 
 export enum SearchHubLicenseType {
-    Assignment = 'assignment',
-    Global = 'global',
+    assignment = 'assignment',
+    global = 'global',
 }
 
 export enum SubscriptionFrequencyEnum {

--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -844,6 +844,42 @@ export enum LicenseSection {
     searchapi = 'searchapi',
 }
 
+export enum SearchHubRawMetrics {
+    normalQueries = 'normalQueries',
+    recommendationQueries = 'recommendationQueries',
+    commerceProductListingQueries = 'commerceProductListingQueries',
+    users = 'users',
+    staticQueries = 'staticQueries',
+}
+
+export enum SearchHubLicenseMetrics {
+    normalQueries = 'normalQueries',
+    recommendationQueries = 'recommendationQueries',
+    commerceProductListingQueries = 'commerceProductListingQueries',
+    agents = 'agents',
+    staticQueries = 'staticQueries',
+    intranetUsers = 'intranetUsers',
+    partnetUsers = 'partnerUsers',
+    timesExceededQps = 'timesExceededQps',
+    platformIntranetUsers = 'platformIntranetUsers',
+    platformAgents = 'platformAgents',
+    platformPortalUsers = 'platformPortalUsers',
+    salesforceServiceCloudAgents = 'salesforceServiceCloudAgents',
+    salesforceSalesCloudUsers = 'salesforceSalesCloudUsers',
+    salesforcePlatformUsers = 'salesforcePlatformUsers',
+    salesforceCommunityCloudUsers = 'salesforceCommunityCloudUsers',
+    snowCSMAgents = 'snowCSMAgents',
+    snowFulfillers = 'snowFulfillers',
+    snowITSMUsers = 'snowITSMUsers',
+    snowHRSDUsers = 'snowHRSDUsers',
+    dynamicsCustomerEngagementUsers = 'dynamicsCustomerEngagementUsers',
+}
+
+export enum SearchHubLicenseType {
+    Assignment = 'assignment',
+    Global = 'global',
+}
+
 export enum SubscriptionFrequencyEnum {
     live = 'LIVE',
     hourly = 'HOURLY',

--- a/src/resources/SearchUsageMetrics/RawMetrics/RawMetrics.ts
+++ b/src/resources/SearchUsageMetrics/RawMetrics/RawMetrics.ts
@@ -12,25 +12,44 @@ import {
 export default class RawMetrics extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/searchusagemetrics/raw/`;
 
+    private addZeroIfRequired = (numberToValidate: number) =>
+        numberToValidate < 10 ? `0${numberToValidate}` : numberToValidate;
+
     list() {
         return this.api.get<RestListOfRawMetrics>(`${RawMetrics.baseUrl}all`);
     }
 
     listMonthly({month, minimumQueries}: MonthlyRawMetricsParameters) {
+        const formattedMonthDate = `${month.year}-${this.addZeroIfRequired(month.month)}`;
+
         return this.api.get<RestListOfSearchHubRawMetrics>(
-            this.buildPath(`${RawMetrics.baseUrl}monthly`, {month, minimumQueries})
+            this.buildPath(`${RawMetrics.baseUrl}monthly`, {month: formattedMonthDate, minimumQueries})
         );
     }
 
     getDaily({to, from, metric, searchHub}: DailyRawMetricParameters) {
+        const formattedFromDate = `${from.year}-${this.addZeroIfRequired(from.month)}-${this.addZeroIfRequired(
+            from.day
+        )}`;
+        const formattedToDate = `${to.year}-${this.addZeroIfRequired(to.month)}-${this.addZeroIfRequired(to.day)}`;
+
         return this.api.get<RestListOfRawMetricValues>(
-            this.buildPath(`${RawMetrics.baseUrl}searchhubs/${searchHub}/daily/${metric}`, {to, from})
+            this.buildPath(`${RawMetrics.baseUrl}searchhubs/${searchHub}/daily/${metric}`, {
+                to: formattedToDate,
+                from: formattedFromDate,
+            })
         );
     }
 
     getMonthly({to, from, metric, searchHub}: MonthlyRawMetricParameters) {
+        const formattedFromDate = `${from.year}-${this.addZeroIfRequired(from.month)}`;
+        const formattedToDate = `${to.year}-${this.addZeroIfRequired(to.month)}`;
+
         return this.api.get<RestListOfRawMetricValues>(
-            this.buildPath(`${RawMetrics.baseUrl}searchhubs/${searchHub}/monthly/${metric}`, {to, from})
+            this.buildPath(`${RawMetrics.baseUrl}searchhubs/${searchHub}/monthly/${metric}`, {
+                to: formattedToDate,
+                from: formattedFromDate,
+            })
         );
     }
 }

--- a/src/resources/SearchUsageMetrics/RawMetrics/RawMetrics.ts
+++ b/src/resources/SearchUsageMetrics/RawMetrics/RawMetrics.ts
@@ -1,0 +1,36 @@
+import API from '../../../APICore';
+import Resource from '../../Resource';
+import {
+    DailyMetricParameters,
+    MonthlyMetricParameters,
+    MonthlyMetricsParameters,
+    RestListOfMetrics,
+    RestListOfMetricValues,
+    RestListOfSearchHubMetrics,
+} from './RawMetricsInterface';
+
+export default class RawMetrics extends Resource {
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/searchusagemetrics/raw/`;
+
+    list() {
+        return this.api.get<RestListOfMetrics>(`${RawMetrics.baseUrl}all`);
+    }
+
+    listMonthly({month, minimumQueries}: MonthlyMetricsParameters) {
+        return this.api.get<RestListOfSearchHubMetrics>(
+            this.buildPath(`${RawMetrics.baseUrl}monthly`, {month, minimumQueries})
+        );
+    }
+
+    getDaily({to, from, metric, searchHub}: DailyMetricParameters) {
+        return this.api.get<RestListOfMetricValues>(
+            this.buildPath(`${RawMetrics.baseUrl}searchhubs/${searchHub}/daily/${metric}`, {to, from})
+        );
+    }
+
+    getMonthly({to, from, metric, searchHub}: MonthlyMetricParameters) {
+        return this.api.get<RestListOfMetricValues>(
+            this.buildPath(`${RawMetrics.baseUrl}searchhubs/${searchHub}/monthly/${metric}`, {to, from})
+        );
+    }
+}

--- a/src/resources/SearchUsageMetrics/RawMetrics/RawMetrics.ts
+++ b/src/resources/SearchUsageMetrics/RawMetrics/RawMetrics.ts
@@ -1,35 +1,35 @@
 import API from '../../../APICore';
 import Resource from '../../Resource';
 import {
-    DailyMetricParameters,
-    MonthlyMetricParameters,
-    MonthlyMetricsParameters,
-    RestListOfMetrics,
-    RestListOfMetricValues,
-    RestListOfSearchHubMetrics,
+    DailyRawMetricParameters,
+    MonthlyRawMetricParameters,
+    MonthlyRawMetricsParameters,
+    RestListOfRawMetrics,
+    RestListOfRawMetricValues,
+    RestListOfSearchHubRawMetrics,
 } from './RawMetricsInterface';
 
 export default class RawMetrics extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/searchusagemetrics/raw/`;
 
     list() {
-        return this.api.get<RestListOfMetrics>(`${RawMetrics.baseUrl}all`);
+        return this.api.get<RestListOfRawMetrics>(`${RawMetrics.baseUrl}all`);
     }
 
-    listMonthly({month, minimumQueries}: MonthlyMetricsParameters) {
-        return this.api.get<RestListOfSearchHubMetrics>(
+    listMonthly({month, minimumQueries}: MonthlyRawMetricsParameters) {
+        return this.api.get<RestListOfSearchHubRawMetrics>(
             this.buildPath(`${RawMetrics.baseUrl}monthly`, {month, minimumQueries})
         );
     }
 
-    getDaily({to, from, metric, searchHub}: DailyMetricParameters) {
-        return this.api.get<RestListOfMetricValues>(
+    getDaily({to, from, metric, searchHub}: DailyRawMetricParameters) {
+        return this.api.get<RestListOfRawMetricValues>(
             this.buildPath(`${RawMetrics.baseUrl}searchhubs/${searchHub}/daily/${metric}`, {to, from})
         );
     }
 
-    getMonthly({to, from, metric, searchHub}: MonthlyMetricParameters) {
-        return this.api.get<RestListOfMetricValues>(
+    getMonthly({to, from, metric, searchHub}: MonthlyRawMetricParameters) {
+        return this.api.get<RestListOfRawMetricValues>(
             this.buildPath(`${RawMetrics.baseUrl}searchhubs/${searchHub}/monthly/${metric}`, {to, from})
         );
     }

--- a/src/resources/SearchUsageMetrics/RawMetrics/RawMetricsInterface.ts
+++ b/src/resources/SearchUsageMetrics/RawMetrics/RawMetricsInterface.ts
@@ -1,6 +1,6 @@
 import {SearchHubRawMetrics} from '../../Enums';
 
-export interface DailyMetricParameters extends CommonMetricParameters {
+export interface DailyRawMetricParameters extends CommonMetricParameters {
     /**
      * The last day to report for
      * Format YYYY-MM-DD
@@ -14,7 +14,7 @@ export interface DailyMetricParameters extends CommonMetricParameters {
     from: string;
 }
 
-export interface MonthlyMetricParameters extends CommonMetricParameters {
+export interface MonthlyRawMetricParameters extends CommonMetricParameters {
     /**
      * The last day to report for
      * Format YYYY-MM
@@ -28,7 +28,7 @@ export interface MonthlyMetricParameters extends CommonMetricParameters {
     from: string;
 }
 
-export interface MonthlyMetricsParameters {
+export interface MonthlyRawMetricsParameters {
     /**
      * The month to report for
      * Format YYYY-MM
@@ -41,21 +41,21 @@ export interface MonthlyMetricsParameters {
     minimumQueries?: string;
 }
 
-export interface RestListOfMetrics {
+export interface RestListOfRawMetrics {
     /**
      * The list of metrics
      */
     metrics: RestMetric[];
 }
 
-export interface RestListOfMetricValues {
+export interface RestListOfRawMetricValues {
     /**
      * The list of daily metric values
      */
     values: RestMetricValueForDate[];
 }
 
-export interface RestListOfSearchHubMetrics {
+export interface RestListOfSearchHubRawMetrics {
     /**
      * The list of search hubs
      */

--- a/src/resources/SearchUsageMetrics/RawMetrics/RawMetricsInterface.ts
+++ b/src/resources/SearchUsageMetrics/RawMetrics/RawMetricsInterface.ts
@@ -16,13 +16,13 @@ export interface DailyRawMetricParameters extends CommonMetricParameters {
 
 export interface MonthlyRawMetricParameters extends CommonMetricParameters {
     /**
-     * The last day to report for
+     * The last month to report for
      * Format YYYY-MM
      */
     to: string;
 
     /**
-     * The first day to report for
+     * The first month to report for
      * Format YYYY-MM
      */
     from: string;
@@ -81,7 +81,7 @@ interface RestMetricValueForDate {
     date: string;
 
     /**
-     * The numeric metric value (int64)
+     * The numeric metric value
      */
     value: number;
 }
@@ -98,27 +98,27 @@ interface RestSearchHubMetrics {
     assignement: SearchHubRawMetrics;
 
     /**
-     * The number of normal queries (int64)
+     * The number of normal queries
      */
     normalQueries: number;
 
     /**
-     * The number of recommendation queries (int64)
+     * The number of recommendation queries
      */
     recommendationQueries: number;
 
     /**
-     * The number of distinct users (int64)
+     * The number of distinct users
      */
     users: number;
 
     /**
-     * The number of distinct persistent queries (int64)
+     * The number of distinct persistent queries
      */
     staticQueries: number;
 
     /**
-     * The number of product listing queries (int64)
+     * The number of product listing queries
      */
     productListingQueries: number;
 }

--- a/src/resources/SearchUsageMetrics/RawMetrics/RawMetricsInterface.ts
+++ b/src/resources/SearchUsageMetrics/RawMetrics/RawMetricsInterface.ts
@@ -2,43 +2,38 @@ import {SearchHubRawMetrics} from '../../Enums';
 
 export interface DailyRawMetricParameters extends CommonMetricParameters {
     /**
-     * The last day to report for
-     * Format YYYY-MM-DD
+     * The first day to report for
      */
-    to: string;
+    from: DateWithoutTime;
 
     /**
-     * The first day to report for
-     * Format YYYY-MM-DD
+     * The last day to report for
      */
-    from: string;
+    to: DateWithoutTime;
 }
 
 export interface MonthlyRawMetricParameters extends CommonMetricParameters {
     /**
-     * The last month to report for
-     * Format YYYY-MM
+     * The first month to report for
      */
-    to: string;
+    from: DateWithoutTimeAndDay;
 
     /**
-     * The first month to report for
-     * Format YYYY-MM
+     * The last month to report for
      */
-    from: string;
+    to: DateWithoutTimeAndDay;
 }
 
 export interface MonthlyRawMetricsParameters {
     /**
      * The month to report for
-     * Format YYYY-MM
      */
-    month: string;
+    month: DateWithoutTimeAndDay;
 
     /**
      * The minimum number of queries required for a search hub to be listed
      */
-    minimumQueries?: string;
+    minimumQueries?: number;
 }
 
 export interface RestListOfRawMetrics {
@@ -134,3 +129,24 @@ interface CommonMetricParameters {
      */
     searchHub: string;
 }
+
+interface DateWithoutTime {
+    /**
+     * Year of the selected date
+     */
+    year: number;
+
+    /**
+     * Month of the selected date
+     * Between 1 to 12
+     */
+    month: number;
+
+    /**
+     * Day of the selected date
+     * Between 1 to 31
+     */
+    day: number;
+}
+
+type DateWithoutTimeAndDay = Omit<DateWithoutTime, 'day'>;

--- a/src/resources/SearchUsageMetrics/RawMetrics/RawMetricsInterface.ts
+++ b/src/resources/SearchUsageMetrics/RawMetrics/RawMetricsInterface.ts
@@ -1,0 +1,136 @@
+import {SearchHubRawMetrics} from '../../Enums';
+
+export interface DailyMetricParameters extends CommonMetricParameters {
+    /**
+     * The last day to report for
+     * Format YYYY-MM-DD
+     */
+    to: string;
+
+    /**
+     * The first day to report for
+     * Format YYYY-MM-DD
+     */
+    from: string;
+}
+
+export interface MonthlyMetricParameters extends CommonMetricParameters {
+    /**
+     * The last day to report for
+     * Format YYYY-MM
+     */
+    to: string;
+
+    /**
+     * The first day to report for
+     * Format YYYY-MM
+     */
+    from: string;
+}
+
+export interface MonthlyMetricsParameters {
+    /**
+     * The month to report for
+     * Format YYYY-MM
+     */
+    month: string;
+
+    /**
+     * The minimum number of queries required for a search hub to be listed
+     */
+    minimumQueries?: string;
+}
+
+export interface RestListOfMetrics {
+    /**
+     * The list of metrics
+     */
+    metrics: RestMetric[];
+}
+
+export interface RestListOfMetricValues {
+    /**
+     * The list of daily metric values
+     */
+    values: RestMetricValueForDate[];
+}
+
+export interface RestListOfSearchHubMetrics {
+    /**
+     * The list of search hubs
+     */
+    searchHubs: RestSearchHubMetrics[];
+}
+
+interface RestMetric {
+    /**
+     * The ID of the metric
+     */
+    id: SearchHubRawMetrics;
+
+    /**
+     * The display name of the metric
+     */
+    label?: string;
+}
+
+interface RestMetricValueForDate {
+    /**
+     * The date for the usage metric value
+     */
+    date: string;
+
+    /**
+     * The numeric metric value (int64)
+     */
+    value: number;
+}
+
+interface RestSearchHubMetrics {
+    /**
+     * The name of the search hub
+     */
+    searchHub: string;
+
+    /**
+     * The usage buckets to which the search hub is assigned
+     */
+    assignement: SearchHubRawMetrics;
+
+    /**
+     * The number of normal queries (int64)
+     */
+    normalQueries: number;
+
+    /**
+     * The number of recommendation queries (int64)
+     */
+    recommendationQueries: number;
+
+    /**
+     * The number of distinct users (int64)
+     */
+    users: number;
+
+    /**
+     * The number of distinct persistent queries (int64)
+     */
+    staticQueries: number;
+
+    /**
+     * The number of product listing queries (int64)
+     */
+    productListingQueries: number;
+}
+
+interface CommonMetricParameters {
+    /**
+     * The raw metric to report on
+     */
+    metric: SearchHubRawMetrics;
+
+    /**
+     * The name of the search hub to report on
+     */
+    searchHub: string;
+}

--- a/src/resources/SearchUsageMetrics/RawMetrics/index.ts
+++ b/src/resources/SearchUsageMetrics/RawMetrics/index.ts
@@ -1,0 +1,2 @@
+export * from './RawMetrics';
+export * from './RawMetricsInterface';

--- a/src/resources/SearchUsageMetrics/RawMetrics/tests/RawMetrics.spec.ts
+++ b/src/resources/SearchUsageMetrics/RawMetrics/tests/RawMetrics.spec.ts
@@ -25,20 +25,24 @@ describe('RawMetrics', () => {
     });
 
     describe('listMonthly', () => {
-        const month = '2021-04';
-        const minimumQueries = '12';
+        const month = {year: 2021, month: 4};
+        const minimumQueries = 12;
 
         it('makes a GET call to fetch a list raw metric value for a specific month', () => {
+            const expectedMonthFormat = '2021-04';
+
             RawMetricsService.listMonthly({month});
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${RawMetrics.baseUrl}monthly?month=${month}`);
+            expect(api.get).toHaveBeenCalledWith(`${RawMetrics.baseUrl}monthly?month=${expectedMonthFormat}`);
         });
 
         it('makes a GET call to fetch a list raw metric value with a number of queries equal or above for a specific month if the minimumQueries parameter is set', () => {
+            const expectedMonthFormat = '2021-04';
+
             RawMetricsService.listMonthly({month, minimumQueries});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `${RawMetrics.baseUrl}monthly?month=${month}&minimumQueries=${minimumQueries}`
+                `${RawMetrics.baseUrl}monthly?month=${expectedMonthFormat}&minimumQueries=${minimumQueries}`
             );
         });
     });
@@ -46,14 +50,17 @@ describe('RawMetrics', () => {
     describe('getDaily', () => {
         const metric = SearchHubRawMetrics.normalQueries;
         const searchHub = 'hello';
-        const to = '2021-01-13';
-        const from = '2021-01-06';
+        const to = {year: 2021, month: 2, day: 12};
+        const from = {year: 2020, month: 3, day: 26};
 
         it('makes a GET call to fetch all daily raw values from a metric and search hub that are included in the range specified', () => {
+            const expectedFromDate = '2020-03-26';
+            const expectedToDate = '2021-02-12';
+
             RawMetricsService.getDaily({metric, searchHub, to, from});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `${RawMetrics.baseUrl}searchhubs/${searchHub}/daily/${metric}?to=${to}&from=${from}`
+                `${RawMetrics.baseUrl}searchhubs/${searchHub}/daily/${metric}?to=${expectedToDate}&from=${expectedFromDate}`
             );
         });
     });
@@ -61,14 +68,17 @@ describe('RawMetrics', () => {
     describe('getMonthly', () => {
         const metric = SearchHubRawMetrics.normalQueries;
         const searchHub = 'hello';
-        const to = '2021-04';
-        const from = '2021-01';
+        const to = {year: 2021, month: 2};
+        const from = {year: 2020, month: 3};
 
         it('makes a GET call to fetch all monthly raw values from a metric and search hub that are included in the range specified', () => {
+            const expectedFromDate = '2020-03';
+            const expectedToDate = '2021-02';
+
             RawMetricsService.getMonthly({metric, searchHub, to, from});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `${RawMetrics.baseUrl}searchhubs/${searchHub}/monthly/${metric}?to=${to}&from=${from}`
+                `${RawMetrics.baseUrl}searchhubs/${searchHub}/monthly/${metric}?to=${expectedToDate}&from=${expectedFromDate}`
             );
         });
     });

--- a/src/resources/SearchUsageMetrics/RawMetrics/tests/RawMetrics.spec.ts
+++ b/src/resources/SearchUsageMetrics/RawMetrics/tests/RawMetrics.spec.ts
@@ -1,0 +1,75 @@
+import {SearchHubRawMetrics} from '../../..';
+import API from '../../../../APICore';
+import RawMetrics from '../RawMetrics';
+
+jest.mock('../../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('RawMetrics', () => {
+    let RawMetricsService: RawMetrics;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        RawMetricsService = new RawMetrics(api, serverlessApi);
+    });
+
+    describe('list', () => {
+        it('makes a GET call to fetch all the available metrics for assignment', () => {
+            RawMetricsService.list();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${RawMetrics.baseUrl}all`);
+        });
+    });
+
+    describe('listMonthly', () => {
+        const month = '2021-04';
+        const minimumQueries = '12';
+
+        it('makes a GET call to fetch a list raw metric value for a specific month', () => {
+            RawMetricsService.listMonthly({month});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${RawMetrics.baseUrl}monthly?month=${month}`);
+        });
+
+        it('makes a GET call to fetch a list raw metric value with a number of queries equal or above for a specific month if the minimumQueries parameter is set', () => {
+            RawMetricsService.listMonthly({month, minimumQueries});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${RawMetrics.baseUrl}monthly?month=${month}&minimumQueries=${minimumQueries}`
+            );
+        });
+    });
+
+    describe('getDaily', () => {
+        const metric = SearchHubRawMetrics.normalQueries;
+        const searchHub = 'hello';
+        const to = '2021-01-13';
+        const from = '2021-01-06';
+
+        it('makes a GET call to fetch all daily raw values from a metric and search hub that are included in the range specified', () => {
+            RawMetricsService.getDaily({metric, searchHub, to, from});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${RawMetrics.baseUrl}searchhubs/${searchHub}/daily/${metric}?to=${to}&from=${from}`
+            );
+        });
+    });
+
+    describe('getMonthly', () => {
+        const metric = SearchHubRawMetrics.normalQueries;
+        const searchHub = 'hello';
+        const to = '2021-04';
+        const from = '2021-01';
+
+        it('makes a GET call to fetch all monthly raw values from a metric and search hub that are included in the range specified', () => {
+            RawMetricsService.getMonthly({metric, searchHub, to, from});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${RawMetrics.baseUrl}searchhubs/${searchHub}/monthly/${metric}?to=${to}&from=${from}`
+            );
+        });
+    });
+});

--- a/src/resources/SearchUsageMetrics/SearchUsageMetrics.ts
+++ b/src/resources/SearchUsageMetrics/SearchUsageMetrics.ts
@@ -1,16 +1,19 @@
 import API from '../../APICore';
 import Resource from '../Resource';
 import LicenseMetrics from './LicenseMetrics/LicenseMetrics';
+import RawMetrics from './RawMetrics/RawMetrics';
 import SearchHubs from './SearchHubs/SearchHubs';
 
 export default class SearchUsageMetrics extends Resource {
     licenseMetrics: LicenseMetrics;
     searchHubs: SearchHubs;
+    rawMetrics: RawMetrics;
 
     constructor(protected api: API, protected serverlessApi: API) {
         super(api, serverlessApi);
 
         this.licenseMetrics = new LicenseMetrics(api, serverlessApi);
         this.searchHubs = new SearchHubs(api, serverlessApi);
+        this.rawMetrics = new RawMetrics(api, serverlessApi);
     }
 }

--- a/src/resources/SearchUsageMetrics/index.ts
+++ b/src/resources/SearchUsageMetrics/index.ts
@@ -1,3 +1,4 @@
 export * from './SearchUsageMetrics';
 export * from './LicenseMetrics';
 export * from './SearchHubs';
+export * from './RawMetrics';

--- a/src/resources/SearchUsageMetrics/tests/SearchUsageMetrics.spec.ts
+++ b/src/resources/SearchUsageMetrics/tests/SearchUsageMetrics.spec.ts
@@ -1,5 +1,7 @@
 import API from '../../../APICore';
 import LicenseMetrics from '../LicenseMetrics/LicenseMetrics';
+import RawMetrics from '../RawMetrics/RawMetrics';
+import SearchHubs from '../SearchHubs/SearchHubs';
 import SearchUsageMetrics from '../SearchUsageMetrics';
 
 jest.mock('../../../APICore');
@@ -19,5 +21,15 @@ describe('SearchUsageMetrics', () => {
     it('registers the licenseMetrics resource', () => {
         expect(searchUsageMetrics.licenseMetrics).toBeDefined();
         expect(searchUsageMetrics.licenseMetrics).toBeInstanceOf(LicenseMetrics);
+    });
+
+    it('registers the searchHubs resource', () => {
+        expect(searchUsageMetrics.searchHubs).toBeDefined();
+        expect(searchUsageMetrics.searchHubs).toBeInstanceOf(SearchHubs);
+    });
+
+    it('registers the rawMetrics resource', () => {
+        expect(searchUsageMetrics.rawMetrics).toBeDefined();
+        expect(searchUsageMetrics.rawMetrics).toBeInstanceOf(RawMetrics);
     });
 });


### PR DESCRIPTION
Story: https://coveord.atlassian.net/browse/SEARCHAPI-6778

This implementation is based on that documentation: https://platformdev.cloud.coveo.com/docs?urls.primaryName=Search%20Usage%20Metrics#/Raw%20Metrics

Interfaces (parameters and responses), calls and enums are added.
The enums provided are based on:
- `SearchHubLicenseMetrics` & `SearchHubLicenseType` are constants availables in the Admin-UI project, but should be exposed in Platform-client
- `SearchHubRawMetrics` is the value accepted based on the information found in the search-usage-metrics repository (service -> RawMetrics.scala)

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
