### PR TITLE
feat(service): add insight panel config resource

### DIFF
--- a/src/resources/InsightPanelConfigs/InsightPanelConfig.ts
+++ b/src/resources/InsightPanelConfigs/InsightPanelConfig.ts
@@ -11,14 +11,7 @@ export default class InsightPanelConfig extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/insightconfig/v1/configs`;
 
     list(options?: InsightPanelConfigListOptions) {
-        const effectiveOptions = {
-            ...options,
-            order: options?.order ?? 'asc',
-        };
-
-        return this.api.get<PageModel<InsightPanelConfigModel>>(
-            this.buildPath(InsightPanelConfig.baseUrl, effectiveOptions)
-        );
+        return this.api.get<PageModel<InsightPanelConfigModel>>(this.buildPath(InsightPanelConfig.baseUrl, options));
     }
 
     create(insightPanelConfig: New<InsightPanelConfigCreationParams>) {

--- a/src/resources/InsightPanelConfigs/InsightPanelConfig.ts
+++ b/src/resources/InsightPanelConfigs/InsightPanelConfig.ts
@@ -1,0 +1,41 @@
+import API from '../../APICore';
+import {New, PageModel} from '../BaseInterfaces';
+import Resource from '../Resource';
+import {
+    InsightPanelConfigCreationParams,
+    InsightPanelConfigListOptions,
+    InsightPanelConfigModel,
+} from './InsightPanelConfigInterfaces';
+
+export default class InsightPanelConfig extends Resource {
+    static baseUrl = `/rest/organization/${API.orgPlaceholder}/insight-config/v1/configs`;
+
+    list(options?: InsightPanelConfigListOptions) {
+        const effectiveOptions = {
+            ...options,
+            sorting: options?.sorting ?? 'asc',
+        };
+
+        return this.api.get<PageModel<InsightPanelConfigModel, 'configurations'>>(
+            this.buildPath(InsightPanelConfig.baseUrl, effectiveOptions)
+        );
+    }
+
+    create(insightPanelConfig: New<InsightPanelConfigCreationParams>) {
+        return this.api.post<InsightPanelConfigCreationParams>(InsightPanelConfig.baseUrl, insightPanelConfig);
+    }
+
+    delete(insightPanelConfigId: string) {
+        return this.api.delete(`${InsightPanelConfig.baseUrl}/${insightPanelConfigId}`);
+    }
+
+    get(insightPanelConfigId: string) {
+        return this.api.get<InsightPanelConfigModel>(`${InsightPanelConfig.baseUrl}/${insightPanelConfigId}`);
+    }
+
+    update(insightPanelConfig: InsightPanelConfigCreationParams) {
+        const {id, ...body} = insightPanelConfig;
+
+        return this.api.put<InsightPanelConfigCreationParams>(`${InsightPanelConfig.baseUrl}/${id}`, body);
+    }
+}

--- a/src/resources/InsightPanelConfigs/InsightPanelConfig.ts
+++ b/src/resources/InsightPanelConfigs/InsightPanelConfig.ts
@@ -8,21 +8,21 @@ import {
 } from './InsightPanelConfigInterfaces';
 
 export default class InsightPanelConfig extends Resource {
-    static baseUrl = `/rest/organization/${API.orgPlaceholder}/insight-config/v1/configs`;
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/insightconfig/v1/configs`;
 
     list(options?: InsightPanelConfigListOptions) {
         const effectiveOptions = {
             ...options,
-            sorting: options?.sorting ?? 'asc',
+            order: options?.order ?? 'asc',
         };
 
-        return this.api.get<PageModel<InsightPanelConfigModel, 'configurations'>>(
+        return this.api.get<PageModel<InsightPanelConfigModel>>(
             this.buildPath(InsightPanelConfig.baseUrl, effectiveOptions)
         );
     }
 
     create(insightPanelConfig: New<InsightPanelConfigCreationParams>) {
-        return this.api.post<InsightPanelConfigCreationParams>(InsightPanelConfig.baseUrl, insightPanelConfig);
+        return this.api.post<InsightPanelConfigModel>(InsightPanelConfig.baseUrl, insightPanelConfig);
     }
 
     delete(insightPanelConfigId: string) {
@@ -36,6 +36,6 @@ export default class InsightPanelConfig extends Resource {
     update(insightPanelConfig: InsightPanelConfigCreationParams) {
         const {id, ...body} = insightPanelConfig;
 
-        return this.api.put<InsightPanelConfigCreationParams>(`${InsightPanelConfig.baseUrl}/${id}`, body);
+        return this.api.put<InsightPanelConfigModel>(`${InsightPanelConfig.baseUrl}/${id}`, body);
     }
 }

--- a/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
+++ b/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
@@ -22,10 +22,11 @@ export interface InsightPanelConfigListOptions {
      * The sort order to apply on the Insight Panel configuration name.
      *
      * **Allowed values:**
+     * - `undefined`: Configurations are returned in no specific order.
      * - `asc`: Sort configurations by name in ascending order.
      * - `desc`: Sort configurations by name in descending order.
      *
-     * @default `asc`
+     * @default `undefined`
      */
     order?: 'asc' | 'desc';
 }

--- a/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
+++ b/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
@@ -27,7 +27,7 @@ export interface InsightPanelConfigListOptions {
      *
      * @default `asc`
      */
-    sorting?: 'asc' | 'desc';
+    order?: 'asc' | 'desc';
 }
 
 /**

--- a/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
+++ b/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
@@ -1,0 +1,139 @@
+/**
+ * Defines the options to list Insight Panel configurations.
+ */
+export interface InsightPanelConfigListOptions {
+    /**
+     * The zero-based page to retrieve.
+     *
+     * @default `0`
+     */
+    page?: number;
+    /**
+     * The number of configurations to return per page.
+     *
+     * @default `10`
+     */
+    perPage?: number;
+    /**
+     * A substring that must appear in a search interface configuration name for this configuration to appear in results.
+     */
+    filter?: string;
+    /**
+     * The sort order to apply on the Insight Panel configuration name.
+     *
+     * **Allowed values:**
+     * - `asc`: Sort configurations by name in ascending order.
+     * - `desc`: Sort configurations by name in descending order.
+     *
+     * @default `asc`
+     */
+    sorting?: 'asc' | 'desc';
+}
+
+/**
+ * Defines the parameters required to create an Insight Panel configuration.
+ */
+export interface InsightPanelConfigCreationParams {
+    /**
+     * The ID of the Insight Panel configuration.
+     */
+    id: string;
+
+    /**
+     * The name of the Insight Panel configuration.
+     */
+    name: string;
+
+    /**
+     * The ID of the associated query pipeline.
+     */
+    pipeline: string;
+
+    /**
+     * The context field mappings to use when performing queries. This mapping allows an Insight Panel integration to retrieve the context information from the CRM and pass it to the Coveo platform when executing Insight Panel queries.
+     *
+     * The key is the context information such as `subject` or `description`.
+     *
+     * The value is a CRM reference allowing the Insight Panel integration to retrieve the context information from the CRM.
+     *
+     * @example
+     * ```json
+     * {
+     *   "subject": "Case_subject",
+     *   "description": "Case_description"
+     * }
+     * ```
+     */
+    contextFields?: Record<string, string>;
+}
+
+/**
+ * Defines an Insight Panel configuration.
+ */
+export interface InsightPanelConfigModel {
+    /**
+     * The Insight Panel configuration ID.
+     */
+    id: string;
+    /**
+     * The Insight Panel configuration name.
+     */
+    name: string;
+    /**
+     * The summary information specific to the associated query pipeline.
+     */
+    pipeline: {
+        /**
+         * The query pipeline ID.
+         */
+        id: string;
+        /**
+         * The query pipeline name.
+         */
+        name: string;
+        /**
+         * The associated ML models information.
+         */
+        models: {
+            /**
+             * Information related to the Automatic Relevance Tuning (ART) ML model.
+             */
+            art: {
+                /**
+                 * Indicates whether an ART ML model is configured in the query pipeline.
+                 */
+                enabled: boolean;
+            };
+            /**
+             * Information related to the Dynamic Navigation Experience (DNE) ML model.
+             */
+            dne: {
+                /**
+                 * Indicates whether a DNE ML model is configured in the query pipeline.
+                 */
+                enabled: boolean;
+            };
+        };
+    };
+    /**
+     * The search hub value affected to this Insight Panel configuration.
+     */
+    searchHub: string;
+
+    /**
+     * The context field mappings to use when performing queries. This mapping allows an Insight Panel integration to retrieve the context information from the CRM and pass it to the Coveo platform when executing Insight Panel queries.
+     *
+     * The key is the context information such as `subject` or `description`.
+     *
+     * The value is a CRM reference allowing the Insight Panel integration to retrieve the context information from the CRM.
+     *
+     * @example
+     * ```json
+     * {
+     *   "subject": "Case_subject",
+     *   "description": "Case_description"
+     * }
+     * ```
+     */
+    contextFields: Record<string, string>;
+}

--- a/src/resources/InsightPanelConfigs/index.ts
+++ b/src/resources/InsightPanelConfigs/index.ts
@@ -1,0 +1,2 @@
+export * from './InsightPanelConfig';
+export * from './InsightPanelConfigInterfaces';

--- a/src/resources/InsightPanelConfigs/tests/InsightPanelConfig.spec.ts
+++ b/src/resources/InsightPanelConfigs/tests/InsightPanelConfig.spec.ts
@@ -1,0 +1,108 @@
+import API from '../../../APICore';
+import InsightPanelConfig from '../InsightPanelConfig';
+
+jest.mock('../../../APICore');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('InsightPanelConfig', () => {
+    let insightPanel: InsightPanelConfig;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        insightPanel = new InsightPanelConfig(api, serverlessApi);
+    });
+
+    describe('list', () => {
+        it('should make a GET call to the InsightPanelConfig base URL', () => {
+            insightPanel.list({page: 2, perPage: 10, filter: 'anything', sorting: 'desc'});
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${InsightPanelConfig.baseUrl}?page=2&perPage=10&filter=anything&sorting=desc`
+            );
+        });
+
+        describe('with sorting parameter', () => {
+            it('should sort in ascending order by default', () => {
+                insightPanel.list();
+
+                expect(api.get).toHaveBeenCalledTimes(1);
+                expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}?sorting=asc`);
+            });
+
+            it('should sort in ascending order when specified', () => {
+                insightPanel.list({sorting: 'asc'});
+
+                expect(api.get).toHaveBeenCalledTimes(1);
+                expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}?sorting=asc`);
+            });
+
+            it('should sort in descending order when specified', () => {
+                insightPanel.list({sorting: 'desc'});
+
+                expect(api.get).toHaveBeenCalledTimes(1);
+                expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}?sorting=desc`);
+            });
+        });
+    });
+
+    describe('create', () => {
+        it('should make a POST call to the InsightPanelConfig base URL', () => {
+            const newInsightPanelModel = {
+                name: 'my insight panel',
+                pipeline: 'some query pipeline',
+            };
+
+            insightPanel.create(newInsightPanelModel);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(InsightPanelConfig.baseUrl, newInsightPanelModel);
+        });
+    });
+
+    describe('delete', () => {
+        it('should make a DELETE call to the specific InsightPanelConfig URL', () => {
+            const insightPanelConfigId = 'some-insight-panel-config';
+            insightPanel.delete(insightPanelConfigId);
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}/${insightPanelConfigId}`);
+        });
+    });
+
+    describe('update', () => {
+        it('should make a PUT call to the specific InsightPanelConfig URL', () => {
+            const insightPanelModel = {
+                id: 'some-insight-panel-config',
+                name: 'my insight panel',
+                pipeline: 'some query pipeline',
+                contextFields: {
+                    subject: 'crm-subject-field',
+                    description: 'crm-description-field',
+                },
+            };
+            const {id, ...insightPanelModelWithoutId} = insightPanelModel;
+
+            insightPanel.update(insightPanelModel);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `${InsightPanelConfig.baseUrl}/${insightPanelModel.id}`,
+                insightPanelModelWithoutId
+            );
+        });
+    });
+
+    describe('get', () => {
+        it('should make a GET call to the specific InsightPanelConfig URL', () => {
+            const insightPanelConfigId = 'some-insight-panel-config';
+            insightPanel.get(insightPanelConfigId);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}/${insightPanelConfigId}`);
+        });
+    });
+});

--- a/src/resources/InsightPanelConfigs/tests/InsightPanelConfig.spec.ts
+++ b/src/resources/InsightPanelConfigs/tests/InsightPanelConfig.spec.ts
@@ -26,11 +26,11 @@ describe('InsightPanelConfig', () => {
         });
 
         describe('with order parameter', () => {
-            it('should sort in ascending order by default', () => {
+            it('should not sort by default', () => {
                 insightPanel.list();
 
                 expect(api.get).toHaveBeenCalledTimes(1);
-                expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}?order=asc`);
+                expect(api.get).toHaveBeenCalledWith(InsightPanelConfig.baseUrl);
             });
 
             it('should sort in ascending order when specified', () => {

--- a/src/resources/InsightPanelConfigs/tests/InsightPanelConfig.spec.ts
+++ b/src/resources/InsightPanelConfigs/tests/InsightPanelConfig.spec.ts
@@ -17,34 +17,34 @@ describe('InsightPanelConfig', () => {
 
     describe('list', () => {
         it('should make a GET call to the InsightPanelConfig base URL', () => {
-            insightPanel.list({page: 2, perPage: 10, filter: 'anything', sorting: 'desc'});
+            insightPanel.list({page: 2, perPage: 10, filter: 'anything', order: 'desc'});
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `${InsightPanelConfig.baseUrl}?page=2&perPage=10&filter=anything&sorting=desc`
+                `${InsightPanelConfig.baseUrl}?page=2&perPage=10&filter=anything&order=desc`
             );
         });
 
-        describe('with sorting parameter', () => {
+        describe('with order parameter', () => {
             it('should sort in ascending order by default', () => {
                 insightPanel.list();
 
                 expect(api.get).toHaveBeenCalledTimes(1);
-                expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}?sorting=asc`);
+                expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}?order=asc`);
             });
 
             it('should sort in ascending order when specified', () => {
-                insightPanel.list({sorting: 'asc'});
+                insightPanel.list({order: 'asc'});
 
                 expect(api.get).toHaveBeenCalledTimes(1);
-                expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}?sorting=asc`);
+                expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}?order=asc`);
             });
 
             it('should sort in descending order when specified', () => {
-                insightPanel.list({sorting: 'desc'});
+                insightPanel.list({order: 'desc'});
 
                 expect(api.get).toHaveBeenCalledTimes(1);
-                expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}?sorting=desc`);
+                expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}?order=desc`);
             });
         });
     });

--- a/src/resources/PlatformResources.ts
+++ b/src/resources/PlatformResources.ts
@@ -14,6 +14,7 @@ import GlobalGroup from './GlobalGroups/GlobalGroup';
 import Group from './Groups/Groups';
 import Index from './Indexes/Indexes';
 import InProductExperiences from './InProductExperiences/InProductExperiences';
+import InsightPanelConfig from './InsightPanelConfigs/InsightPanelConfig';
 import License from './License/License';
 import Limits from './Limits/Limits';
 import Links from './Links/Links';
@@ -54,6 +55,7 @@ const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'globalGroup', resource: GlobalGroup},
     {key: 'group', resource: Group},
     {key: 'index', resource: Index},
+    {key: 'insightPanelConfig', resource: InsightPanelConfig},
     {key: 'ipx', resource: InProductExperiences},
     {key: 'license', resource: License},
     {key: 'limits', resource: Limits},
@@ -98,6 +100,7 @@ class PlatformResources {
     globalGroup: GlobalGroup;
     group: Group;
     index: Index;
+    insightPanelConfig: InsightPanelConfig;
     ipx: InProductExperiences;
     license: License;
     limits: Limits;

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -14,6 +14,7 @@ export * from './GlobalGroups';
 export * from './Groups';
 export * from './Indexes';
 export * from './InProductExperiences';
+export * from './InsightPanelConfigs';
 export * from './License';
 export * from './Limits';
 export * from './Links';


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-459

This PR adds the `insightPanelConfig` resource allowing a developer to invoke CRUD operations for the Insight Panel configurations.

### Acceptance Criteria

-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
