### PR TITLE
fix(ip): updated ip config update interface

### DIFF
--- a/src/resources/InsightPanelConfigs/InsightPanelConfig.ts
+++ b/src/resources/InsightPanelConfigs/InsightPanelConfig.ts
@@ -1,4 +1,5 @@
 import API from '../../APICore';
+import {WithRequiredProperty} from '../../utils/WithRequired';
 import {New, PageModel} from '../BaseInterfaces';
 import Resource from '../Resource';
 import {
@@ -26,7 +27,7 @@ export default class InsightPanelConfig extends Resource {
         return this.api.get<InsightPanelConfigModel>(`${InsightPanelConfig.baseUrl}/${insightPanelConfigId}`);
     }
 
-    update(insightPanelConfig: InsightPanelConfigCreationParams) {
+    update(insightPanelConfig: WithRequiredProperty<InsightPanelConfigCreationParams, 'contextFields'>) {
         const {id, ...body} = insightPanelConfig;
 
         return this.api.put<InsightPanelConfigModel>(`${InsightPanelConfig.baseUrl}/${id}`, body);

--- a/src/utils/WithRequired.ts
+++ b/src/utils/WithRequired.ts
@@ -1,0 +1,4 @@
+export type WithRequiredProperty<Type, Key extends keyof Type> = Type &
+    {
+        [Property in Key]-?: Type[Property];
+    };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './Retriever';
+export * from './WithRequired';


### PR DESCRIPTION
BREAKING CHANGE: optional param now required

The back-end will be requiring the `contextFields` param on UPDATE calls for Insight Panel configs so it should be enforced by the interface as well.

I added a utility interface to implement the variation. Let me know what you think.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
