### PR TITLE
feat(catalog): add getFieldStats endpoint

### DIFF
--- a/src/resources/Catalogs/Catalog.ts
+++ b/src/resources/Catalogs/Catalog.ts
@@ -3,7 +3,9 @@ import {New, PageModel} from '../BaseInterfaces';
 import Resource from '../Resource';
 import {
     CachedCatalogFieldsModel,
+    CachedCatalogFieldStatsModel,
     CatalogFieldsOptions,
+    CatalogFieldStatsOptions,
     CatalogModel,
     CatalogsListOptions,
     CreateCatalogModel,
@@ -49,5 +51,11 @@ export default class Catalog extends Resource {
 
     getFieldsSuggestions(query: FieldsSuggestionsQueryModel) {
         return this.api.post<FieldsSuggestionsModel>(`${Catalog.baseUrl}/fieldsSuggestions`, query);
+    }
+
+    getFieldStats(catalogId: string, options?: CatalogFieldStatsOptions) {
+        return this.api.get<CachedCatalogFieldStatsModel>(
+            this.buildPath(`${Catalog.baseUrl}/${catalogId}/fieldStats`, options)
+        );
     }
 }

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -323,3 +323,24 @@ export type ScopeModel =
           query?: string;
           sourceIds: string[];
       };
+
+export interface FieldStatsItemModel {
+    objectsWithField: number;
+    objectsWithType: number;
+}
+
+export interface CatalogFieldStatsModel {
+    fieldName: string;
+    product: FieldStatsItemModel;
+    variant: FieldStatsItemModel;
+    availability: FieldStatsItemModel;
+}
+
+export type CachedCatalogFieldStatsModel = Cached<CatalogFieldStatsModel>;
+
+export interface CatalogFieldStatsOptions {
+    /**
+     * Wether we need to force a refresh of field statistics. Field statistics are cached and computed on a regular interval.
+     */
+    forceRefresh?: boolean;
+}

--- a/src/resources/Catalogs/tests/Catalog.spec.ts
+++ b/src/resources/Catalogs/tests/Catalog.spec.ts
@@ -184,4 +184,22 @@ describe('Catalog', () => {
             expect(api.put).toHaveBeenCalledWith(`${Catalog.baseUrl}/${catalogModel.id}`, catalogModel);
         });
     });
+
+    describe('getFieldStats', () => {
+        it("should make a GET call to the specific catalog's fields stats url", () => {
+            const catalogOfFieldsToGetId = 'catalog-of-fields';
+            catalog.getFieldStats(catalogOfFieldsToGetId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Catalog.baseUrl}/${catalogOfFieldsToGetId}/fieldStats`);
+        });
+
+        it('should allow refreshing the field statistics cache', () => {
+            const catalogOfFieldsToGetId = 'catalog-of-fields';
+            catalog.getFieldStats(catalogOfFieldsToGetId, {forceRefresh: true});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Catalog.baseUrl}/${catalogOfFieldsToGetId}/fieldStats?forceRefresh=true`
+            );
+        });
+    });
 });


### PR DESCRIPTION
Expose the new fieldStats endpoint through the getFieldStats function on the catalog.

-   [ x ] JSDoc annotates each property added in the exported interfaces
-   [ x ] The proposed changes are covered by unit tests
-   [ x ] Commits containing breaking changes a properly identified as such
-   [ x ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
