### PR TITLE
fix(searchhublicensemetrics): fix recommendationsQueries typo

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -879,7 +879,7 @@ export enum SearchHubRawMetrics {
 
 export enum SearchHubLicenseMetrics {
     normalQueries = 'normalQueries',
-    recommendationQueries = 'recommendationQueries',
+    recommendationsQueries = 'recommendationsQueries',
     commerceProductListingQueries = 'commerceProductListingQueries',
     agents = 'agents',
     staticQueries = 'staticQueries',


### PR DESCRIPTION
Bug: https://coveord.atlassian.net/browse/SEARCHAPI-6934
This task: https://coveord.atlassian.net/browse/SEARCHAPI-6935

This is only to fix a type that was included in the `SearchHubLicenseMetrics` enum, in which the `recommendationQueries` value should be `recommendationsQueries`. With this update (and linking this fix to the Admin-UI), I could display the total recommendation queries value in the consumption dashboard

![total_recommendation_queries_now_available_on_the_admin_ui](https://user-images.githubusercontent.com/58052881/165400259-b67dce7c-3018-47c7-a8de-1db4c3c87369.png)

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
