### PR TITLE
fix(search): update the interface key property `maximumTimeoutMs` case

### DIFF
--- a/src/resources/Search/SearchInterfaces.ts
+++ b/src/resources/Search/SearchInterfaces.ts
@@ -391,7 +391,7 @@ export interface ListFieldValuesBodyQueryParams {
      *
      * @default: `0`
      */
-    maximumTimeOutMs?: string;
+    maximumTimeoutMs?: string;
 
     /**
      * Contextual information about the user performing the request and the request itself.


### PR DESCRIPTION
[`maximumTimeoutMs` was spelled incorrectly and had it `maximumTimeOutMs`](https://platformdev.cloud.coveo.com/docs/?urls.primaryName=Search%20API#/Search%20V2/searchUsingPost)

(changed commit message - removed breaking change)

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
