### PR TITLE
chore(codeowners): fix codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,8 +4,7 @@
 # review when someone opens a pull request.
 # see https://help.github.com/articles/about-codeowners/ for more details
 
-* @coveo/admin-console
-* @coveo/dx
+* @coveo/admin-console @coveo/dx
 
 # Prevent PRs that only modify package.json from notifying everyone
 package.json @ghost


### PR DESCRIPTION
Now, with auto attribution to both teams.

See example https://github.com/coveo/testing-codweownersfile/pull/2
