### PR TITLE
feat: add support for list pipelines with pagination enabled

### DIFF
--- a/src/resources/Pipelines/Pipelines.ts
+++ b/src/resources/Pipelines/Pipelines.ts
@@ -6,6 +6,7 @@ import FacetStateRules from './FacetStateRules/FacetStateRules';
 import MLAssociations from './MLAssociations/MLAssociations';
 import {
     ListPipelinesOptions,
+    ListPipelinesReturnVariant,
     NewPipelineModel,
     PipelineBackendVersion,
     PipelineModel,
@@ -43,8 +44,8 @@ export default class Pipelines extends Resource {
         );
     }
 
-    list(options?: ListPipelinesOptions) {
-        return this.api.get<PipelineModel[]>(
+    list<ListPipelinesVariant extends ListPipelinesOptions>(options?: ListPipelinesVariant) {
+        return this.api.get<ListPipelinesReturnVariant<ListPipelinesVariant>>(
             this.buildPath(Pipelines.searchUrlVersion1, {organizationId: this.api.organizationId, ...options})
         );
     }

--- a/src/resources/Pipelines/PipelinesInterfaces.ts
+++ b/src/resources/Pipelines/PipelinesInterfaces.ts
@@ -180,11 +180,36 @@ export interface NewPipelineModel extends PipelineShared, GranularResource {}
 export interface UpdatePipelineModel extends PipelineModel, GranularResource {}
 
 export interface ListPipelinesOptions extends Paginated {
+    /**
+     * Whether to sort the results in ascending order.
+     */
     isOrderAscending?: boolean;
+    /**
+     * The query filter to match.
+     *
+     * This allows you to search within query pipeline statement definitions and descriptions.
+     *
+     * By default, results are not required to match a specific query filter.
+     */
     filter?: string;
-    sortby?: string;
+    /**
+     * The sort criteria to apply on the results.
+     *
+     * Allowed values: `definition`, `description`, and `position`.
+     *
+     * Default: `position`
+     */
+    sortby?: 'definition' | 'description' | 'position';
     feature?: string;
+    /**
+     * The unique identifier of the target Coveo Cloud organization.
+     *
+     * Specifying a value for this parameter is only necessary when you are authenticating the API call with an OAuth2 token.
+     */
     organizationId?: string;
+    /**
+     * Whether to enable pagination.
+     */
     enablePagination?: boolean;
 }
 

--- a/src/resources/Pipelines/PipelinesInterfaces.ts
+++ b/src/resources/Pipelines/PipelinesInterfaces.ts
@@ -1,4 +1,4 @@
-import {GranularResource, Paginated} from '../BaseInterfaces';
+import {GranularResource, PageModel, Paginated} from '../BaseInterfaces';
 import {ConditionModel} from './Conditions';
 
 export interface PipelineBackendVersion {
@@ -185,4 +185,11 @@ export interface ListPipelinesOptions extends Paginated {
     sortby?: string;
     feature?: string;
     organizationId?: string;
+    enablePagination?: boolean;
 }
+
+export type PaginatedListPipelinesModel = Omit<PageModel<PipelineModel>, 'totalPages'>;
+
+export type ListPipelinesReturnVariant<ListPipelineVariant> = ListPipelineVariant extends {enablePagination: true}
+    ? PaginatedListPipelinesModel
+    : PipelineModel[];


### PR DESCRIPTION
The list pipelines API added (a long time ago) a parameter to specify that the call should be paginated, in a backward compatible way.

If the parameter `enablePagination` is not specified or set to false, the API returns a list: `PipelineModel[]`

If `enablePagination=true`, then the API return an object with `{items: PipelineModel[], totalEntries: number}` 

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
