### PR TITLE
fix(platform-client): revert enum removal

### DIFF
--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
@@ -1,5 +1,10 @@
 import {FilterConditions} from '../FilterConditions';
 
+export enum Operator {
+    Equals = 'EQUALS',
+    NotEquals = 'NOT_EQUALS',
+}
+
 export type CaseClassificationDocumentRequirementStatus = 'OK' | 'INSUFFICIENT_DOCUMENTS';
 
 export interface DateField {

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
@@ -3,6 +3,7 @@ import CaseClassificationConfiguration from '../CaseClassificationConfiguration'
 import {
     CaseClassificationConfigurationModel,
     CaseClassificationContentFieldsParams,
+    Operator,
 } from '../CaseClassificationConfigurationInterfaces';
 
 jest.mock('../../../../APICore');
@@ -27,7 +28,7 @@ describe('CaseClassificationConfiguration', () => {
             caseFilterConditions: [
                 {
                     field: 'test-field',
-                    operator: 'EQUALS',
+                    operator: Operator.Equals,
                     value: 'test-value',
                 },
             ],
@@ -55,7 +56,7 @@ describe('CaseClassificationConfiguration', () => {
             caseFilterConditions: [
                 {
                     field: 'test-field',
-                    operator: 'NOT_EQUALS',
+                    operator: Operator.NotEquals,
                     value: 'test-value',
                 },
             ],
@@ -129,7 +130,7 @@ describe('CaseClassificationConfiguration', () => {
                 caseFilterConditions: [
                     {
                         field: 'test-field',
-                        operator: 'EQUALS',
+                        operator: Operator.Equals,
                         value: 'test-value',
                     },
                 ],
@@ -153,7 +154,7 @@ describe('CaseClassificationConfiguration', () => {
                 caseFilterConditions: [
                     {
                         field: 'test-field',
-                        operator: 'EQUALS',
+                        operator: Operator.Equals,
                         value: 'test-value',
                     },
                 ],

--- a/src/resources/MachineLearning/FilterConditions.ts
+++ b/src/resources/MachineLearning/FilterConditions.ts
@@ -1,3 +1,5 @@
+import {Operator} from './CaseClassificationConfiguration';
+
 export interface FilterConditions {
     /**
      * The name of the field.
@@ -8,7 +10,7 @@ export interface FilterConditions {
      * The operator to use to evaluate the condition.
      * Must be EQUALS or NOT_EQUALS
      */
-    operator: 'EQUALS' | 'NOT_EQUALS';
+    operator: Operator;
     /**
      * The value to use for the condition.
      * Example: completed


### PR DESCRIPTION
[MLX-86]

Restore an enum that was deleted in a previous version of the platform client (while still being used by the admin-UI). This will allow bumping the platform client in the admin UI once more.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->
-   [X] The proposed changes are covered by unit tests


[MLX-86]: https://coveord.atlassian.net/browse/MLX-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ