### PR TITLE
feat(ml): add expected return types to details endpoints

### DIFF
--- a/src/resources/MachineLearning/MachineLearningInterfaces.ts
+++ b/src/resources/MachineLearning/MachineLearningInterfaces.ts
@@ -1,6 +1,6 @@
 import {GranularResource} from '../BaseInterfaces';
 import {IntervalUnit} from '../Enums';
-import {MLModel} from './Models/ModelsInterfaces';
+import {MLModel} from './Models';
 
 export interface RegistrationModel extends GranularResource {
     // The id of the engine

--- a/src/resources/MachineLearning/ModelInformation/ModelInformation.ts
+++ b/src/resources/MachineLearning/ModelInformation/ModelInformation.ts
@@ -1,15 +1,15 @@
 import API from '../../../APICore';
 import Resource from '../../Resource';
 import {RegistrationModel} from '../MachineLearningInterfaces';
-import {MLModel} from '../Models/ModelsInterfaces';
-import {MLModelInfo} from './ModelInformationInterfaces';
+import {MLModelInfo, MLModelTypeInfo} from './ModelInformationInterfaces';
+import {MLModel} from '../Models';
 
 export default class ModelInformation extends Resource {
     static getBaseUrl = (engineId: string, modelName: string) =>
         `/rest/organizations/${API.orgPlaceholder}/machinelearning/engines/${engineId}/models/${modelName}`;
 
-    get(engineId: string, modelName: string) {
-        return this.api.get<MLModelInfo>(`${ModelInformation.getBaseUrl(engineId, modelName)}/details`);
+    get<T extends MLModelTypeInfo>(engineId: string, modelName: string) {
+        return this.api.get<MLModelInfo<T>>(`${ModelInformation.getBaseUrl(engineId, modelName)}/details`);
     }
 
     delete(engineId: string, modelName: string) {

--- a/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
+++ b/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
@@ -1,14 +1,16 @@
-export interface MLModelInfo {
+export interface MLModelInfo<T extends MLModelTypeInfo = never> {
     id: string;
-    info?:
-        | ModelInformationART
-        | ModelInformationDNE
-        | ModelInformationER
-        | ModelInformationPR
-        | ModelInformationQS
-        | ModelInformationSS
-        | ModelInformationCC;
+    info?: T;
 }
+
+export type MLModelTypeInfo =
+    | ModelInformationART
+    | ModelInformationCC
+    | ModelInformationDNE
+    | ModelInformationER
+    | ModelInformationPR
+    | ModelInformationQS
+    | ModelInformationSS;
 
 export interface MetaInfo {
     modelName: string;

--- a/src/resources/MachineLearning/Models/Models.ts
+++ b/src/resources/MachineLearning/Models/Models.ts
@@ -1,8 +1,8 @@
 import API from '../../../APICore';
 import Resource from '../../Resource';
 import {RegistrationModel} from '../MachineLearningInterfaces';
-import {MLModelInfo} from '../ModelInformation/ModelInformationInterfaces';
 import {MLModel} from './ModelsInterfaces';
+import {MLModelTypeInfo} from '../ModelInformation';
 
 export default class Models extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/models`;
@@ -15,11 +15,11 @@ export default class Models extends Resource {
     }
 
     listDetails() {
-        return this.api.get<MLModel[]>(`${Models.baseUrl}/details`);
+        return this.api.get<Array<MLModel<MLModelTypeInfo>>>(`${Models.baseUrl}/details`);
     }
 
-    getDetails(modelId: string) {
-        return this.api.get<MLModelInfo>(`${Models.baseUrl}/${modelId}/details`);
+    getDetails<T extends MLModelTypeInfo>(modelId: string) {
+        return this.api.get<MLModel<T>>(`${Models.baseUrl}/${modelId}/details`);
     }
 
     get(modelId: string) {

--- a/src/resources/MachineLearning/Models/ModelsInterfaces.ts
+++ b/src/resources/MachineLearning/Models/ModelsInterfaces.ts
@@ -1,9 +1,9 @@
 import {GranularResource} from '../../BaseInterfaces';
 import {IntervalUnit, ModelActivenessState, ModelStatus} from '../../Enums';
 import {AssociatedPipelineModel} from '../../Pipelines';
-import {MLModelInfo} from '../ModelInformation/ModelInformationInterfaces';
+import {MLModelInfo, MLModelTypeInfo} from '../ModelInformation';
 
-export interface MLModel extends MLModelInfo, ModelAttributes, GranularResource {
+export interface MLModel<T extends MLModelTypeInfo = never> extends MLModelInfo<T>, ModelAttributes, GranularResource {
     orgId: string;
     id: string;
     engineId: string;


### PR DESCRIPTION
[MLX-132](https://coveord.atlassian.net/browse/MLX-132)

The purpose of this PR is to create better return types if we know the expected ML model type, making models easier to work with.

This shouldn't make any breaking changes as far as I can tell.  It's an improvement over the existing typings and is optional to use.

I have tested this with our UI and it works as expected except our UI needs a bit of work before it can really get value from this.

| Before | After |
| ---- | ---- |
| Before we would not know what `info` is exactly. <img width="1022" alt="image" src="https://user-images.githubusercontent.com/5728044/163393399-f92b1682-7744-4957-a49d-bb97bd6298a7.png"> | If we know the expected type, we can get better Intellisense. <img width="613" alt="image" src="https://user-images.githubusercontent.com/5728044/163392793-890cb123-5002-4999-8ded-34468e48ace5.png"> <br/><br/>The IDE knows which properties exist for Query Suggest<img width="479" alt="image" src="https://user-images.githubusercontent.com/5728044/163392718-d5c5a272-b839-44bd-b35e-f3b3bf7243a8.png"> <br/><br/>and for backwards compatibility it still shows what it expected before <img width="482" alt="image" src="https://user-images.githubusercontent.com/5728044/163393878-eb4287c6-d381-443e-b559-a9690c36496c.png">
 | <img width="1046" alt="image" src="https://user-images.githubusercontent.com/5728044/163394644-bc2b42cb-66f1-44cb-add3-67252d2667f5.png"> | <img width="609" alt="image" src="https://user-images.githubusercontent.com/5728044/163394340-05942208-ccb1-4b39-9cf1-b0856c0b35eb.png"> <br/><br/> and backwards compatibility <img width="555" alt="image" src="https://user-images.githubusercontent.com/5728044/163394529-94cdb721-c209-4c2d-90cc-c7cd0023f4b5.png">





### Acceptance Criteria

-   [X] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests (no, typings)
-   [X] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
