### PR TITLE
fix(activities): fixed API calls for activities, removing public in URL

### DIFF
--- a/src/resources/Activities/Activities.ts
+++ b/src/resources/Activities/Activities.ts
@@ -23,7 +23,7 @@ export default class Activity extends Resource {
     list(params?: ListActivitiesParams, activityFacet?: ActivityListingFilters) {
         const isPublic = activityFacet.sections?.includes('INTERNAL');
         return this.api.post<PageModel<ActivityModel>>(
-            this.buildPath(isPublic ? `${Activity.getBaseUrl()}/public` : `${Activity.getBaseUrl()}`, params),
+            this.buildPath(isPublic ? `${Activity.getBaseUrl()}/public` : Activity.getBaseUrl(), params),
             activityFacet
         );
     }

--- a/src/resources/Activities/Activities.ts
+++ b/src/resources/Activities/Activities.ts
@@ -21,15 +21,20 @@ export default class Activity extends Resource {
     }
 
     list(params?: ListActivitiesParams, activityFacet?: ActivityListingFilters) {
+        const isPublic = activityFacet.sections?.includes('INTERNAL');
         return this.api.post<PageModel<ActivityModel>>(
-            this.buildPath(`${Activity.getBaseUrl()}/public`, params),
+            this.buildPath(isPublic ? `${Activity.getBaseUrl()}/public` : `${Activity.getBaseUrl()}`, params),
             activityFacet
         );
     }
 
     listFacets(params?: ListActivitiesFacetsParams, activityFacet?: ActivityListingFilters) {
+        const isPublic = activityFacet.sections?.includes('INTERNAL');
         return this.api.post<ActivityFacetModel>(
-            this.buildPath(`${Activity.getBaseUrl()}/facets/public`, params),
+            this.buildPath(
+                isPublic ? `${Activity.getBaseUrl()}/facets/public` : `${Activity.getBaseUrl()}/facets`,
+                params
+            ),
             activityFacet
         );
     }

--- a/src/resources/Activities/Activities.ts
+++ b/src/resources/Activities/Activities.ts
@@ -21,7 +21,7 @@ export default class Activity extends Resource {
     }
 
     list(params?: ListActivitiesParams, activityFacet?: ActivityListingFilters) {
-        const isPublic = activityFacet.sections?.includes('INTERNAL');
+        const isPublic = !activityFacet.sections?.includes('INTERNAL');
         return this.api.post<PageModel<ActivityModel>>(
             this.buildPath(isPublic ? `${Activity.getBaseUrl()}/public` : Activity.getBaseUrl(), params),
             activityFacet
@@ -29,7 +29,7 @@ export default class Activity extends Resource {
     }
 
     listFacets(params?: ListActivitiesFacetsParams, activityFacet?: ActivityListingFilters) {
-        const isPublic = activityFacet.sections?.includes('INTERNAL');
+        const isPublic = !activityFacet.sections?.includes('INTERNAL');
         return this.api.post<ActivityFacetModel>(
             this.buildPath(
                 isPublic ? `${Activity.getBaseUrl()}/facets/public` : `${Activity.getBaseUrl()}/facets`,

--- a/src/resources/Activities/tests/Activities.spec.ts
+++ b/src/resources/Activities/tests/Activities.spec.ts
@@ -40,8 +40,15 @@ describe('Activity', () => {
     describe('list', () => {
         it('should make a POST call to the specific Activity url to fetch activities of an organization', () => {
             const params: ListActivitiesParams = {};
-            const activityFacet: ActivityListingFilters = {};
+            const activityFacet: ActivityListingFilters = {sections: ['INTERNAL']};
+            activity.list(params, activityFacet);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(Activity.getBaseUrl(), activityFacet);
+        });
 
+        it('should make a POST call to the specific Activity url to fetch public activities of an organization', () => {
+            const params: ListActivitiesParams = {};
+            const activityFacet: ActivityListingFilters = {};
             activity.list(params, activityFacet);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/public`, activityFacet);
@@ -49,10 +56,17 @@ describe('Activity', () => {
     });
 
     describe('listFacets', () => {
-        it('should make a POST call to the specific Activity url with the facetsOnly param set as true', () => {
+        it('should make a POST call to the specific Activity url to fetch the facets', () => {
+            const params: ListActivitiesFacetsParams = {};
+            const activityFacet: ActivityListingFilters = {sections: ['INTERNAL']};
+            activity.listFacets(params, activityFacet);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/facets`, activityFacet);
+        });
+
+        it('should make a POST call to the specific Activity url to fetch the public facets', () => {
             const params: ListActivitiesFacetsParams = {};
             const activityFacet: ActivityListingFilters = {};
-
             activity.listFacets(params, activityFacet);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${Activity.getBaseUrl()}/facets/public`, activityFacet);
@@ -63,7 +77,6 @@ describe('Activity', () => {
         it('should make a POST call to the specific Activity url to fetch activities of all organizations', () => {
             const params: ListActivitiesFacetsParams = {};
             const activityFacet: ActivityListingFilters = {};
-
             activity.listAll(params, activityFacet);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(Activity.getBaseUrlAllOrgs(), activityFacet);


### PR DESCRIPTION
Fixed an issue in the Activities Resources.
Removed the 'Public' from the urls for the calls. Also adjusted the unit tests for those calls

### Acceptance Criteria

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
