### PR TITLE
chore: fix cd flow bad env variable

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,5 +21,5 @@ jobs:
             - name: Release
               run: npm run release
               env:
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaced by the proper env var name
see why: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages

You can also look up NODE_AUTH_TOKEN on org:coveo, you'll see it being used elsewhere too. (oopsie, should have been more careful)
