### PR TITLE
feat: support CJS and ESM

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ jest.config.js
 commitlint.config.js
 .eslintrc.js
 webpack.config.js
+scripts

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,4 +1,4 @@
-const unmockedDependencies = ['query-string', 'decode-uri-component', 'split-on-first', 'filter-obj'];
+const unmockedDependencies = ['query-string-esm', 'decode-uri-component', 'split-on-first', 'filter-obj'];
 
 // /*
 //  * For a detailed explanation regarding each configuration property, visit:
@@ -19,6 +19,7 @@ export default {
             preset: 'ts-jest/presets/default-esm',
             moduleNameMapper: {
                 '^(\\.{1,2}/.*)\\.js$': '$1',
+                '^#query-string': 'query-string-esm',
             },
             globals: {'ts-jest': {tsconfig: '<rootDir>/../tsconfig.test.json', useESM: true}},
             transform: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "exponential-backoff": "^3.1.0",
-                "query-string": "^8.0.0"
+                "query-string-cjs": "npm:query-string@^7.0.0",
+                "query-string-esm": "npm:query-string@^8.0.0"
             },
             "devDependencies": {
                 "@commitlint/cli": "17.4.1",
@@ -13071,7 +13072,50 @@
                 "teleport": ">=0.2.0"
             }
         },
-        "node_modules/query-string": {
+        "node_modules/query-string-cjs": {
+            "name": "query-string",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+            "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+            "dependencies": {
+                "decode-uri-component": "^0.2.2",
+                "filter-obj": "^1.1.0",
+                "split-on-first": "^1.0.0",
+                "strict-uri-encode": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/query-string-cjs/node_modules/decode-uri-component": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/query-string-cjs/node_modules/filter-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+            "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/query-string-cjs/node_modules/split-on-first": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+            "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/query-string-esm": {
+            "name": "query-string",
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/query-string/-/query-string-8.1.0.tgz",
             "integrity": "sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==",
@@ -14885,6 +14929,14 @@
             "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/strict-uri-encode": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+            "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,16 @@
     "name": "@coveo/platform-client",
     "version": "0.0.0-development",
     "description": "",
-    "main": "dist/Entry.js",
     "type": "module",
+    "exports": {
+        ".": {
+            "types": "./dist/definitions/Entry.d.ts",
+            "import": "./dist/esm/Entry.js",
+            "require": "./dist/cjs/Entry.js"
+        }
+    },
     "types": "dist/definitions/Entry.d.ts",
+    "main": "dist/cjs/Entry.js",
     "keywords": [
         "coveo",
         "api",
@@ -14,8 +21,8 @@
         "web"
     ],
     "scripts": {
-        "start": "tsc -p tsconfig.build.json --watch",
-        "build": "eslint \"src/**.*\" --ignore-pattern '**/*.spec.*' --color && tsc -p tsconfig.build.json",
+        "start": "tsc -p tsconfig.build.esm.json --watch",
+        "build": "eslint \"src/**.*\" --ignore-pattern '**/*.spec.*' --color && tsc -p tsconfig.build.cjs.json && tsc -p tsconfig.build.esm.json && node scripts/dualOutputCompat.js",
         "test": "jest --clearCache && jest",
         "test:changed": "jest --watch",
         "test:watch": "jest --watchAll",
@@ -74,9 +81,16 @@
             "path": "./node_modules/cz-conventional-changelog"
         }
     },
+    "imports": {
+        "#query-string": {
+            "import": "query-string-esm",
+            "require": "query-string-cjs"
+        }
+    },
     "dependencies": {
         "exponential-backoff": "^3.1.0",
-        "query-string": "^8.0.0"
+        "query-string-esm": "npm:query-string@^8.0.0",
+        "query-string-cjs": "npm:query-string@^7.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
     "type": "module",
     "exports": {
         ".": {
-            "types": "./dist/definitions/Entry.d.ts",
+            "types": "./dist/types/Entry.d.ts",
             "import": "./dist/esm/Entry.js",
             "require": "./dist/cjs/Entry.js"
         }
     },
-    "types": "dist/definitions/Entry.d.ts",
+    "types": "dist/types/Entry.d.ts",
     "main": "dist/cjs/Entry.js",
     "keywords": [
         "coveo",

--- a/scripts/dualOutputCompat.js
+++ b/scripts/dualOutputCompat.js
@@ -1,0 +1,23 @@
+import {readFileSync, writeFileSync} from 'node:fs';
+
+// Ensure NodeJS resolves dist/cjs/**/*.js as dist/cjs/**/*.cjs
+writeFileSync(
+    'dist/cjs/package.json',
+    JSON.stringify({
+        type: 'commonjs',
+    })
+);
+
+// Ensure NodeJS resolves dist/esm/**/*.js as dist/esm/**/*.mjs
+writeFileSync(
+    'dist/esm/package.json',
+    JSON.stringify({
+        type: 'module',
+    })
+);
+
+// Replace #query-string by the proper query-string version.
+const cjsPath = 'dist/cjs/resources/Resource.js';
+writeFileSync(cjsPath, readFileSync(cjsPath, 'utf-8').replaceAll(/#query-string/gm, 'query-string-cjs'));
+const esmPath = 'dist/esm/resources/Resource.js';
+writeFileSync(esmPath, readFileSync(esmPath, 'utf-8').replaceAll(/#query-string/gm, 'query-string-esm'));

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -1,6 +1,5 @@
-import queryString from 'query-string';
-
 import API from '../APICore.js';
+import queryString from '#query-string';
 
 class Resource {
     static baseUrl: string;

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig",
+    "include": ["src/*"],
+    "exclude": ["node_modules"],
+    "compilerOptions": {
+        "module": "CommonJS",
+        "outDir": "dist/cjs"
+    }
+}

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig",
+    "include": ["src/*"],
+    "exclude": ["node_modules"],
+    "compilerOptions": {
+        "outDir": "dist/esm"
+    }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,0 @@
-{
-    "extends": "./tsconfig",
-    "include": ["src/*"],
-    "exclude": ["node_modules"]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
         "sourceMap": true,
         "declaration": true,
         "target": "ESNext",
-        "declarationDir": "dist/definitions",
+        "declarationDir": "dist/types",
         "lib": ["DOM", "ESNext"],
         "moduleResolution": "Node16",
         "importHelpers": true,


### PR DESCRIPTION
Reestablish support for CJS.
⚠️this is a temporary fix, ESM only is inevitable⚠️ 

Users can shift from CJS to ESM and vice-versa without changing anything in their code.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
