### PR TITLE
feat(search-hubs): update interfaces and add list params

### DIFF
--- a/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/SearchHubs.ts
@@ -5,13 +5,17 @@ import {
     RestSearchHub,
     UpdateSearchHubParams,
     UpdateSearchHubBucketParams,
+    ListSearchHubsParams,
+    ListSearchHubs,
 } from './SearchHubsInterface';
 
 export default class SearchHubs extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/searchusagemetrics/hubs/`;
 
-    list() {
-        return this.api.get<{hubs: RestSearchHub[]}>(SearchHubs.baseUrl);
+    list(params?: ListSearchHubsParams) {
+        return this.api.get<ListSearchHubs>(
+            this.buildPath(SearchHubs.baseUrl, {filter: params?.filter, pageSize: params?.perPage, page: params?.page})
+        );
     }
 
     create(params: RestSearchHub) {

--- a/src/resources/SearchUsageMetrics/SearchHubs/SearchHubsInterface.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/SearchHubsInterface.ts
@@ -1,3 +1,16 @@
+import {Paginated} from '../../BaseInterfaces';
+
+export interface ListSearchHubs {
+    /**
+     * The array of search hubs
+     */
+    hubs: RestSearchHub[];
+
+    /**
+     * The number of search hub created on the organization
+     */
+    totalCount: number;
+}
 export interface RestSearchHub {
     /**
      * The name of the search hub
@@ -13,6 +26,27 @@ export interface RestSearchHub {
      * A description for the search hub
      */
     description?: string;
+}
+
+export interface ListSearchHubsParams extends Paginated {
+    /**
+     * The free-form string to filter the returned list based on the values of the search hub attributes
+     */
+    filter?: string;
+
+    /**
+     * The maximum number of search hubs to list per page
+     *
+     * @default `100`
+     */
+    perPage?: number;
+
+    /**
+     * The 0-based index number of page to list
+     *
+     * @default `0`
+     */
+    page?: number;
 }
 
 export interface SearchHubNameParams {

--- a/src/resources/SearchUsageMetrics/SearchHubs/tests/SearchHubs.spec.ts
+++ b/src/resources/SearchUsageMetrics/SearchHubs/tests/SearchHubs.spec.ts
@@ -1,5 +1,6 @@
 import API from '../../../../APICore';
 import SearchHubs from '../SearchHubs';
+import {ListSearchHubsParams} from '../SearchHubsInterface';
 
 jest.mock('../../../../APICore');
 
@@ -21,6 +22,28 @@ describe('SearchHubs', () => {
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(SearchHubs.baseUrl);
+        });
+
+        it('makes the call with parameters if it is set', () => {
+            const params: ListSearchHubsParams = {
+                filter: 'patate',
+                perPage: 25,
+                page: 1,
+            };
+            searchHubs.list(params);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${SearchHubs.baseUrl}?filter=patate&pageSize=25&page=1`);
+        });
+
+        it('makes the call with parameters if it is partially set', () => {
+            const partialParams: ListSearchHubsParams = {
+                filter: 'patate',
+            };
+            searchHubs.list(partialParams);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${SearchHubs.baseUrl}?filter=patate`);
         });
     });
 


### PR DESCRIPTION
Story: https://coveord.atlassian.net/browse/SUMS-222

This branch is to add a parameters interface for the list API call, as there is now some optional parameters available for this request + add the `totalCount` parameter to the list call's response.

### Acceptance Criteria

-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
