### PR TITLE
feat(ml): add contextCandidateExamples to CR Model Information interface

### DIFF
--- a/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
+++ b/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
@@ -93,7 +93,17 @@ export interface ModelInformationDNE {
 export interface ModelInformationER {
     indicatorsModifier: Record<string, number>;
     deprecatedUrlToFieldValueSize: number;
+    /**
+     * The sample of the top queries for which the model could recommend items for each listed context key.
+     *
+     * Consider using `contextCandidateExamples` which provides the same data but not prefixed with
+     * `c_context` and no `visit` suffix
+     */
     candidateExamples: Record<string, string[]>;
+    /**
+     * The sample of the top queries for which the model could recommend items for each listed context key.
+     */
+    contextCandidateExamples: Record<string, string[]>;
     primaryIdToValue: number;
     eventGroups: string[];
     primaryEventType: string;


### PR DESCRIPTION
MLX-65 is work required to use the new `contextCandidateExamples` key for a Content Recommendation model.  This adds a parameter to `ModelInformationER` interface for use.  This parameter is so the frontend will not have to parse these values to be pretty.

### Acceptance Criteria

-   [X] JSDoc annotates each property added in the exported interfaces 
-   [ ] The proposed changes are covered by unit tests - is not covered by unit tests, as it's interface changes
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
