### PR TITLE
feat(securitycache): new list call with identity name & type filters

### DIFF
--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -11,7 +11,7 @@ import {
     SecurityCacheListRelationshipsOptions,
     SecurityCacheMemberModel,
     SecurityProviderModel,
-    SecurityCacheIdentitiesFilters,
+    SecurityProviderIdentitiesFilters,
 } from './SecurityCacheInterfaces';
 
 export default class SecurityCache extends Ressource {
@@ -35,7 +35,10 @@ export default class SecurityCache extends Ressource {
         );
     }
 
-    listSecurityProviderIdentities(providerId: string, {page, perPage, ...rest}: SecurityCacheIdentitiesFilters = {}) {
+    listSecurityProviderIdentities(
+        providerId: string,
+        {page, perPage, ...rest}: SecurityProviderIdentitiesFilters = {}
+    ) {
         const filteringModel = {
             filteringTerm: rest.filteringTerm,
             identityTypes: rest.identityTypes,

--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -11,7 +11,7 @@ import {
     SecurityCacheListRelationshipsOptions,
     SecurityCacheMemberModel,
     SecurityProviderModel,
-    SecurityCacheFilters,
+    SecurityCacheIdentitiesFilters,
 } from './SecurityCacheInterfaces';
 
 export default class SecurityCache extends Ressource {
@@ -35,10 +35,16 @@ export default class SecurityCache extends Ressource {
         );
     }
 
-    listFilteredEntities(filters: SecurityCacheFilters) {
+    listSecurityIdentities(providerId: string, filters?: SecurityCacheIdentitiesFilters) {
+        const {page, perPage, ...rest} = filters || {};
+        const filteringModel = {
+            filteringTerm: rest.filteringTerm,
+            identityTypes: rest.identityTypes,
+            providerIds: [providerId],
+        };
         return this.api.post<PageModel<SecurityCacheIdentityModel>>(
-            this.buildPath(`${SecurityCache.cacheUrl}/entities/list`, {page: filters.page, perPage: filters.perPage}),
-            filters
+            this.buildPath(`${SecurityCache.cacheUrl}/entities/list`, {page, perPage}),
+            filteringModel
         );
     }
 

--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -35,7 +35,7 @@ export default class SecurityCache extends Ressource {
         );
     }
 
-    listSecurityIdentities(providerId: string, filters?: SecurityCacheIdentitiesFilters) {
+    listSecurityProviderIdentities(providerId: string, filters?: SecurityCacheIdentitiesFilters) {
         const {page, perPage, ...rest} = filters || {};
         const filteringModel = {
             filteringTerm: rest.filteringTerm,

--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -35,8 +35,7 @@ export default class SecurityCache extends Ressource {
         );
     }
 
-    listSecurityProviderIdentities(providerId: string, filters?: SecurityCacheIdentitiesFilters) {
-        const {page, perPage, ...rest} = filters || {};
+    listSecurityProviderIdentities(providerId: string, {page, perPage, ...rest}: SecurityCacheIdentitiesFilters = {}) {
         const filteringModel = {
             filteringTerm: rest.filteringTerm,
             identityTypes: rest.identityTypes,

--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -11,6 +11,7 @@ import {
     SecurityCacheListRelationshipsOptions,
     SecurityCacheMemberModel,
     SecurityProviderModel,
+    SecurityCacheFilters,
 } from './SecurityCacheInterfaces';
 
 export default class SecurityCache extends Ressource {
@@ -31,6 +32,13 @@ export default class SecurityCache extends Ressource {
     listEntities(providerId: string, options?: SecurityCacheListOptions) {
         return this.api.get<PageModel<SecurityCacheIdentityModel>>(
             this.buildPath(`${SecurityCache.cacheUrl}/entities/${providerId}`, options)
+        );
+    }
+
+    listFilteredEntities(filters: SecurityCacheFilters) {
+        return this.api.post<PageModel<SecurityCacheIdentityModel>>(
+            this.buildPath(`${SecurityCache.cacheUrl}/entities/list`, {page: filters.page, perPage: filters.perPage}),
+            filters
         );
     }
 

--- a/src/resources/SecurityCache/SecurityCacheInterfaces.ts
+++ b/src/resources/SecurityCache/SecurityCacheInterfaces.ts
@@ -129,11 +129,9 @@ export interface SecurityCacheListOptions extends Paginated {
     to?: string;
 }
 
-export interface SecurityCacheFilters extends Paginated {
+export interface SecurityCacheIdentitiesFilters extends Paginated {
     filteringTerm?: string;
-    filteringMode: string;
-    identityTypes?: string[];
-    providerIds: string[];
+    identityTypes?: PermissionIdentityType[];
 }
 
 export interface SecurityCacheListRelationshipsOptions extends Paginated {

--- a/src/resources/SecurityCache/SecurityCacheInterfaces.ts
+++ b/src/resources/SecurityCache/SecurityCacheInterfaces.ts
@@ -129,6 +129,13 @@ export interface SecurityCacheListOptions extends Paginated {
     to?: string;
 }
 
+export interface SecurityCacheFilters extends Paginated {
+    filteringTerm?: string;
+    filteringMode: string;
+    identityTypes?: string[];
+    providerIds: string[];
+}
+
 export interface SecurityCacheListRelationshipsOptions extends Paginated {
     recursive?: boolean;
 }

--- a/src/resources/SecurityCache/SecurityCacheInterfaces.ts
+++ b/src/resources/SecurityCache/SecurityCacheInterfaces.ts
@@ -129,7 +129,7 @@ export interface SecurityCacheListOptions extends Paginated {
     to?: string;
 }
 
-export interface SecurityCacheIdentitiesFilters extends Paginated {
+export interface SecurityProviderIdentitiesFilters extends Paginated {
     filteringTerm?: string;
     identityTypes?: PermissionIdentityType[];
 }

--- a/src/resources/SecurityCache/tests/SecurityCache.spec.ts
+++ b/src/resources/SecurityCache/tests/SecurityCache.spec.ts
@@ -1,4 +1,4 @@
-import {ScheduleModel, SecurityCacheIdentitiesFilters, SecurityCacheMemberModel, SecurityProviderModel} from '..';
+import {ScheduleModel, SecurityProviderIdentitiesFilters, SecurityCacheMemberModel, SecurityProviderModel} from '..';
 import API from '../../../APICore';
 import {PermissionIdentityType} from '../../Enums';
 import SecurityCache from '../SecurityCache';
@@ -52,7 +52,7 @@ describe('securityCache', () => {
             securityCache.listSecurityProviderIdentities(providerId, {
                 filteringTerm: securityCacheFiltersBody.filteringTerm,
                 identityTypes: securityCacheFiltersBody.identityTypes,
-            } as SecurityCacheIdentitiesFilters);
+            } as SecurityProviderIdentitiesFilters);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(
                 `/rest/organizations/{organizationName}/securitycache/entities/list`,

--- a/src/resources/SecurityCache/tests/SecurityCache.spec.ts
+++ b/src/resources/SecurityCache/tests/SecurityCache.spec.ts
@@ -19,6 +19,7 @@ describe('securityCache', () => {
 
     describe('list', () => {
         const providerId = 'PROVIDER_ID';
+        const securityCacheFilters = {filteringTerm: 'test', filteringMode: 'PREFIX', providerIds: [providerId]};
 
         it('should make a GET call to the securityCache correct url with listMembers', () => {
             securityCache.listMembers(providerId);
@@ -32,6 +33,15 @@ describe('securityCache', () => {
             securityCache.listEntities(providerId);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${SecurityCache.cacheUrl}/entities/${providerId}`);
+        });
+
+        it('should make a POST call to the securityCache correct url with listEntities with filters', () => {
+            securityCache.listFilteredEntities(securityCacheFilters);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(
+                `/rest/organizations/{organizationName}/securitycache/entities/list`,
+                securityCacheFilters
+            );
         });
 
         it('should make a GET call to the securityProvider url with listProvider', () => {

--- a/src/resources/SecurityCache/tests/SecurityCache.spec.ts
+++ b/src/resources/SecurityCache/tests/SecurityCache.spec.ts
@@ -40,7 +40,7 @@ describe('securityCache', () => {
         });
 
         it('should make a POST call to the securityCache correct url with listSecurityIdentities without filters', () => {
-            securityCache.listSecurityIdentities(providerId);
+            securityCache.listSecurityProviderIdentities(providerId);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(
                 `/rest/organizations/{organizationName}/securitycache/entities/list`,
@@ -49,7 +49,7 @@ describe('securityCache', () => {
         });
 
         it('should make a POST call to the securityCache correct url with listSecurityIdentities with filters', () => {
-            securityCache.listSecurityIdentities(providerId, {
+            securityCache.listSecurityProviderIdentities(providerId, {
                 filteringTerm: securityCacheFiltersBody.filteringTerm,
                 identityTypes: securityCacheFiltersBody.identityTypes,
             } as SecurityCacheIdentitiesFilters);

--- a/src/resources/SecurityCache/tests/SecurityCache.spec.ts
+++ b/src/resources/SecurityCache/tests/SecurityCache.spec.ts
@@ -1,4 +1,4 @@
-import {ScheduleModel, SecurityCacheMemberModel, SecurityProviderModel} from '..';
+import {ScheduleModel, SecurityCacheIdentitiesFilters, SecurityCacheMemberModel, SecurityProviderModel} from '..';
 import API from '../../../APICore';
 import {PermissionIdentityType} from '../../Enums';
 import SecurityCache from '../SecurityCache';
@@ -19,7 +19,11 @@ describe('securityCache', () => {
 
     describe('list', () => {
         const providerId = 'PROVIDER_ID';
-        const securityCacheFilters = {filteringTerm: 'test', filteringMode: 'PREFIX', providerIds: [providerId]};
+        const securityCacheFiltersBody = {
+            filteringTerm: 'test',
+            identityTypes: [PermissionIdentityType.User],
+            providerIds: [providerId],
+        };
 
         it('should make a GET call to the securityCache correct url with listMembers', () => {
             securityCache.listMembers(providerId);
@@ -35,12 +39,24 @@ describe('securityCache', () => {
             expect(api.get).toHaveBeenCalledWith(`${SecurityCache.cacheUrl}/entities/${providerId}`);
         });
 
-        it('should make a POST call to the securityCache correct url with listEntities with filters', () => {
-            securityCache.listFilteredEntities(securityCacheFilters);
+        it('should make a POST call to the securityCache correct url with listSecurityIdentities without filters', () => {
+            securityCache.listSecurityIdentities(providerId);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(
                 `/rest/organizations/{organizationName}/securitycache/entities/list`,
-                securityCacheFilters
+                {providerIds: [providerId]}
+            );
+        });
+
+        it('should make a POST call to the securityCache correct url with listSecurityIdentities with filters', () => {
+            securityCache.listSecurityIdentities(providerId, {
+                filteringTerm: securityCacheFiltersBody.filteringTerm,
+                identityTypes: securityCacheFiltersBody.identityTypes,
+            } as SecurityCacheIdentitiesFilters);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(
+                `/rest/organizations/{organizationName}/securitycache/entities/list`,
+                securityCacheFiltersBody
             );
         });
 


### PR DESCRIPTION
Added support for new Security Cache list call that allows to search and filter for an identity name
and/or a specific type, this call will live alongside the exisiting one for now but in the future
all options will come together in the new call and the old one will be deprecated.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
