### PR TITLE
feat(licenseMetrics): +assignable call for new consumption dashboard …

### DIFF
--- a/src/resources/SearchUsageMetrics/LicenseMetrics/LicenseMetrics.ts
+++ b/src/resources/SearchUsageMetrics/LicenseMetrics/LicenseMetrics.ts
@@ -5,6 +5,10 @@ import {ListLicenseMonthlyParams, RestListOfMetricsModel, RestListOfMetricValues
 export default class LicenseMetrics extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/searchusagemetrics/license`;
 
+    listAssignable() {
+        return this.api.get<RestListOfMetricsModel>(`${LicenseMetrics.baseUrl}/assignable`);
+    }
+
     listInUse() {
         return this.api.get<RestListOfMetricsModel>(`${LicenseMetrics.baseUrl}/inUse`);
     }

--- a/src/resources/SearchUsageMetrics/LicenseMetrics/tests/LicenseMetrics.spec.ts
+++ b/src/resources/SearchUsageMetrics/LicenseMetrics/tests/LicenseMetrics.spec.ts
@@ -18,6 +18,12 @@ describe.only('LicenseMetrics', () => {
     });
 
     describe('list', () => {
+        it('should make a GET call to the assignable metrics for an organization', () => {
+            LicenseMetricsService.listAssignable();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${LicenseMetrics.baseUrl}/assignable`);
+        });
+
         it('should make a GET call to the in-use metrics for an organization', () => {
             LicenseMetricsService.listInUse();
             expect(api.get).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
…feature

https://coveord.atlassian.net/browse/FOUND-4294

We will now use the modified `/assignable` endpoint to populate the Entitlement metric dropdown in the consumption dashboard.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
<!-- TODO November 29th: Remove this -->
**BONUS:** For the duration of the Centraide Campain 2022, author of unconventional commit on master will be strongly invited to amend by making a donation to Centraide :heart:
