### PR TITLE
feat(maestro): support empty crawling module log requests

### DIFF
--- a/src/resources/CrawlingModule/CrawlingModuleInterfaces.ts
+++ b/src/resources/CrawlingModule/CrawlingModuleInterfaces.ts
@@ -130,6 +130,7 @@ export enum CrawlingModuleLogRequestState {
     RUNNING = 'RUNNING',
     SUCCESSFUL = 'SUCCESSFUL',
     TIMEOUT = 'TIMEOUT',
+    EMPTY = 'EMPTY',
 }
 
 export interface CrawlingModuleLogRequestModel {


### PR DESCRIPTION
[CTINFRA-3117]

A new possible state for Crawling Module Log Requests should be supported, EMPTY. This is a log request that *was* processed, but no log was found for it locally.

![image](https://user-images.githubusercontent.com/13049746/206513093-f7249a51-eb56-41c6-900a-693cef0fcc55.png)

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[CTINFRA-3117]: https://coveord.atlassian.net/browse/CTINFRA-3117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ