### PR TITLE
feat(snapshot): add new parameter for diff method

### DIFF
--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -192,10 +192,17 @@ export default class ResourceSnapshots extends Resource {
     /**
      * @description Shows the diff report for the target snapshot and dry-run report
      * @experimental
+     *
+     * @param {string} snapshotId - The unique identifier of the target snapshot.
+     * @param {string} relativeReportId - The unique identifier of the dry-run operation report associated with the target diff report.
+     * @param {(number|undefined)} [numberOfLinesMax=undefined] - Maximum number of lines before the diff is downloaded to a file.
      */
-    diff(snapshotId: string, relativeReportId: string) {
+    diff(snapshotId: string, relativeReportId: string, numberOfLinesMax?: number) {
         return this.api.get<SnapshotDiffModel>(
-            this.buildPath(`${ResourceSnapshots.baseUrl}/${snapshotId}/diff`, {relativeReportId})
+            this.buildPath(`${ResourceSnapshots.baseUrl}/${snapshotId}/diff`, {
+                relativeReportId,
+                numberOfLinesMax,
+            })
         );
     }
 }

--- a/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
+++ b/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
@@ -445,5 +445,18 @@ describe('ResourceSnapshots', () => {
                 `${ResourceSnapshots.baseUrl}/${snapshotId}/diff?relativeReportId=${reportId}`
             );
         });
+
+        it('should make a GET call to the specific Resource Snapshots url with "numberOfLinesMax" parameter', () => {
+            const snapshotId = 'my-snapshot-id';
+            const reportId = 'my-report-id';
+            const numberOfLinesMax = 10000;
+
+            resourceSnapshots.diff(snapshotId, reportId, numberOfLinesMax);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${ResourceSnapshots.baseUrl}/${snapshotId}/diff?relativeReportId=${reportId}&numberOfLinesMax=${numberOfLinesMax}`
+            );
+        });
     });
 });


### PR DESCRIPTION
It's not yet in dev but it will happen very quickly.
 
  The Diff method will be entitled to a new parameter, it is a limit to know how to build the URL.
- if the number of data is less than the limit, the url returns the file to view
- if the number of data is greater than the limit, the url forces the download of this file

API Doc => https://platformdev.cloud.coveo.com/docs?urls.primaryName=Migration#/Snapshot/rest_organizations_paramId_snapshots_paramId_diff_get

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
