### PR TITLE
build: fix commit hook on windows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,4 +18,7 @@ module.exports = {
             extends: ['plugin:jest/recommended'],
         },
     ],
+    rules: {
+        'prettier/prettier': ['error', {endOfLine: 'auto'}],
+    },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,4 @@ module.exports = {
             extends: ['plugin:jest/recommended'],
         },
     ],
-    rules: {
-        'prettier/prettier': ['error', {endOfLine: 'auto'}],
-    },
 };

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,2 @@
+#!/bin/sh
 npx commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/bin/sh
 npx lint-staged


### PR DESCRIPTION
## Commit
After I finished my work, meticulously going over the Read service resources, I wasn't able to commit my work. Luckily the error pointed me towards it being an issue with husky:
> error: cannot spawn .husky/pre-commit: No such file or directory

After searching the internet I found that putting the `#!/bin/sh` shebang in the commit hook files solves the issue. Probably because it is using a different execution environment by default on Windows, which fails.

## Line endings
<details><summary>Reverted after feedback</summary>
<p>
To start working on the Read service resource definitions, I pulled in this repository. Only to be greeted with every single line in every TS file having an error. It asked me to remove the `CR` character on every line.

I found this [StackOverflow about it](https://stackoverflow.com/questions/53516594/why-do-i-keep-getting-eslint-delete-cr-prettier-prettier) and was once again having mixed feelings about StackOverflow. People simultaneously gave the right fix, but some also suggest horrible fixes such as setting `core.autocrlf` to false globally. That's basically asking for line ending wars on every git repository that has cross Windows & Mac/Linux development. To be fair, even the [git docs on autocrlf](https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf) are wrong, stating:
> If you’re a Windows programmer doing a Windows-only project, then you can turn off this functionality, recording the carriage returns **in the repository** by setting the config value to false:
> ```powershell
> git config --global core.autocrlf false
> ```
_(Emphasis of "in the repository" is mine, but of course that means you shouldn't use the `--global` flag!)_

Apparently the default for prettier is to enforce `LF` newlines, which is a poor decision in my opinion. The best cross-platform default is to use the system's default newlines. Not doing so is forcing people on Windows to never open files in any program that doesn't support line endings different than the OS one. Any git user on Windows should be recommended to have `core.autocrlf = true` globally, and honestly I don't see any good reason for disabling it locally ever.
</p>
</details>

### Acceptance Criteria

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
    _Not applicable_
-   [X] JSDoc annotates each property added in the exported interfaces
    _Not applicable_
-   [X] The proposed changes are covered by unit tests
    _Not applicable_
-   [X] Commits containing breaking changes a properly identified as such
    _Not applicable_
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
    _Not applicable, I think?_
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
