### PR TITLE
feat(metadata): add dates to metadata discovery interface

### DIFF
--- a/src/resources/Sources/SourcesMetadata/SourcesMetadataInterfaces.ts
+++ b/src/resources/Sources/SourcesMetadata/SourcesMetadataInterfaces.ts
@@ -2,6 +2,8 @@ import {PageModel} from '../../BaseInterfaces';
 
 export interface MetadataPageModel extends PageModel {
     items: Metadata[];
+    creationDate: number;
+    expirationDate: number;
     sampledDocumentCount: number;
     documentErrorCount: number;
 }


### PR DESCRIPTION
As Metadata Discoveries are time-limited for security reasons, we want to make sure that this fact is understood by users by showing last refresh date and expiration date in the UI. This PR adds these values, from the API, to the platform client.

[CTINFRA-2837]

