### PR TITLE
feat: add support for bulkGet query pipeline statements

### DIFF
--- a/src/resources/Pipelines/Statements/Statements.ts
+++ b/src/resources/Pipelines/Statements/Statements.ts
@@ -2,6 +2,7 @@ import {getFormData} from '../../../utils/FormData';
 import {PageModel} from '../../BaseInterfaces';
 import Resource from '../../Resource';
 import {
+    BulkGetStatementsParams,
     CopyStatementModel,
     CreateStatementModel,
     ExportStatementParams,
@@ -90,6 +91,17 @@ export default class Statements extends Resource {
             this.buildPath(Statements.getStatementUrl(pipelineId, statementId), {
                 organizationId: this.api.organizationId,
             })
+        );
+    }
+
+    bulkGet(pipelineId: string, options: BulkGetStatementsParams) {
+        const {ids, ...allQueryStringOptions} = options;
+        return this.api.post<PageModel<StatementModel, 'statements'>>(
+            this.buildPath(`${Statements.getBaseUrl(pipelineId)}/bulkGet`, {
+                organizationId: this.api.organizationId,
+                ...allQueryStringOptions,
+            }),
+            {ids}
         );
     }
 }

--- a/src/resources/Pipelines/Statements/Statements.ts
+++ b/src/resources/Pipelines/Statements/Statements.ts
@@ -94,8 +94,7 @@ export default class Statements extends Resource {
         );
     }
 
-    bulkGet(pipelineId: string, options: BulkGetStatementsParams) {
-        const {ids, ...allQueryStringOptions} = options;
+    bulkGet(pipelineId: string, {ids, ...allQueryStringOptions}: BulkGetStatementsParams) {
         return this.api.post<PageModel<StatementModel, 'statements'>>(
             this.buildPath(`${Statements.getBaseUrl(pipelineId)}/bulkGet`, {
                 organizationId: this.api.organizationId,

--- a/src/resources/Pipelines/Statements/StatementsInterfaces.ts
+++ b/src/resources/Pipelines/Statements/StatementsInterfaces.ts
@@ -144,3 +144,10 @@ export interface ExportStatementParams {
      */
     organizationId?: string;
 }
+
+export interface BulkGetStatementsParams extends ListStatementParams {
+    /*
+     * A set of parameters to customize the results.
+     */
+    ids: string[];
+}

--- a/src/resources/Pipelines/Statements/tests/Statements.spec.ts
+++ b/src/resources/Pipelines/Statements/tests/Statements.spec.ts
@@ -168,4 +168,15 @@ describe('Statements', () => {
             expect(mockedFormData.append).toHaveBeenCalledWith('file', content, 'raw-string');
         });
     });
+
+    describe('bulkGet', () => {
+        it('should make a POST call to the specific Statement url', () => {
+            const pipelineId = '🏐';
+            const ids = ['one', 'two', 'three'];
+
+            statements.bulkGet(pipelineId, {ids});
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Statements.getBaseUrl(pipelineId)}/bulkGet`, {ids});
+        });
+    });
 });


### PR DESCRIPTION
[KIT-2096](https://coveord.atlassian.net/browse/KIT-2096)

Add support for `bulkGet` statements API for query pipelines: https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20API#/Statements%20V2/bulkGetStatementsOperationV2

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
