### PR TITLE
fix(result-rankings-interfaces): update localizedContent part

### DIFF
--- a/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
@@ -153,11 +153,15 @@ export interface ResultRankingTargetUniqueId {
 }
 
 export interface ResultRankingTargetLocalizedContent {
+    localizedContent: ResultRankingLocalizedContent;
+}
+
+export interface ResultRankingLocalizedContent {
     /**
      * The ID of the knowledge article to show.
      */
     familyId: string;
-    locale: ResultRankingLocalizedContentLocale;
+    locale: ResultRankingLocalizedContentLocaleAuto | ResultRankingLocalizedContentLocaleSpecific;
     /**
      * Field that identifies the knowledge article.
      */
@@ -166,12 +170,6 @@ export interface ResultRankingTargetLocalizedContent {
      * Field that identifies the locale of the document.
      */
     localeField: string;
-}
-
-export interface ResultRankingLocalizedContentLocale {
-    ResultRankingLocalizedContentLocale:
-        | ResultRankingLocalizedContentLocaleAuto
-        | ResultRankingLocalizedContentLocaleSpecific;
 }
 
 export interface ResultRankingLocalizedContentLocaleAuto {
@@ -187,7 +185,7 @@ export interface ResultRankingLocalizedContentLocaleSpecific {
     /**
      * The locale code of the knowledge article to show.
      */
-    code: string;
+    specific: string;
 }
 
 export interface ResultRankingTargetQueryExpression {


### PR DESCRIPTION
Based on this documentation: https://platformdev.cloud.coveo.com/docs?urls.primaryName=Search%20API#/Result%20rankings/getResultRankingRule, it seems that the _ResultRankingTargetLocalizedContent_ interface need to be updated. The _ResultRankingLocalizedContent_ and the _ResultRankingLocalizedContentLocaleSpecific_ were also to be updated.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
