### PR TITLE
Feat client platform add activities resources

### DIFF
--- a/src/resources/Activities/Activities.ts
+++ b/src/resources/Activities/Activities.ts
@@ -2,7 +2,7 @@ import API from '../../APICore';
 import {PageModel} from '../BaseInterfaces';
 import Indexes from '../Indexes/Indexes';
 import Resource from '../Resource';
-import {ActivityModel, ListActivitiesParams} from './ActivitiesInterfaces';
+import {ActivityModel, ListActivitiesParams, ActivityFacetModel} from './ActivitiesInterfaces';
 
 export default class Activity extends Resource {
     static getBaseUrl = () => `/rest/organizations/${API.orgPlaceholder}/activities`;
@@ -11,30 +11,15 @@ export default class Activity extends Resource {
         return this.api.get<ActivityModel>(`${Activity.getBaseUrl()}/${activityId}`);
     }
     getResourceTypes() {
-        return this.api.get<ActivityModel>(`${Activity.getBaseUrl()}/resourcetypes`);
+        return this.api.get<string[]>(`${Activity.getBaseUrl()}/resourcetypes`);
     }
 
-    /**
-     * @deprecated list(params?: ListFieldsParams) is kept for backward compatibility, you should now use `search(params?: FieldListingOptions)`.
-     */
     list(params?: ListActivitiesParams) {
         return this.api.post<PageModel<ActivityModel>>(this.buildPath(`${Indexes.baseUrl}/public`, params));
     }
 
     listFacets(params?: ListActivitiesParams) {
-        return this.api.post<PageModel<ActivityModel>>(this.buildPath(`${Indexes.baseUrl}/facets/public`, params));
-    }
-
-    search(params?: ListActivitiesParams) {
-        return this.api.post<PageModel<ActivityModel>>(
-            this.buildPath(`${Activity.getBaseUrl()}/public/search`, params)
-        );
-    }
-
-    searchFacets(params?: ListActivitiesParams) {
-        return this.api.post<PageModel<ActivityModel>>(
-            this.buildPath(`${Activity.getBaseUrl()}/facets/public/search`, params)
-        );
+        return this.api.post<ActivityFacetModel>(this.buildPath(`${Indexes.baseUrl}/facets/public`, params));
     }
 
     cancelActivity(activityId: string, options: ActivityModel) {

--- a/src/resources/Activities/Activities.ts
+++ b/src/resources/Activities/Activities.ts
@@ -1,0 +1,28 @@
+import API from '../../APICore';
+import {PageModel} from '../BaseInterfaces';
+import Indexes from '../Indexes/Indexes';
+import Resource from '../Resource';
+import {ActivityListingOptions, ActivityModel, ListActivitiesParams} from './ActivitiesInterfaces';
+
+export default class Activity extends Resource {
+    static getBaseUrl = () => `/rest/organizations/${API.orgPlaceholder}/activities`;
+
+    get(activityId: string) {
+        return this.api.get<ActivityModel>(`${Activity.getBaseUrl()}/${activityId}`);
+    }
+
+    /**
+     * @deprecated list(params?: ListFieldsParams) is kept for backward compatibility, you should now use `search(params?: FieldListingOptions)`.
+     */
+    list(params?: ListActivitiesParams) {
+        return this.api.get<PageModel<ActivityModel>>(this.buildPath(`${Indexes.baseUrl}/page/activities`, params));
+    }
+
+    search(params?: ActivityListingOptions) {
+        return this.api.post<PageModel<ActivityModel>>(this.buildPath(`${Activity.baseUrl}/search`, params));
+    }
+
+    cancelActivity(activityId: string, options: ActivityModel) {
+        return this.api.put(`${Activity.getBaseUrl()}/${activityId}`, options);
+    }
+}

--- a/src/resources/Activities/Activities.ts
+++ b/src/resources/Activities/Activities.ts
@@ -2,7 +2,7 @@ import API from '../../APICore';
 import {PageModel} from '../BaseInterfaces';
 import Indexes from '../Indexes/Indexes';
 import Resource from '../Resource';
-import {ActivityListingOptions, ActivityModel, ListActivitiesParams} from './ActivitiesInterfaces';
+import {ActivityModel, ListActivitiesParams} from './ActivitiesInterfaces';
 
 export default class Activity extends Resource {
     static getBaseUrl = () => `/rest/organizations/${API.orgPlaceholder}/activities`;
@@ -10,16 +10,31 @@ export default class Activity extends Resource {
     get(activityId: string) {
         return this.api.get<ActivityModel>(`${Activity.getBaseUrl()}/${activityId}`);
     }
+    getResourceTypes() {
+        return this.api.get<ActivityModel>(`${Activity.getBaseUrl()}/resourcetypes`);
+    }
 
     /**
      * @deprecated list(params?: ListFieldsParams) is kept for backward compatibility, you should now use `search(params?: FieldListingOptions)`.
      */
     list(params?: ListActivitiesParams) {
-        return this.api.get<PageModel<ActivityModel>>(this.buildPath(`${Indexes.baseUrl}/page/activities`, params));
+        return this.api.post<PageModel<ActivityModel>>(this.buildPath(`${Indexes.baseUrl}/public`, params));
     }
 
-    search(params?: ActivityListingOptions) {
-        return this.api.post<PageModel<ActivityModel>>(this.buildPath(`${Activity.baseUrl}/search`, params));
+    listFacets(params?: ListActivitiesParams) {
+        return this.api.post<PageModel<ActivityModel>>(this.buildPath(`${Indexes.baseUrl}/facets/public`, params));
+    }
+
+    search(params?: ListActivitiesParams) {
+        return this.api.post<PageModel<ActivityModel>>(
+            this.buildPath(`${Activity.getBaseUrl()}/public/search`, params)
+        );
+    }
+
+    searchFacets(params?: ListActivitiesParams) {
+        return this.api.post<PageModel<ActivityModel>>(
+            this.buildPath(`${Activity.getBaseUrl()}/facets/public/search`, params)
+        );
     }
 
     cancelActivity(activityId: string, options: ActivityModel) {

--- a/src/resources/Activities/ActivitiesInterfaces.ts
+++ b/src/resources/Activities/ActivitiesInterfaces.ts
@@ -31,13 +31,6 @@ export interface ActivityListingFilters {
     facet?: FacetOrSortStatus;
 }
 
-export interface ActivityListingOptions {
-    /**
-     * Filters to narrow down the returned fields.
-     */
-    filters?: ActivityListingFilters;
-}
-
 export interface TriggeredByAttributes {
     type: string;
     id?: string;

--- a/src/resources/Activities/ActivitiesInterfaces.ts
+++ b/src/resources/Activities/ActivitiesInterfaces.ts
@@ -2,23 +2,29 @@ import {Paginated} from '../BaseInterfaces';
 import {FacetOrSortStatus} from '../Enums';
 
 export interface ActivityModel {
+    content?: any;
+    createDate?: number;
+    duration?: number;
+    endDate?: number;
     id?: string;
     operation: string;
-    result: string;
-    errorCode?: string;
-    documentsProcessed?: number;
-    duration?: number;
-    isInitialBuild?: boolean;
-    startDate?: number;
-    endDate?: number;
-    createDate?: number;
-    state: string;
-    triggeredBy: TriggeredByAttributes;
-    content?: any;
     organizationId?: string;
+    progress?: number;
     resourceId?: string;
     resourceName?: string;
     resourceType?: string;
+    result: string;
+    section?: string;
+    startDate?: number;
+    state: string;
+    triggeredBy: TriggeredByAttributes;
+    errorCode?: string;
+    errorDetail?: string;
+    abortReason?: string;
+    abortedBy?: any;
+    snapShotId?: string;
+    documentsProcessed?: number;
+    isInitialBuild?: boolean;
     showOrgCol?: boolean;
 }
 

--- a/src/resources/Activities/ActivitiesInterfaces.ts
+++ b/src/resources/Activities/ActivitiesInterfaces.ts
@@ -29,6 +29,7 @@ export interface ActivityModel {
 }
 
 export interface ListActivitiesParams extends Paginated {
+    /* The facet status of the activities to list */
     facetsOnly?: boolean;
 }
 
@@ -44,4 +45,13 @@ export interface TriggeredByAttributes {
     relatedActivity?: string;
     relatedActivityId?: string;
     relatedActivityResourceType?: string;
+}
+
+export interface ActivityFacetModel {
+    operations?: string[];
+    organizationIds?: string[];
+    resourceIds?: string[];
+    resourceTypes?: string[];
+    sections?: string[];
+    states?: string[];
 }

--- a/src/resources/Activities/ActivitiesInterfaces.ts
+++ b/src/resources/Activities/ActivitiesInterfaces.ts
@@ -1,0 +1,48 @@
+import {Paginated} from '../BaseInterfaces';
+import {FacetOrSortStatus} from '../Enums';
+
+export interface ActivityModel {
+    id?: string;
+    operation: string;
+    result: string;
+    errorCode?: string;
+    documentsProcessed?: number;
+    duration?: number;
+    isInitialBuild?: boolean;
+    startDate?: number;
+    endDate?: number;
+    createDate?: number;
+    state: string;
+    triggeredBy: TriggeredByAttributes;
+    content?: any;
+    organizationId?: string;
+    resourceId?: string;
+    resourceName?: string;
+    resourceType?: string;
+    showOrgCol?: boolean;
+}
+
+export interface ListActivitiesParams extends Paginated {
+    facetsOnly?: boolean;
+}
+
+export interface ActivityListingFilters {
+    /* The facet status of the activities to list. */
+    facet?: FacetOrSortStatus;
+}
+
+export interface ActivityListingOptions {
+    /**
+     * Filters to narrow down the returned fields.
+     */
+    filters?: ActivityListingFilters;
+}
+
+export interface TriggeredByAttributes {
+    type: string;
+    id?: string;
+    displayName?: string;
+    relatedActivity?: string;
+    relatedActivityId?: string;
+    relatedActivityResourceType?: string;
+}

--- a/src/resources/Activities/index.ts
+++ b/src/resources/Activities/index.ts
@@ -1,0 +1,2 @@
+export * from './Activities';
+export * from './ActivitiesInterfaces';

--- a/src/resources/Activities/tests/Activities.spec.ts
+++ b/src/resources/Activities/tests/Activities.spec.ts
@@ -1,7 +1,7 @@
 import API from '../../../APICore';
 import Indexes from '../../Indexes/Indexes';
 import Activity from '../Activities';
-import {ActivityListingOptions, ActivityModel, ListActivitiesParams} from '../ActivitiesInterfaces';
+import {ActivityModel, ListActivitiesParams} from '../ActivitiesInterfaces';
 
 jest.mock('../../../APICore.ts');
 const APIMock: jest.Mock<API> = API as any;
@@ -19,38 +19,53 @@ describe('Activity', () => {
     describe('get', () => {
         it('should make a GET call to the specific Activity url', () => {
             const activityId = 'gandalf';
-
             activity.get(activityId);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/${activityId}`);
         });
     });
 
-    describe('list', () => {
+    describe('getResourceTypes', () => {
         it('should make a GET call to the specific Activity url', () => {
+            activity.getResourceTypes();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/resourcetypes`);
+        });
+    });
+
+    describe('list', () => {
+        it('should make a POST call to the specific Activity url', () => {
             const params: ListActivitiesParams = {};
 
             activity.list(params);
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Indexes.baseUrl}/page/activities`);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Indexes.baseUrl}/public`);
         });
 
-        it('should make a GET call to the specific Activity url with the facetsOnly param set as true', () => {
+        it('should make a POST call to the specific Activity url with the facetsOnly param set as true', () => {
             const params: ListActivitiesParams = {facetsOnly: true};
 
             activity.list(params);
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Indexes.baseUrl}/page/activities?facetsOnly=true`);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Indexes.baseUrl}/public?facetsOnly=true`);
         });
     });
-    // to fix
+
     describe('search', () => {
-        it.skip('should make a GET call to the specific Activity url', () => {
-            const params: ActivityListingOptions = {};
+        it('should make a POST call to the specific Activity url', () => {
+            const params: ListActivitiesParams = {};
 
             activity.search(params);
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/search`);
+            expect(api.post).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/public/search`);
+        });
+
+        it('should make a POST call to the specific Activity url with the facetsOnly param set as true', () => {
+            const params: ListActivitiesParams = {facetsOnly: true};
+
+            activity.searchFacets(params);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/facets/public/search?facetsOnly=true`);
         });
     });
 

--- a/src/resources/Activities/tests/Activities.spec.ts
+++ b/src/resources/Activities/tests/Activities.spec.ts
@@ -1,0 +1,72 @@
+import API from '../../../APICore';
+import Indexes from '../../Indexes/Indexes';
+import Activity from '../Activities';
+import {ActivityListingOptions, ActivityModel, ListActivitiesParams} from '../ActivitiesInterfaces';
+
+jest.mock('../../../APICore.ts');
+const APIMock: jest.Mock<API> = API as any;
+
+describe('Activity', () => {
+    let activity: Activity;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        activity = new Activity(api, serverlessApi);
+    });
+
+    describe('get', () => {
+        it('should make a GET call to the specific Activity url', () => {
+            const activityId = 'gandalf';
+
+            activity.get(activityId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/${activityId}`);
+        });
+    });
+
+    describe('list', () => {
+        it('should make a GET call to the specific Activity url', () => {
+            const params: ListActivitiesParams = {};
+
+            activity.list(params);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Indexes.baseUrl}/page/activities`);
+        });
+
+        it('should make a GET call to the specific Activity url with the facetsOnly param set as true', () => {
+            const params: ListActivitiesParams = {facetsOnly: true};
+
+            activity.list(params);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Indexes.baseUrl}/page/activities?facetsOnly=true`);
+        });
+    });
+    // to fix
+    describe('search', () => {
+        it.skip('should make a GET call to the specific Activity url', () => {
+            const params: ActivityListingOptions = {};
+
+            activity.search(params);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/search`);
+        });
+    });
+
+    describe('cancelActivity', () => {
+        it('should make a PUT call to the specific Activity url', () => {
+            const activityId = 'gimli';
+            const activityModel: ActivityModel = {
+                operation: '',
+                result: '',
+                state: '',
+                triggeredBy: undefined,
+            };
+
+            activity.cancelActivity(activityId, activityModel);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/${activityId}`, activityModel);
+        });
+    });
+});

--- a/src/resources/Activities/tests/Activities.spec.ts
+++ b/src/resources/Activities/tests/Activities.spec.ts
@@ -51,24 +51,6 @@ describe('Activity', () => {
         });
     });
 
-    describe('search', () => {
-        it('should make a POST call to the specific Activity url', () => {
-            const params: ListActivitiesParams = {};
-
-            activity.search(params);
-            expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/public/search`);
-        });
-
-        it('should make a POST call to the specific Activity url with the facetsOnly param set as true', () => {
-            const params: ListActivitiesParams = {facetsOnly: true};
-
-            activity.searchFacets(params);
-            expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/facets/public/search?facetsOnly=true`);
-        });
-    });
-
     describe('cancelActivity', () => {
         it('should make a PUT call to the specific Activity url', () => {
             const activityId = 'gimli';

--- a/src/resources/PlatformResources.ts
+++ b/src/resources/PlatformResources.ts
@@ -1,3 +1,5 @@
+import Access from './OrganizationAccess/Access';
+import Activity from './Activities/Activities';
 import API from '../APICore';
 import ApiKey from './ApiKeys/ApiKeys';
 import AWS from './AWS/AWS';
@@ -43,9 +45,9 @@ import UsageAnalytics from './UsageAnalytics/UsageAnalytics';
 import User from './Users/User';
 import Vaults from './Vaults/Vaults';
 import TableauService from './TableauService/TableauService';
-import Access from './OrganizationAccess/Access';
 
 const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
+    {key: 'activity', resource: Activity},
     {key: 'apiKey', resource: ApiKey},
     {key: 'aws', resource: AWS},
     {key: 'caseAssistConfig', resource: CaseAssistConfig},
@@ -98,6 +100,7 @@ class PlatformResources {
     protected API: API;
     protected ServerlessAPI: API;
 
+    activity: Activity;
     apiKey: ApiKey;
     aws: AWS;
     caseAssistConfig: CaseAssistConfig;


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

Added a new Resource class for the Activities with the following calls:
- GET (an activity for an id)
- GET  resourcetype
- list (POST) activities
- list (POST) facets activities
- search (POST) activities (the list is said to be deprecated hence the need for search)
- searchfacet (POST) activities (the list is said to be deprecated hence the need for search)
- cancelActivity (PUT) to cancel the activity

I instantiated the new resource on the base PlatformResources.ts and wrote the unit tests for the calls.


### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
