### PR TITLE
fix(snapshot): support windows silly mime-type

### DIFF
--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -171,6 +171,7 @@ export default class ResourceSnapshots extends Resource {
 
     private getSnapshotFileType(file: File) {
         switch (file.type) {
+            case 'application/x-zip-compressed':
             case 'application/zip':
                 return ResourceSnapshotSupportedFileTypes.ZIP;
             case 'application/json':

--- a/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
+++ b/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
@@ -181,27 +181,31 @@ describe('ResourceSnapshots', () => {
         const mockedFormData = {
             append: mockedAppendToFormData,
         };
-        const mockedFile = {
-            type: 'application/zip',
-        };
-
         beforeEach(() => {
             (global as any).FormData = jest.fn(() => mockedFormData);
-            (global as any).File = jest.fn(() => mockedFile);
         });
 
-        it('should make a post call to the specific Resource Snapshots url if zip file', () => {
-            const createFromFileOptions: CreateFromFileOptions = {developerNotes: 'Cut my life into pieces! 🎵🎵🎵'};
-            const file = new File([''], 'mock.zip', {type: 'application/zip'});
+        it.each(['application/zip', 'application/x-zip-compressed'])(
+            'should make a post call to the specific Resource Snapshots url if zip file',
+            (fileType: string) => {
+                const mockedFileZIP = {
+                    type: fileType,
+                } as unknown as File;
+                (global as any).File = jest.fn(() => mockedFileZIP);
+                const createFromFileOptions: CreateFromFileOptions = {
+                    developerNotes: 'Cut my life into pieces! 🎵🎵🎵',
+                };
+                const file = new File([''], 'mock.zip', {type: fileType});
 
-            resourceSnapshots.createFromFile(file, createFromFileOptions);
+                resourceSnapshots.createFromFile(file, createFromFileOptions);
 
-            expect(api.postForm).toHaveBeenCalledTimes(1);
-            expect(api.postForm).toHaveBeenCalledWith(
-                `${ResourceSnapshots.baseUrl}/file?developerNotes=Cut%20my%20life%20into%20pieces%21%20%F0%9F%8E%B5%F0%9F%8E%B5%F0%9F%8E%B5&snapshotFileType=ZIP`,
-                mockedFormData
-            );
-        });
+                expect(api.postForm).toHaveBeenCalledTimes(1);
+                expect(api.postForm).toHaveBeenCalledWith(
+                    `${ResourceSnapshots.baseUrl}/file?developerNotes=Cut%20my%20life%20into%20pieces%21%20%F0%9F%8E%B5%F0%9F%8E%B5%F0%9F%8E%B5&snapshotFileType=ZIP`,
+                    mockedFormData
+                );
+            }
+        );
 
         it('should make a post call to the specific Resource Snapshots url if json file', () => {
             const mockedFileJSON = {


### PR DESCRIPTION
### Acceptance Criteria

Windows is using `application/x-zip-compressed` instead of the standard `application/zip` :finnadie:.
If we don't support it, we go into the 'default' clause of the switch and the snapshot upload doesn't work on Windows.

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
<!-- TODO November 29th: Remove this -->
**BONUS:** For the duration of the Centraide Campain 2022, author of unconventional commit on master will be strongly invited to amend by making a donation to Centraide :heart:

----

Fixes SRC-5204
