### PR TITLE
feat(connectivity): add resourceType param to createLogRequest

### DIFF
--- a/src/resources/Connectivity/Connectivity.ts
+++ b/src/resources/Connectivity/Connectivity.ts
@@ -1,12 +1,13 @@
 import Resource from '../Resource';
 import API from '../../APICore';
-import {LogRequest, LogRequestId, LogRequestResult} from './ConnectivityInterface';
+import {LogRequest, LogRequestId, LogRequestResourceType, LogRequestResult} from './ConnectivityInterface';
 
 export default class Connectivity extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/logrequests`;
 
-    requestLog(body: LogRequest) {
-        return this.api.post<LogRequestId>(Connectivity.baseUrl, body);
+    requestLog(body: LogRequest, type?: LogRequestResourceType) {
+        const url = type ? this.buildPath(Connectivity.baseUrl, type) : Connectivity.baseUrl;
+        return this.api.post<LogRequestId>(url, body);
     }
 
     getLogRequestState(logRequestId: string) {

--- a/src/resources/Connectivity/Connectivity.ts
+++ b/src/resources/Connectivity/Connectivity.ts
@@ -5,9 +5,8 @@ import {LogRequest, LogRequestId, LogRequestResourceType, LogRequestResult} from
 export default class Connectivity extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/logrequests`;
 
-    requestLog(body: LogRequest, type?: LogRequestResourceType) {
-        const url = type ? this.buildPath(Connectivity.baseUrl, type) : Connectivity.baseUrl;
-        return this.api.post<LogRequestId>(url, body);
+    requestLog(body: LogRequest, type: LogRequestResourceType = LogRequestResourceType.SOURCE) {
+        return this.api.post<LogRequestId>(this.buildPath(Connectivity.baseUrl, {resourceType: type}), body);
     }
 
     getLogRequestState(logRequestId: string) {

--- a/src/resources/Connectivity/ConnectivityInterface.ts
+++ b/src/resources/Connectivity/ConnectivityInterface.ts
@@ -12,3 +12,8 @@ export interface LogRequest {
     resourceId: string;
     activityId: string;
 }
+
+export enum LogRequestResourceType {
+    SOURCE = 'SOURCE',
+    SECURITY_PROVIDER = 'SECURITY_PROVIDER',
+}

--- a/src/resources/Connectivity/tests/Connectivity.spec.ts
+++ b/src/resources/Connectivity/tests/Connectivity.spec.ts
@@ -1,5 +1,6 @@
 import API from '../../../APICore';
 import Connectivity from '../Connectivity';
+import {LogRequestResourceType} from '../ConnectivityInterface';
 
 jest.mock('../../../APICore');
 
@@ -30,6 +31,15 @@ describe('Connectivity Service', () => {
             connectivity.getLogRequestState(logRequestId);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Connectivity.baseUrl}/${logRequestId}`);
+        });
+
+        it('should have the resource type if specified', () => {
+            connectivity.requestLog({resourceId, activityId}, LogRequestResourceType.SECURITY_PROVIDER);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Connectivity.baseUrl}?resourceType=SECURITY_PROVIDER`, {
+                resourceId,
+                activityId,
+            });
         });
     });
 });

--- a/src/resources/Connectivity/tests/Connectivity.spec.ts
+++ b/src/resources/Connectivity/tests/Connectivity.spec.ts
@@ -24,7 +24,10 @@ describe('Connectivity Service', () => {
         it('should post a new new log request', () => {
             connectivity.requestLog({resourceId, activityId});
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(`${Connectivity.baseUrl}`, {resourceId, activityId});
+            expect(api.post).toHaveBeenCalledWith(`${Connectivity.baseUrl}?resourceType=SOURCE`, {
+                resourceId,
+                activityId,
+            });
         });
 
         it('should get the state of a log request', () => {


### PR DESCRIPTION
# [CTINFRA-2907](https://coveord.atlassian.net/browse/CTINFRA-2907) :rocket:

Add a query param for the create log request call. 

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
