### PR TITLE
fix(vault)!: remove useless arg from /import

### DIFF
--- a/src/resources/Vaults/Vaults.ts
+++ b/src/resources/Vaults/Vaults.ts
@@ -21,20 +21,13 @@ export default class Vaults extends Resource {
      * Import vault entries from the starting organization into the current organization.
      *
      * @param {string} currentSnapshotId The unique identifier of the current snapshot.
-     * @param {string} currentOrganizationId The unique identifier of the current organization.
      * @param {string} sourceOrganizationId The unique identifier of the source organization.
      * @param {VaultFetchStrategy} fetchStrategy Choosing the strategy to use when importing vault entries.
      */
-    import(
-        currentSnapshotId: string,
-        currentOrganizationId: string,
-        sourceOrganizationId: string,
-        fetchStrategy: VaultFetchStrategy
-    ) {
+    import(currentSnapshotId: string, sourceOrganizationId: string, fetchStrategy: VaultFetchStrategy) {
         return this.api.put(
             this.buildPath(`${Vaults.baseUrl}/fetch`, {
                 referenceSnapshotId: currentSnapshotId,
-                organizationId: currentOrganizationId,
                 sourceOrganizationId,
                 fetchStrategy,
             })

--- a/src/resources/Vaults/tests/Vaults.spec.ts
+++ b/src/resources/Vaults/tests/Vaults.spec.ts
@@ -31,14 +31,13 @@ describe('Vaults', () => {
     describe('import', () => {
         it('should make a PUT call to the specific Vaults url', () => {
             const currentSnaphostId = 'current-snapshot-id';
-            const currentOrganizationId = 'current-organization-id';
             const sourceOrganizationId = 'source-organization-id';
 
-            vaults.import(currentSnaphostId, currentOrganizationId, sourceOrganizationId, VaultFetchStrategy.overwrite);
+            vaults.import(currentSnaphostId, sourceOrganizationId, VaultFetchStrategy.overwrite);
 
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(
-                `${Vaults.baseUrl}/fetch?referenceSnapshotId=${currentSnaphostId}&organizationId=${currentOrganizationId}&sourceOrganizationId=${sourceOrganizationId}&fetchStrategy=${VaultFetchStrategy.overwrite}`
+                `${Vaults.baseUrl}/fetch?referenceSnapshotId=${currentSnaphostId}&sourceOrganizationId=${sourceOrganizationId}&fetchStrategy=${VaultFetchStrategy.overwrite}`
             );
         });
     });


### PR DESCRIPTION
Removed `currentOrganizationId`. The API does not accept such query parameter. The role described by `currentOrganizationID` is actually played by the `API.orgPlaceholder` in the `baseUrl` of the resource.
Ergo, one should initialize its platformclient with the `currentOrganizationId` as its organizationId to do actually what the function was describing.

Removing the param remove this confusion. It is also a breaking change because the removed parameter is not the last, so existing calls will break.

### Acceptance Criteria

-   [x] JSDoc annotates each property added in the exported interfaces: N.A.
-   [x] The proposed changes are covered by unit tests: adapted
-   [x] Commits containing breaking changes a properly identified as such: yep, see the `!`
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant): N.A.
