### PR TITLE
fix: set snapshot diff files as partial record

### DIFF
--- a/src/resources/ResourceSnapshots/ResourceSnapshotsInterfaces.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshotsInterfaces.ts
@@ -334,5 +334,5 @@ export interface SnapshotDiffModel {
     relativeReportId: string;
     updatedDate: number;
     status: ResourceSnapshotsReportStatus;
-    files: Record<ResourceSnapshotType, SnapshotDiffFileModel>;
+    files: Partial<Record<ResourceSnapshotType, SnapshotDiffFileModel>>;
 }


### PR DESCRIPTION
The diff response can contain only a subset of resources, hence the `Partial<>`.
It can also return an empty object.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
