### PR TITLE
feat(product-listing): add name field to ranking configuration interface

### DIFF
--- a/src/resources/Catalogs/ProductListingConfigurationInterfaces.ts
+++ b/src/resources/Catalogs/ProductListingConfigurationInterfaces.ts
@@ -9,6 +9,10 @@ export interface ProductListingConfigurationModel {
 
 export interface RankingConfiguration {
     /**
+     * The name of the RankingConfiguration.
+     */
+    name: string;
+    /**
      * The list of inclusion filters.
      */
     include: QueryFilterModel[];

--- a/src/resources/Catalogs/tests/ProductListingConfiguration.spec.ts
+++ b/src/resources/Catalogs/tests/ProductListingConfiguration.spec.ts
@@ -35,6 +35,7 @@ describe('ProductListingConfiguration', () => {
             const productListingConfigurationModel: New<ProductListingConfigurationModel> = {
                 rankingConfigurations: [
                     {
+                        name: 'Bury brand',
                         include: [
                             {
                                 fieldName: 'ec_brand',
@@ -50,6 +51,7 @@ describe('ProductListingConfiguration', () => {
                         value: 10,
                     },
                     {
+                        name: 'Boost brand',
                         include: [
                             {
                                 fieldName: 'ec_brand',
@@ -105,6 +107,7 @@ describe('ProductListingConfiguration', () => {
             const productListingConfigurationModel: ProductListingConfigurationModel = {
                 rankingConfigurations: [
                     {
+                        name: 'Bury brand',
                         include: [
                             {
                                 fieldName: 'ec_brand',
@@ -120,6 +123,7 @@ describe('ProductListingConfiguration', () => {
                         value: 100,
                     },
                     {
+                        name: 'Boost brand',
                         include: [
                             {
                                 fieldName: 'ec_brand',


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

Added new `name` field to `RankingConfiguration` interface

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
