### PR TITLE
docs: add public APIS only acceptance criteria

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ If a new Resource class was created in this PR, have you done the following?
 
 <!-- PRs that don't respect all of those criteria won't be merged. -->
 
+-   [ ] My API is publicly available and documented in production, i.e. on [Swagger](https://platform.cloud.coveo.com/docs)
 -   [ ] JSDoc annotates each property added in the exported interfaces
 -   [ ] The proposed changes are covered by unit tests
 -   [ ] Commits containing breaking changes a properly identified as such


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
<!-- TODO November 29th: Remove this -->
**BONUS:** For the duration of the Centraide Campain 2022, author of unconventional commit on master will be strongly invited to amend by making a donation to Centraide :heart:
