### PR TITLE
feat(catalog): expose cached properties on getFieldStats result

### DIFF
--- a/src/resources/Catalogs/Catalog.ts
+++ b/src/resources/Catalogs/Catalog.ts
@@ -3,8 +3,8 @@ import {New, PageModel} from '../BaseInterfaces';
 import Resource from '../Resource';
 import {
     CachedCatalogFieldsModel,
+    CachedCatalogFieldStatsModel,
     CatalogFieldsOptions,
-    CatalogFieldStatsModel,
     CatalogFieldStatsOptions,
     CatalogModel,
     CatalogsListOptions,
@@ -54,7 +54,7 @@ export default class Catalog extends Resource {
     }
 
     getFieldStats(catalogId: string, options?: CatalogFieldStatsOptions) {
-        return this.api.get<CatalogFieldStatsModel[]>(
+        return this.api.get<CachedCatalogFieldStatsModel>(
             this.buildPath(`${Catalog.baseUrl}/${catalogId}/fieldStats`, options)
         );
     }

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -324,15 +324,42 @@ export type ScopeModel =
           sourceIds: string[];
       };
 
+export interface CatalogFieldStatsModel {
+    /**
+     * List of field statistics
+     */
+    fieldStats: FieldStatsModel[];
+}
+
+export type CachedCatalogFieldStatsModel = Cached<CatalogFieldStatsModel>;
+
 export interface FieldStatsItemModel {
+    /**
+     * Number of objects in the catalog with this field
+     */
     objectsWithField: number;
+    /**
+     * Number of objects in the catalog with this type
+     */
     objectsWithType: number;
 }
 
-export interface CatalogFieldStatsModel {
+export interface FieldStatsModel {
+    /**
+     * Field name
+     */
     fieldName: string;
+    /**
+     * The field stats for product structure
+     */
     product: FieldStatsItemModel;
+    /**
+     * The field stats for variant structure
+     */
     variant: FieldStatsItemModel;
+    /**
+     * The field stats for availability structure
+     */
     availability: FieldStatsItemModel;
 }
 

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -140,11 +140,7 @@ export type HierarchyWithFields<T extends {fields?: string[]}> = Omit<T, 'fields
     fields: string[];
 };
 
-interface Cached<T> {
-    /**
-     * Cached items
-     */
-    item: T;
+interface Updated {
     /**
      * Cache last updated timestamp
      */
@@ -153,6 +149,13 @@ interface Cached<T> {
      * Cache next update timestamp
      */
     nextUpdate: number;
+}
+
+interface Cached<T> extends Updated {
+    /**
+     * Cached items
+     */
+    item: T;
 }
 
 interface CatalogFieldsModel {
@@ -324,14 +327,12 @@ export type ScopeModel =
           sourceIds: string[];
       };
 
-export interface CatalogFieldStatsModel {
+export interface CachedCatalogFieldStatsModel extends Updated {
     /**
      * List of field statistics
      */
     fieldStats: FieldStatsModel[];
 }
-
-export type CachedCatalogFieldStatsModel = Cached<CatalogFieldStatsModel>;
 
 export interface FieldStatsItemModel {
     /**


### PR DESCRIPTION
Expose cashed properties from the fieldStats endpoint response on the result from the getFieldStats function on the catalog.

Note, [the endpoint changes are only on dev](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Catalog#/Catalogs/rest_organizations_paramId_catalogs_paramId_fieldStats_get) and not yet on production. Code can be reviewed in the meanwhile. And used to develop the admin UI changes for the facet association table. **This PR can only be merged when the changes are on prod.**

### Acceptance Criteria

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)

