### PR TITLE
refactor(ua read): breaking api alignment & fixes

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -834,6 +834,12 @@ export enum DimensionType {
     DATETIME = 'DATETIME',
 }
 
+export enum AccountStatus {
+    AVAILABLE = 'AVAILABLE',
+    CREATING = 'CREATING',
+    DELETING = 'DELETING',
+}
+
 export enum DimensionStatus {
     AVAILABLE = 'AVAILABLE',
     UPDATING = 'UPDATING',

--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -1012,13 +1012,6 @@ export enum IndexingPipelineLogTasks {
     preindexing = 'PREINDEXING',
 }
 
-export enum RedshiftEndpointStatus {
-    online = 'ONLINE',
-    unavailable = 'UNAVAILABLE',
-    readOnly = 'READ_ONLY',
-    writeOnly = 'WRITE_ONLY',
-}
-
 export enum ExportStatus {
     available = 'AVAILABLE',
     pending = 'PENDING',

--- a/src/resources/UsageAnalytics/Read/Administration/Administration.ts
+++ b/src/resources/UsageAnalytics/Read/Administration/Administration.ts
@@ -1,4 +1,3 @@
-import {RedshiftEndpointStatus} from '../../../Enums';
 import ReadServiceResource from '../ReadServiceResource';
 import {
     AccountInfoModelV15,
@@ -24,12 +23,6 @@ export default class Administration extends ReadServiceResource {
      */
     updateAccount(model: AccountInfoModelV15) {
         return this.api.put<AccountResponseV15>(this.buildPathWithOrg(`${Administration.baseUrl}/account`), model);
-    }
-
-    setRedshiftStatus(endpoint: string, status: RedshiftEndpointStatus) {
-        return this.api.post<Record<string, unknown>>(
-            this.buildPath(`${Administration.baseUrl}/redshift/endpoint/status`, {endpointId: endpoint, status})
-        );
     }
 
     /**

--- a/src/resources/UsageAnalytics/Read/Administration/AdministrationInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Administration/AdministrationInterfaces.ts
@@ -1,3 +1,4 @@
+import {AccountStatus} from '../../../Enums';
 import {DeprecatedShortPaginatedParamParts, OrganizationParamParts, TimeRangeParamParts} from '../CommonParamParts';
 
 export interface AccountInfoModelV15 {
@@ -8,7 +9,7 @@ export interface AccountInfoModelV15 {
 export interface AccountResponseV15 extends AccountInfoModelV15 {
     name: string;
     enabled: boolean;
-    status: any;
+    status: AccountStatus;
 }
 
 export interface StrictValidationTestResponseV15 {

--- a/src/resources/UsageAnalytics/Read/Administration/tests/Administration.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Administration/tests/Administration.spec.ts
@@ -1,5 +1,4 @@
 import API from '../../../../../APICore';
-import {RedshiftEndpointStatus} from '../../../../Enums';
 
 import Administration from '../Administration';
 import {AccountInfoModelV15} from '../AdministrationInterfaces';
@@ -34,16 +33,6 @@ describe('Administation', () => {
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
                 `${Administration.baseUrl}/account/strictValidationTest?from=yyyy-mm-dd&to=yyyy-mm-dd&d=allo`
-            );
-        });
-    });
-
-    describe('setRedshiftStatus', () => {
-        it('should make a post call to the Administration base url + /redshift/endpoint/status', () => {
-            administation.setRedshiftStatus('allo', RedshiftEndpointStatus.unavailable);
-
-            expect(api.post).toHaveBeenCalledWith(
-                `${Administration.baseUrl}/redshift/endpoint/status?endpointId=allo&status=UNAVAILABLE`
             );
         });
     });

--- a/src/resources/UsageAnalytics/Read/CommonParamParts.ts
+++ b/src/resources/UsageAnalytics/Read/CommonParamParts.ts
@@ -1,3 +1,5 @@
+import { MetricsInterval } from "./ReadServiceCommon";
+
 /**
  * Almost all calls of the Read service have an optional `org` query parameter.
  * (Notable exceptions are service status monitoring calls).
@@ -67,9 +69,9 @@ export interface EventMetricsParamParts {
  */
 export interface EventMetricsIntervalParamParts {
     /**
-     * The metrics to fetch.
+     * The interval on which data will be grouped. Default value is 'DAY'.
      */
-    i?: string[];
+    i?: MetricsInterval;
 }
 
 /**

--- a/src/resources/UsageAnalytics/Read/Dimensions/Dimensions.ts
+++ b/src/resources/UsageAnalytics/Read/Dimensions/Dimensions.ts
@@ -1,4 +1,5 @@
 import {DimensionEventTypes} from '../../../Enums';
+import {ReadServiceHealthResponse, ReadServiceHealthApi, ReadServiceStatusResponse} from '../ReadServiceCommon';
 import ReadServiceResource from '../ReadServiceResource';
 import {
     CreateCustomDimensionParams,
@@ -11,7 +12,7 @@ import {
     ListUncreatedDimensionsParams,
 } from './DimensionsInterfaces';
 
-export default class Dimensions extends ReadServiceResource {
+export default class Dimensions extends ReadServiceResource implements ReadServiceHealthApi {
     static baseUrl = '/rest/ua/v15/dimensions';
 
     /**
@@ -46,20 +47,6 @@ export default class Dimensions extends ReadServiceResource {
         return this.api.get<DimensionValuesModel>(
             this.buildPathWithOrg(`${Dimensions.baseUrl}/${dimension}/values`, params)
         );
-    }
-
-    /**
-     * Get the dimensions service status.
-     */
-    getStatus() {
-        return this.api.get<Record<string, string>>(`${Dimensions.baseUrl}/status`);
-    }
-
-    /**
-     * Health check for the dimensions service.
-     */
-    checkHealth() {
-        return this.api.get<Record<string, string>>(`${Dimensions.baseUrl}/monitoring/health`);
     }
 
     /**
@@ -148,5 +135,13 @@ export default class Dimensions extends ReadServiceResource {
         return this.api.get<CustomDimensionSuggestionModel[]>(
             this.buildPathWithOrg(`${Dimensions.baseUrl}/custom/${event}/suggestions`, params)
         );
+    }
+
+    checkHealth() {
+        return this.api.get<ReadServiceHealthResponse>(`${Dimensions.baseUrl}/monitoring/health`);
+    }
+
+    checkStatus() {
+        return this.api.get<ReadServiceStatusResponse>(`${Dimensions.baseUrl}/status`);
     }
 }

--- a/src/resources/UsageAnalytics/Read/Dimensions/tests/Dimensions.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Dimensions/tests/Dimensions.spec.ts
@@ -55,24 +55,6 @@ describe('Dimensions', () => {
         });
     });
 
-    describe('getStatus', () => {
-        it('should make a GET call to the specific Dimensions url', () => {
-            dimensions.getStatus();
-
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/status`);
-        });
-    });
-
-    describe('checkHealth', () => {
-        it('should make a GET call to the specific Dimensions url', () => {
-            dimensions.checkHealth();
-
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/monitoring/health`);
-        });
-    });
-
     describe('listCustomDimensions', () => {
         it('should make a GET call to the specific Dimensions url', () => {
             dimensions.listCustomDimensions(true);
@@ -172,6 +154,24 @@ describe('Dimensions', () => {
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/custom/${event}/suggestions`);
+        });
+    });
+
+    describe('checkHealth', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            dimensions.checkHealth();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/monitoring/health`);
+        });
+    });
+
+    describe('checkStatus', () => {
+        it('should make a GET call to the specific Dimensions url', () => {
+            dimensions.checkStatus();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Dimensions.baseUrl}/status`);
         });
     });
 });

--- a/src/resources/UsageAnalytics/Read/Exports/Exports.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/Exports.ts
@@ -1,3 +1,4 @@
+import {ReadServiceHealthApi, ReadServiceHealthResponse, ReadServiceStatusResponse} from '../ReadServiceCommon';
 import ReadServiceResource from '../ReadServiceResource';
 import {
     CreateExportScheduleModel,
@@ -11,7 +12,7 @@ import {
     GenerateVisitExportParams,
 } from './ExportsInterfaces';
 
-export default class Exports extends ReadServiceResource {
+export default class Exports extends ReadServiceResource implements ReadServiceHealthApi {
     static baseUrl = '/rest/ua/v15/exports';
 
     /**
@@ -61,20 +62,6 @@ export default class Exports extends ReadServiceResource {
      */
     estimateRowsCount(params: EstimateExportParams) {
         return this.api.get<ExportEstimateModel>(this.buildPathWithOrg(`${Exports.baseUrl}/estimate`, params));
-    }
-
-    /**
-     * Get the exports service status.
-     */
-    getStatus() {
-        return this.api.get<Record<string, string>>(`${Exports.baseUrl}/status`);
-    }
-
-    /**
-     * Health check for the exports service.
-     */
-    checkHealth() {
-        return this.api.get<Record<string, string>>(`${Exports.baseUrl}/monitoring/health`);
     }
 
     /**
@@ -135,5 +122,13 @@ export default class Exports extends ReadServiceResource {
      */
     deleteSchedule(exportScheduleId: string) {
         return this.api.delete<void>(this.buildPathWithOrg(`${Exports.baseUrl}/schedules/${exportScheduleId}`));
+    }
+
+    checkHealth() {
+        return this.api.get<ReadServiceHealthResponse>(`${Exports.baseUrl}/monitoring/health`);
+    }
+
+    checkStatus() {
+        return this.api.get<ReadServiceStatusResponse>(`${Exports.baseUrl}/status`);
     }
 }

--- a/src/resources/UsageAnalytics/Read/Exports/tests/Exports.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/tests/Exports.spec.ts
@@ -87,24 +87,6 @@ describe('Exports', () => {
         });
     });
 
-    describe('getStatus', () => {
-        it('makes a GET call to the specific Exports url', () => {
-            exports.getStatus();
-
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/status`);
-        });
-    });
-
-    describe('checkHealth', () => {
-        it('makes a GET call to the specific Exports url', () => {
-            exports.checkHealth();
-
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/monitoring/health`);
-        });
-    });
-
     describe('generateVisitExport', () => {
         it('makes a POST call to the specific Exports url', () => {
             const params: GenerateVisitExportParams = {
@@ -184,6 +166,24 @@ describe('Exports', () => {
 
             expect(api.delete).toHaveBeenCalledTimes(1);
             expect(api.delete).toHaveBeenCalledWith(`${Exports.baseUrl}/schedules/${exportScheduleId}`);
+        });
+    });
+
+    describe('checkHealth', () => {
+        it('makes a GET call to the specific Exports url', () => {
+            exports.checkHealth();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/monitoring/health`);
+        });
+    });
+
+    describe('checkStatus', () => {
+        it('makes a GET call to the specific Exports url', () => {
+            exports.checkStatus();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/status`);
         });
     });
 });

--- a/src/resources/UsageAnalytics/Read/Filters/Filters.ts
+++ b/src/resources/UsageAnalytics/Read/Filters/Filters.ts
@@ -1,3 +1,4 @@
+import {ReadServiceHealthResponse, ReadServiceHealthApi, ReadServiceStatusResponse} from '../ReadServiceCommon';
 import ReadServiceResource from '../ReadServiceResource';
 import {
     CreatePermissionsFilterModel,
@@ -5,8 +6,6 @@ import {
     CreateReportingFilterModel,
     CreateReportingFilterResponse,
     FilterResponse,
-    FilterServiceHealthResponse,
-    FilterServiceStatusResponse,
     FilterTargetsModel,
     FilterTargetsResponse,
     ListFiltersResponse,
@@ -17,7 +16,7 @@ import {
     UpdateReportingFilterResponse,
 } from './FiltersInterfaces';
 
-export default class Filters extends ReadServiceResource {
+export default class Filters extends ReadServiceResource implements ReadServiceHealthApi {
     static baseUrl = '/rest/ua/v15/filters';
     static reportingBaseUrl = `${Filters.baseUrl}/reporting`;
     static permissionsBaseUrl = `${Filters.baseUrl}/permissions`;
@@ -147,17 +146,11 @@ export default class Filters extends ReadServiceResource {
         return this.api.put(this.buildPathWithOrg(`${Filters.permissionsBaseUrl}/${filterId}/targets`), targets);
     }
 
-    /**
-     * Health check for the filter service.
-     */
-    healthcheck() {
-        return this.api.get<FilterServiceHealthResponse>(`${Filters.baseUrl}/monitoring/health`);
+    checkHealth() {
+        return this.api.get<ReadServiceHealthResponse>(`${Filters.baseUrl}/monitoring/health`);
     }
 
-    /**
-     * Get the filter service status.
-     */
-    status() {
-        return this.api.get<FilterServiceStatusResponse>(`${Filters.baseUrl}/status`);
+    checkStatus() {
+        return this.api.get<ReadServiceStatusResponse>(`${Filters.baseUrl}/status`);
     }
 }

--- a/src/resources/UsageAnalytics/Read/Filters/FiltersInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Filters/FiltersInterfaces.ts
@@ -79,13 +79,3 @@ export interface FilterTargetsResponse {
     /** The groups targeted by the filter. */
     targetedGroups: GroupResponse[];
 }
-
-export interface FilterServiceHealthResponse {
-    /** The health of the service */
-    status: 'UP' | 'DOWN';
-}
-
-export interface FilterServiceStatusResponse {
-    /** The status of the service */
-    status: 'online' | 'offline';
-}

--- a/src/resources/UsageAnalytics/Read/Filters/tests/Filters.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Filters/tests/Filters.spec.ts
@@ -175,18 +175,18 @@ describe('Filters', () => {
         });
     });
 
-    describe('healthcheck', () => {
+    describe('checkHealth', () => {
         it('should make a GET call to the service healthcheck url', () => {
-            filters.healthcheck();
+            filters.checkHealth();
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Filters.baseUrl}/monitoring/health`);
         });
     });
 
-    describe('status', () => {
+    describe('checkStatus', () => {
         it('should make a GET call to the service status url', () => {
-            filters.status();
+            filters.checkStatus();
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Filters.baseUrl}/status`);

--- a/src/resources/UsageAnalytics/Read/ReadServiceCommon.ts
+++ b/src/resources/UsageAnalytics/Read/ReadServiceCommon.ts
@@ -37,3 +37,14 @@ export interface ReadServiceHealthApi {
      */
     checkStatus(): Promise<ReadServiceStatusResponse>;
 }
+
+/**
+ * Supported intervals for calls returning metrics over time.
+ */
+export enum MetricsInterval {
+    MINUTE = 'MINUTE',
+    HOUR = 'HOUR',
+    DAY = 'DAY',
+    WEEK = 'WEEK',
+    MONTH = 'MONTH',
+}

--- a/src/resources/UsageAnalytics/Read/ReadServiceCommon.ts
+++ b/src/resources/UsageAnalytics/Read/ReadServiceCommon.ts
@@ -1,0 +1,39 @@
+/**
+ * Represents the health of the service.
+ */
+export enum ReadServiceHealthEnum {
+    UP = 'up',
+    UNAVAILABLE = 'unavailable',
+    DEGRADED = 'degraded',
+}
+
+export interface ReadServiceHealthResponse {
+    /** The health status of the service. */
+    status: ReadServiceHealthEnum;
+}
+
+/**
+ * Represents the status of the service.
+ */
+export enum ReadServiceStatusEnum {
+    ONLINE = 'online',
+    UNAVAILABLE = 'unavailable',
+    DEGRADED = 'degraded',
+}
+
+export interface ReadServiceStatusResponse {
+    /** The status of the service. */
+    status: ReadServiceStatusEnum;
+}
+
+export interface ReadServiceHealthApi {
+    /**
+     * Health check for the service.
+     */
+    checkHealth(): Promise<ReadServiceHealthResponse>;
+
+    /**
+     * Get the service status.
+     */
+    checkStatus(): Promise<ReadServiceStatusResponse>;
+}

--- a/src/resources/UsageAnalytics/Read/Reports/Reports.ts
+++ b/src/resources/UsageAnalytics/Read/Reports/Reports.ts
@@ -1,4 +1,5 @@
 import {ReportType} from '../../../Enums';
+import {ReadServiceHealthApi, ReadServiceHealthResponse, ReadServiceStatusResponse} from '../ReadServiceCommon';
 import ReadServiceResource from '../ReadServiceResource';
 import {
     CreateReportModel,
@@ -12,12 +13,11 @@ import {
     ReportModel,
     TemplateResponse,
     ReportUsersResponse,
-    StatusResponse,
     TemplateMetadataResponse,
     UpdateReportModel,
 } from './ReportsInterfaces';
 
-export default class Reports extends ReadServiceResource {
+export default class Reports extends ReadServiceResource implements ReadServiceHealthApi {
     static baseUrl = '/rest/ua/v15/reports';
 
     /**
@@ -98,13 +98,6 @@ export default class Reports extends ReadServiceResource {
     }
 
     /**
-     * Health check for the reports service
-     */
-    healthcheck() {
-        return this.api.get<StatusResponse>(`${Reports.baseUrl}/monitoring/health`);
-    }
-
-    /**
      * Get a report template.
      *
      * @param templateId The unique identifier of a template.
@@ -126,10 +119,11 @@ export default class Reports extends ReadServiceResource {
         );
     }
 
-    /**
-     * Get the reports service status.
-     */
-    getServiceStatus() {
-        return this.api.get<StatusResponse>(`${Reports.baseUrl}/status`);
+    checkHealth() {
+        return this.api.get<ReadServiceHealthResponse>(`${Reports.baseUrl}/monitoring/health`);
+    }
+
+    checkStatus() {
+        return this.api.get<ReadServiceStatusResponse>(`${Reports.baseUrl}/status`);
     }
 }

--- a/src/resources/UsageAnalytics/Read/Reports/ReportsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Reports/ReportsInterfaces.ts
@@ -89,8 +89,6 @@ export interface GroupResponse extends AccountMetaModel {
     account: string;
 }
 
-export type StatusResponse = Record<string, unknown>;
-
 export interface GetReportTemplateOptions {
     /** Whether to include metadata about the report template. */
     includeMetadata?: boolean;

--- a/src/resources/UsageAnalytics/Read/Reports/tests/Reports.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Reports/tests/Reports.spec.ts
@@ -124,15 +124,6 @@ describe('Reports', () => {
         });
     });
 
-    describe('healthcheck', () => {
-        it('should make a GET call to the specific report endpoint for healthchecks', () => {
-            reports.healthcheck();
-
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Reports.baseUrl}/monitoring/health`);
-        });
-    });
-
     describe('getReportTemplate', () => {
         it('should make a GET call to the Reports base url for the specific template ID', () => {
             reports.getReportTemplate(testTemplateId);
@@ -151,9 +142,18 @@ describe('Reports', () => {
         });
     });
 
-    describe('status', () => {
+    describe('checkHealth', () => {
+        it('should make a GET call to the specific report endpoint for healthchecks', () => {
+            reports.checkHealth();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Reports.baseUrl}/monitoring/health`);
+        });
+    });
+
+    describe('checkStatus', () => {
         it('should make a GET call to the specific report endpoint for service status', () => {
-            reports.getServiceStatus();
+            reports.checkStatus();
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Reports.baseUrl}/status`);

--- a/src/resources/UsageAnalytics/Read/Statistics/Statistics.ts
+++ b/src/resources/UsageAnalytics/Read/Statistics/Statistics.ts
@@ -17,7 +17,6 @@ import {
     VisitsStatisticsModel,
     VisitsStatisticsOptions,
     VisitViewOptions,
-    DeleteQueryOptions,
 } from './StatisticsInterfaces';
 
 export default class Statistics extends ReadServiceResource implements ReadServiceHealthApi {
@@ -83,28 +82,10 @@ export default class Statistics extends ReadServiceResource implements ReadServi
     }
 
     /**
-     * Please use {@link cancelQuery} instead.
-     *
-     * @deprecated
-     */
-    delete(queryId: string, options: DeleteQueryOptions) {
-        return this.cancelQuery(queryId, options);
-    }
-
-    /**
      * Get metrics combined with dimensions for a date range.
      */
     listCombinedData(options: CombinedDataOptions) {
         return this.api.get<CombinedDataModel>(this.buildPathWithOrg(`${Statistics.baseUrl}/combinedData`, options));
-    }
-
-    /**
-     * This call no longer exists on the API, it will be removed.
-     *
-     * @deprecated
-     */
-    listTopQueries() {
-        return this.api.get<string[]>(`${Statistics.baseUrl}/topQueries`);
     }
 
     /**

--- a/src/resources/UsageAnalytics/Read/Statistics/Statistics.ts
+++ b/src/resources/UsageAnalytics/Read/Statistics/Statistics.ts
@@ -1,3 +1,4 @@
+import {ReadServiceHealthApi, ReadServiceHealthResponse, ReadServiceStatusResponse} from '../ReadServiceCommon';
 import ReadServiceResource from '../ReadServiceResource';
 import {
     CombinedDataModel,
@@ -9,8 +10,6 @@ import {
     IncoherentEventsModel,
     IncoherentEventsOptions,
     MetricsModel,
-    MonitoringHealthModel,
-    ServiceStatus,
     TrendsModel,
     TrendsOptions,
     VisitsGraphDataPointsOptions,
@@ -21,15 +20,8 @@ import {
     DeleteQueryOptions,
 } from './StatisticsInterfaces';
 
-export default class Statistics extends ReadServiceResource {
+export default class Statistics extends ReadServiceResource implements ReadServiceHealthApi {
     static baseUrl = '/rest/ua/v15/stats';
-
-    /**
-     * Get the statistics service status.
-     */
-    status() {
-        return this.api.get<ServiceStatus>(`${Statistics.baseUrl}/status`);
-    }
 
     /**
      * Get the incoherent events for a date range.
@@ -116,13 +108,6 @@ export default class Statistics extends ReadServiceResource {
     }
 
     /**
-     * Health check for the statistics service.
-     */
-    getMonitoringHealth() {
-        return this.api.get<MonitoringHealthModel>(`${Statistics.baseUrl}/monitoring/health`);
-    }
-
-    /**
      * Get the details of the visits matching the specified criteria.
      */
     listVisits(options: VisitsStatisticsOptions) {
@@ -134,5 +119,13 @@ export default class Statistics extends ReadServiceResource {
      */
     updateVisitView(options: VisitViewOptions) {
         return this.api.post(this.buildPathWithOrg(`${Statistics.baseUrl}/visits`, options));
+    }
+
+    checkHealth() {
+        return this.api.get<ReadServiceHealthResponse>(`${Statistics.baseUrl}/monitoring/health`);
+    }
+
+    checkStatus() {
+        return this.api.get<ReadServiceStatusResponse>(`${Statistics.baseUrl}/status`);
     }
 }

--- a/src/resources/UsageAnalytics/Read/Statistics/StatisticsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Statistics/StatisticsInterfaces.ts
@@ -35,10 +35,6 @@ export interface BindOnLastSearchParamPart {
     bindOnLastSearch?: boolean;
 }
 
-export interface ServiceStatus {
-    status: string;
-}
-
 export interface MetricValue {
     value: number;
 }
@@ -234,10 +230,6 @@ export interface TopQueries {
     pageSize?: number;
     pageNumber?: number;
     org: string;
-}
-
-export interface MonitoringHealthModel {
-    status: string;
 }
 
 export interface VisitsStatisticsOptions

--- a/src/resources/UsageAnalytics/Read/Statistics/StatisticsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Statistics/StatisticsInterfaces.ts
@@ -12,6 +12,8 @@ import {
     TimeZoneParamParts,
 } from '../CommonParamParts';
 
+export type MetricsResponseFormat = 'JSON' | 'CSV';
+
 export interface MetricsSortParamParts {
     /**
      * The field to order the results by.
@@ -144,7 +146,7 @@ export interface TrendsOptions
     /**
      * The format of the response. Default is JSON.
      */
-    format?: string;
+    format?: MetricsResponseFormat;
 }
 
 export interface VisitsMetricsOptions
@@ -214,7 +216,7 @@ export interface CombinedDataOptions
     /**
      * The format of the response. Default is 'JSON'.
      */
-    format?: boolean;
+    format?: MetricsResponseFormat;
 }
 
 export interface CombinedDataModel {

--- a/src/resources/UsageAnalytics/Read/Statistics/StatisticsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Statistics/StatisticsInterfaces.ts
@@ -176,8 +176,6 @@ export interface VisitsGraphDataPointsOptions
         EventDimensionsHideEventsFilterParamParts {}
 
 export interface CancelQueryOptions extends OrganizationParamParts {}
-// Alias for backwards compatibility.
-export type DeleteQueryOptions = CancelQueryOptions;
 
 export interface DataPointModel {
     dateTime: number;

--- a/src/resources/UsageAnalytics/Read/Statistics/tests/Statistics.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Statistics/tests/Statistics.spec.ts
@@ -165,14 +165,6 @@ describe('Statistics', () => {
         });
     });
 
-    describe('listTopQueries', () => {
-        it('should make a GET call to /v15/stats/topQueries with specific options', () => {
-            statistics.listTopQueries();
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Statistics.baseUrl}/topQueries`);
-        });
-    });
-
     describe('listVisits', () => {
         it('should make a GET call to /v15/stats/visits with specific options', () => {
             const options: VisitsStatisticsOptions = {

--- a/src/resources/UsageAnalytics/Read/Statistics/tests/Statistics.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Statistics/tests/Statistics.spec.ts
@@ -27,14 +27,6 @@ describe('Statistics', () => {
         statistics = new Statistics(api, serverlessApi);
     });
 
-    describe('status', () => {
-        it('should make a GET call to the Statistics status url', () => {
-            statistics.status();
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Statistics.baseUrl}/status`);
-        });
-    });
-
     describe('cancelQuery', () => {
         it('should make a DELETE call to the specific Statistics url', () => {
             const queryId = 'Jida';
@@ -44,14 +36,6 @@ describe('Statistics', () => {
             statistics.cancelQuery(queryId, options);
             expect(api.delete).toHaveBeenCalledTimes(1);
             expect(api.delete).toHaveBeenCalledWith(`${Statistics.baseUrl}/query/${queryId}?org=tuna-durgod`);
-        });
-    });
-
-    describe('get', () => {
-        it('should make a GET call to the specific Statistics url', () => {
-            statistics.getMonitoringHealth();
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Statistics.baseUrl}/monitoring/health`);
         });
     });
 
@@ -201,6 +185,22 @@ describe('Statistics', () => {
             expect(api.get).toHaveBeenCalledWith(
                 `${Statistics.baseUrl}/visits?org=yes&from=2020-05-12T00%3A00%3A00.000Z&to=2020-05-14T00%3A00%3A00.000Z`
             );
+        });
+    });
+
+    describe('checkHealth', () => {
+        it('should make a GET call to the specific Statistics url', () => {
+            statistics.checkHealth();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Statistics.baseUrl}/monitoring/health`);
+        });
+    });
+
+    describe('checkStatus', () => {
+        it('should make a GET call to the Statistics status url', () => {
+            statistics.checkStatus();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Statistics.baseUrl}/status`);
         });
     });
 });

--- a/src/resources/UsageAnalytics/Read/Users/Users.ts
+++ b/src/resources/UsageAnalytics/Read/Users/Users.ts
@@ -1,3 +1,4 @@
+import {ReadServiceHealthApi, ReadServiceHealthResponse, ReadServiceStatusResponse} from '../ReadServiceCommon';
 import ReadServiceResource from '../ReadServiceResource';
 import {
     FilterParams,
@@ -6,10 +7,9 @@ import {
     ListUsersReportsParams,
     UsersReportsModel,
     UserModel,
-    UsersStatusModel,
 } from './UsersInterfaces';
 
-export default class Users extends ReadServiceResource {
+export default class Users extends ReadServiceResource implements ReadServiceHealthApi {
     static baseUrl = '/rest/ua/v15/users';
 
     /**
@@ -49,25 +49,19 @@ export default class Users extends ReadServiceResource {
     }
 
     /**
-     * Health check for the users service.
-     */
-    getUsersServiceHealth() {
-        return this.api.get<UsersStatusModel>(`${Users.baseUrl}/monitoring/health`);
-    }
-
-    /**
-     * Get the users service status.
-     */
-    getUsersServiceStatus() {
-        return this.api.get<UsersStatusModel>(`${Users.baseUrl}/status`);
-    }
-
-    /**
      * Get a user.
      *
      * @param userId The unique identifier of a user.
      */
     getUser(userId: string) {
         return this.api.get<UserModel>(this.buildPathWithOrg(`${Users.baseUrl}/${userId}`));
+    }
+
+    checkHealth() {
+        return this.api.get<ReadServiceHealthResponse>(`${Users.baseUrl}/monitoring/health`);
+    }
+
+    checkStatus() {
+        return this.api.get<ReadServiceStatusResponse>(`${Users.baseUrl}/status`);
     }
 }

--- a/src/resources/UsageAnalytics/Read/Users/UsersInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Users/UsersInterfaces.ts
@@ -68,13 +68,6 @@ export interface UsersReportsModel {
     reports: UsersReportModel[];
 }
 
-export interface UsersStatusModel {
-    /**
-     * Service's status information
-     */
-    status: string;
-}
-
 export interface UserModel {
     /**
      * The user id

--- a/src/resources/UsageAnalytics/Read/Users/tests/Users.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Users/tests/Users.spec.ts
@@ -66,28 +66,28 @@ describe('Statistics', () => {
         });
     });
 
-    describe('getUsersServiceHealth', () => {
-        it('should make a GET call to /v15/users/monitoring/health', () => {
-            users.getUsersServiceHealth();
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Users.baseUrl}/monitoring/health`);
-        });
-    });
-
-    describe('getUsersServiceStatus', () => {
-        it('should make a GET call to /v15/users/status with specific options', () => {
-            users.getUsersServiceStatus();
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Users.baseUrl}/status`);
-        });
-    });
-
     describe('getUser', () => {
         it('should make a GET call to /v15/users/:userId', () => {
             const userId = 'Jida';
             users.getUser(userId);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Users.baseUrl}/${userId}`);
+        });
+    });
+
+    describe('checkHealth', () => {
+        it('should make a GET call to /v15/users/monitoring/health', () => {
+            users.checkHealth();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Users.baseUrl}/monitoring/health`);
+        });
+    });
+
+    describe('checkStatus', () => {
+        it('should make a GET call to /v15/users/status with specific options', () => {
+            users.checkStatus();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Users.baseUrl}/status`);
         });
     });
 });

--- a/src/resources/UsageAnalytics/Read/index.ts
+++ b/src/resources/UsageAnalytics/Read/index.ts
@@ -8,4 +8,5 @@ export * from './Snowflake';
 export * from './Statistics';
 export * from './Users';
 
+export * from './ReadServiceCommon';
 export * from './ReadServiceResource';


### PR DESCRIPTION
This is basically a continuation of what I started in #581, but these are the breaking changes I took note of during my pass over the existing resources:
  - Rename most health and status check calls, change return types of all. I created an interface to enforce the calls to be aligned, and re-use the doc.
    _I realize it makes the diff a bit more annoying, but I also moved the health and status check to the end of each resource, putting them in that order. (Same for the test files)._
  - Remove the `setRedshiftStatus` method (that is not on the back-end service anymore)
  - Fix some various minor mis-typing
  - Remove deprecated methods from the Statistics API.

Of course, any of these changes may lead integrators to have type conflicts/missing method calls. I manually tested a built version of this in admin UI, and admin UI doesn't seem to require any updates.

~Question: it seems a bit soon, but should I remove the `delete` method I deprecated in #581? Since these changes should lead to a new major version…~ Applied after feedback from Louis.

### Acceptance Criteria

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
  _Not Applicable_
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
