### PR TITLE
feat(org): organization call to be added

### DIFF
--- a/src/resources/Organizations/Organization.ts
+++ b/src/resources/Organizations/Organization.ts
@@ -73,6 +73,17 @@ export default class Organization extends Resource {
         return this.api.post(`${Organization.baseUrl}/${organizationId}/resume`);
     }
 
+    updateAdditionalInformation(additionalInformationObj: Record<string, unknown>) {
+        return this.api.put<Record<string, unknown>>(
+            `${Organization.baseUrl}/${API.orgPlaceholder}/additionalinformation`,
+            additionalInformationObj
+        );
+    }
+
+    getAdditionalInformation(organizationId: string = API.orgPlaceholder) {
+        return this.api.get<any>(`${Organization.baseUrl}/${organizationId}/additionalinformation`);
+    }
+
     listPrivileges() {
         return this.api.get<PrivilegeModel[]>(`${Organization.baseUrl}/${API.orgPlaceholder}/privileges`);
     }

--- a/src/resources/Organizations/tests/Organizations.spec.ts
+++ b/src/resources/Organizations/tests/Organizations.spec.ts
@@ -224,4 +224,29 @@ describe('Organization', () => {
         expect(organization.members).toBeDefined();
         expect(organization.members).toBeInstanceOf(Members);
     });
+
+    describe('additional information', () => {
+        it('should make a GET call with additional information', () => {
+            const organizationToGetId = 'Organization-to-be-fetched';
+            organization.getAdditionalInformation(organizationToGetId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Organization.baseUrl}/${organizationToGetId}/additionalinformation`
+            );
+        });
+        it('should make a PUT call to put data in additional information', () => {
+            const additionalInformationObj = {
+                trialProgress: {
+                    completedSource: true,
+                },
+            };
+            organization.updateAdditionalInformation(additionalInformationObj);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `${Organization.baseUrl}/{organizationName}/additionalinformation`,
+                additionalInformationObj
+            );
+        });
+    });
 });


### PR DESCRIPTION
Adding the org call created in FOUND 3921

For context, this call allows us to persist data at the organization level and is meant to accept any type of object `{}`

Use case would be to persist information for a Trial type org for instance so that we can make a call to retrieve the appropriate data across all different panels

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
