### PR TITLE
Ua 6254 fix dimensions suggestions call

### DIFF
--- a/src/resources/UsageAnalytics/Read/Dimensions/Dimensions.ts
+++ b/src/resources/UsageAnalytics/Read/Dimensions/Dimensions.ts
@@ -3,7 +3,7 @@ import ReadServiceResource from '../ReadServiceResource';
 import {
     CreateCustomDimensionParams,
     CustomDimensionModel,
-    CustomDimensionSuggestionModel,
+    CustomDimensionSuggestionsModel,
     DimensionModel,
     DimensionValuesModel,
     GetDimensionValuesParams,
@@ -145,8 +145,11 @@ export default class Dimensions extends ReadServiceResource {
      * @param event The type of event for which to look for suggestions.
      */
     listUncreatedDimensions(event: DimensionEventTypes, params?: ListUncreatedDimensionsParams) {
-        return this.api.get<CustomDimensionSuggestionModel[]>(
-            this.buildPathWithOrg(`${Dimensions.baseUrl}/custom/${event}/suggestions`, params)
+        return this.api.get<CustomDimensionSuggestionsModel>(
+            this.buildPath(`${Dimensions.baseUrl}/custom/${event}/suggestions`, {
+                ...params,
+                org: this.api.organizationId,
+            })
         );
     }
 }

--- a/src/resources/UsageAnalytics/Read/Dimensions/DimensionsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Dimensions/DimensionsInterfaces.ts
@@ -50,6 +50,9 @@ export interface DimensionValuesModel {
     values: Array<Record<string, string | number>>;
 }
 
+export interface CustomDimensionSuggestionsModel {
+    suggestions: CustomDimensionSuggestionModel[];
+}
 export interface CustomDimensionSuggestionModel {
     eventName?: string;
     apiName?: string;

--- a/src/resources/UsageAnalytics/Read/Dimensions/DimensionsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Dimensions/DimensionsInterfaces.ts
@@ -51,11 +51,23 @@ export interface DimensionValuesModel {
 }
 
 export interface CustomDimensionSuggestionsModel {
+    /**
+     * Suggestions of custom dimensions that could be created
+     */
     suggestions: CustomDimensionSuggestionModel[];
 }
 export interface CustomDimensionSuggestionModel {
+    /**
+     * The event type of the custom dimension
+     */
     eventName?: string;
+    /**
+     * The api name of the custom dimension
+     */
     apiName?: string;
+    /**
+     * The existing values for the custom dimension
+     */
     values?: string[];
 }
 


### PR DESCRIPTION
The listUncreatedDimension was not returning the right data format (it was missing the suggestions layer)
```
suggestions: subObject[] <--- tight now it's only returning subObject[] from the call
```
So I've added the layer with `suggestions` so we can use this call with the api name autocomplete feature

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
