### PR TITLE
feat(snapshot): add diff endpoint

### DIFF
--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -7,8 +7,8 @@ import {
     CreateFromFileOptions,
     CreateFromOrganizationOptions,
     DryRunOptions,
-    GenerateUrlOptions,
     ExportSnapshotContentOptions,
+    GenerateUrlOptions,
     GetSnapshotOptions,
     PushSnapshotOptions,
     ResourceSnapshotExportConfigurationModel,
@@ -19,6 +19,7 @@ import {
     ResourceSnapshotSupportedFileTypes,
     ResourceSnapshotUrlModel,
     SnapshotAccessModel,
+    SnapshotDiffModel,
     SnapshotListParams,
     UpdateChildrenOptions,
     ValidateAccessOptions,
@@ -186,5 +187,15 @@ export default class ResourceSnapshots extends Resource {
             default:
                 throw new Error('The uploaded file must be either a ZIP or a JSON file.');
         }
+    }
+
+    /**
+     * @description Shows the diff report for the target snapshot and dry-run report
+     * @experimental
+     */
+    diff(snapshotId: string, relativeReportId: string) {
+        return this.api.get<SnapshotDiffModel>(
+            this.buildPath(`${ResourceSnapshots.baseUrl}/${snapshotId}/diff`, {relativeReportId})
+        );
     }
 }

--- a/src/resources/ResourceSnapshots/ResourceSnapshotsInterfaces.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshotsInterfaces.ts
@@ -34,6 +34,10 @@ export interface ResourceSnapshotsModel {
      */
     synchronizationReports?: ResourceSnapshotsSynchronizationReportModel[];
     /**
+     * The list of diff generation reports on the snapshot.
+     */
+    diffGenerationReports?: SnapshotDiffModel[];
+    /**
      * A summary of the contents of the snapshot.
      */
     contentSummary?: Record<string, number>;
@@ -300,4 +304,17 @@ export interface UpdateChildrenOptions {
     snapshotParentResourceName: string;
     parentResourceType: string;
     targetParentId: string;
+}
+
+export interface SnapshotDiffFileModel extends ResourceSnapshotUrlModel {
+    numberOfLines: number;
+}
+
+export interface SnapshotDiffModel {
+    id: string;
+    snapshotId: string;
+    relatedSnapshotId: string;
+    updatedDate: number;
+    status: ResourceSnapshotsReportStatus;
+    files: Record<ResourceSnapshotType, SnapshotDiffFileModel>;
 }

--- a/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
+++ b/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
@@ -432,4 +432,18 @@ describe('ResourceSnapshots', () => {
             );
         });
     });
+
+    describe('diff', () => {
+        it('should make a GET call to the specific Resource Snapshots url', () => {
+            const snapshotId = 'my-snapshot-id';
+            const reportId = 'my-report-id';
+
+            resourceSnapshots.diff(snapshotId, reportId);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${ResourceSnapshots.baseUrl}/${snapshotId}/diff?relativeReportId=${reportId}`
+            );
+        });
+    });
 });


### PR DESCRIPTION
Task: https://coveord.atlassian.net/browse/SRC-4727

This implementation is based on that documentation: https://platformdev.cloud.coveo.com/docs?urls.primaryName=Migration#/Snapshot/rest_organizations_paramId_snapshots_paramId_diff_get

Added diff endpoint for the snapshot resource.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
