### PR TITLE
feat(vaults): add Import method

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -984,3 +984,9 @@ export enum ReportType {
     Dashboard = 'DASHBOARD',
     Explorer = 'EXPLORER',
 }
+
+export enum VaultFetchStrategy {
+    allOrNothing = 'ALL_OR_NOTHING',
+    onlyMissing = 'ONLY_MISSING',
+    overwrite = 'OVERWRITE',
+}

--- a/src/resources/Vaults/Vaults.ts
+++ b/src/resources/Vaults/Vaults.ts
@@ -1,4 +1,5 @@
 import API from '../../APICore';
+import {VaultFetchStrategy} from '../Enums';
 import Resource from '../Resource';
 import {MissingVaultModel} from './VaultsInterfaces';
 
@@ -14,5 +15,29 @@ export default class Vaults extends Resource {
      */
     findMissing(snapshotId: string) {
         return this.api.get<MissingVaultModel>(this.buildPath(`${Vaults.baseUrl}/missing`, {snapshotId}));
+    }
+
+    /**
+     * Import vault entries from the starting organization into the current organization.
+     *
+     * @param {string} currentSnapshotId The unique identifier of the current snapshot.
+     * @param {string} currentOrganizationId The unique identifier of the current organization.
+     * @param {string} sourceOrganizationId The unique identifier of the source organization.
+     * @param {VaultFetchStrategy} fetchStrategy Choosing the strategy to use when importing vault entries.
+     */
+    import(
+        currentSnapshotId: string,
+        currentOrganizationId: string,
+        sourceOrganizationId: string,
+        fetchStrategy: VaultFetchStrategy
+    ) {
+        return this.api.put(
+            this.buildPath(`${Vaults.baseUrl}/fetch`, {
+                referenceSnapshotId: currentSnapshotId,
+                organizationId: currentOrganizationId,
+                sourceOrganizationId,
+                fetchStrategy,
+            })
+        );
     }
 }

--- a/src/resources/Vaults/tests/Vaults.spec.ts
+++ b/src/resources/Vaults/tests/Vaults.spec.ts
@@ -1,5 +1,6 @@
 import API from '../../../APICore';
 import Vaults from '../Vaults';
+import {VaultFetchStrategy} from '../../Enums';
 
 jest.mock('../../../APICore');
 
@@ -23,6 +24,21 @@ describe('Vaults', () => {
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Vaults.baseUrl}/missing?snapshotId=${snapshotToGetId}`);
+        });
+    });
+
+    describe('import', () => {
+        it('should make a PUT call to the specific Vaults url', () => {
+            const currentSnaphostId = 'current-snapshot-id';
+            const currentOrganizationId = 'current-organization-id';
+            const sourceOrganizationId = 'source-organization-id';
+
+            vaults.import(currentSnaphostId, currentOrganizationId, sourceOrganizationId, VaultFetchStrategy.overwrite);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `${Vaults.baseUrl}/fetch?referenceSnapshotId=${currentSnaphostId}&organizationId=${currentOrganizationId}&sourceOrganizationId=${sourceOrganizationId}&fetchStrategy=${VaultFetchStrategy.overwrite}`
+            );
         });
     });
 });


### PR DESCRIPTION
Task: https://coveord.atlassian.net/browse/SRC-4843

This implementation is based on that documentation: https://platformdev.cloud.coveo.com/docs?urls.primaryName=Migration#/Vault/rest_organizations_paramId_vaultentries_fetch_put

Add `import` method in `Vaults` resource.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
