### PR TITLE
feature: add status information on CrawlingModuleEntity

### DIFF
--- a/src/resources/CrawlingModule/CrawlingModuleInterfaces.ts
+++ b/src/resources/CrawlingModule/CrawlingModuleInterfaces.ts
@@ -5,39 +5,117 @@ export interface MaestroVersionOptions {
 }
 
 export interface CrawlingModuleStatus {
+    /**
+     * Whether the crawling module is using a proxy or not.
+     */
     usingProxy: boolean;
+    /**
+     * Whether the auto update is enable or not.
+     */
     autoUpdateEnable: boolean;
+    /**
+     * Whether the log request is enable or not.
+     * This enables the client to query logs directly from the platform.
+     */
     logRequestEnable: boolean;
+    /**
+     * Frequency at which the setup look for update.
+     */
     autoUpdateFrequency: number;
+    /**
+     * The number for crawler set in the configuration of the crawling module.
+     */
     numberOfCrawlerWorkers: number;
+    /**
+     * The number for security provider set in the configuration of the crawling module.
+     */
     numberOfSecurityWorkers: number;
 }
 
 export interface CrawlingModuleEntity {
+    /**
+     * Creation date.
+     */
     createdDate: number;
+    /**
+     * @deprecated Should not be used.
+     */
     databaseVersion?: string;
+    /**
+     * After a given period, a crawling module that doesn't report to the
+     * platform is going be disabled. It won't be able to process job.
+     */
     disabled: boolean;
+    /**
+     * Id of the crawling module.
+     */
     id: string;
+    /**
+     * The last time the crawling module report itself to the platform.
+     */
     lastHeartbeat: number;
+    /**
+     * The latest date at which the crawling module update itself.
+     */
     lastVersionUpgrade: number;
+    /**
+     * The version of the crawling module.
+     */
     maestroVersion: string;
+    /**
+     * The name of the crawling module.
+     */
     name: string;
+    /**
+     * Organization id on which the crawling module is linked.
+     */
     organizationId: string;
+    /**
+     * @deprecated Should not be used.
+     */
     securityWorkerVersion?: string;
+    /**
+     * Latest updated date.
+     */
     updatedDate: number;
+    /**
+     * @deprecated Should not be used.
+     */
     workerVersion?: string;
+    /**
+     * Advance information about a crawling module, see @type {CrawlingModuleStatus}.
+     */
     status?: CrawlingModuleStatus;
 }
 
 export interface ComponentVersion {
+    /**
+     * @deprecated Should not be used.
+     */
     databaseVersion: string;
+    /**
+     * The version of the crawling module.
+     */
     maestroVersion: string;
+    /**
+     * @deprecated Should not be used.
+     */
     securityWorkerVersion: string;
+    /**
+     * @deprecated Should not be used.
+     */
     workerVersion: string;
 }
 
 export interface UpdateStatus {
+    /**
+     * Whether an update is available.
+     */
     updateAvailable: boolean;
+    /**
+     * If an update is available, the category of update.
+     * See @type {UpdateStatusCategory}.
+     */
     updateCategory?: UpdateStatusCategory;
 }
 
@@ -55,22 +133,58 @@ export enum CrawlingModuleLogRequestState {
 }
 
 export interface CrawlingModuleLogRequestModel {
+    /**
+     * Creation date for the log request.
+     */
     createdDate: number;
+    /**
+     * Id of the log request.
+     */
     id: string;
+    /**
+     * InstanceId for the log request.
+     */
     instanceId: string;
+    /**
+     * The type of log requested, see @type {CrawlingModuleLogRequestLogType}
+     */
     logType: CrawlingModuleLogRequestLogType;
+    /**
+     * Operation on for which we want to get the logs.
+     */
     operationId: string;
+    /**
+     * The state of the request, see @enum {CrawlingModuleLogRequestState}
+     */
     state: CrawlingModuleLogRequestState;
 }
 
 export interface CreateCrawlingModuleLogRequestModel {
+    /**
+     * InstanceId for the log request.
+     */
     instanceId: string;
+    /**
+     * The type of log requested, see @type {CrawlingModuleLogRequestLogType}
+     */
     logType: CrawlingModuleLogRequestLogType;
+    /**
+     * Operation on for which we want to get the logs.
+     */
     operationId: string;
 }
 
 export interface CrawlingModuleLogRequestDownloadModel {
+    /**
+     * Information about the request, mostly error message.
+     */
     info: string;
+    /**
+     * The state of the request, see @enum {CrawlingModuleLogRequestState}
+     */
     state: CrawlingModuleLogRequestState;
+    /**
+     * Url to download the log.
+     */
     url: string;
 }

--- a/src/resources/CrawlingModule/CrawlingModuleInterfaces.ts
+++ b/src/resources/CrawlingModule/CrawlingModuleInterfaces.ts
@@ -4,6 +4,15 @@ export interface MaestroVersionOptions {
     crawlingModuleVersion: string;
 }
 
+export interface CrawlingModuleStatus {
+    usingProxy: boolean;
+    autoUpdateEnable: boolean;
+    logRequestEnable: boolean;
+    autoUpdateFrequency: number;
+    numberOfCrawlerWorkers: number;
+    numberOfSecurityWorkers: number;
+}
+
 export interface CrawlingModuleEntity {
     createdDate: number;
     databaseVersion?: string;
@@ -17,6 +26,7 @@ export interface CrawlingModuleEntity {
     securityWorkerVersion?: string;
     updatedDate: number;
     workerVersion?: string;
+    status?: CrawlingModuleStatus;
 }
 
 export interface ComponentVersion {
@@ -28,7 +38,7 @@ export interface ComponentVersion {
 
 export interface UpdateStatus {
     updateAvailable: boolean;
-    updateCategory: UpdateStatusCategory;
+    updateCategory?: UpdateStatusCategory;
 }
 
 export enum CrawlingModuleLogRequestLogType {


### PR DESCRIPTION
## [CTINFRA-3053](https://coveord.atlassian.net/browse/CTINFRA-3053) :rocket:

- We are now returning the `status` of a crawling module that contains more information about the client setup. 
- updateCategory is nullable 
### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
<!-- TODO November 29th: Remove this -->
**BONUS:** For the duration of the Centraide Campain 2022, author of unconventional commit on master will be strongly invited to amend by making a donation to Centraide :heart:
