### PR TITLE
chore(renovate): block query-string-cjs updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,10 @@
             "groupName": "all dependencies",
             "groupSlug": "all"
         }
+        {   "matchPackageNames": ["query-string-cjs"]
+            "allowedVersions": "7.x"
+            "description": "8.x and above are ESM only. Remove this when we stop CJS support"
+        }
     ],
     "rangeStrategy": "auto",
     "lockFileMaintenance": {


### PR DESCRIPTION
We don't want `query-string-cjs` to update.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
