### PR TITLE
feat(metadata): rename frequency property for count in Metadata interface

### DIFF
--- a/src/resources/Sources/SourcesMetadata/SourcesMetadataInterfaces.ts
+++ b/src/resources/Sources/SourcesMetadata/SourcesMetadataInterfaces.ts
@@ -14,7 +14,7 @@ export interface MetadataValue {
      */
     metadataValue: any;
     /**
-     * The number of time the value has been seen on documents
+     * The number of times the value has been seen on documents
      */
     count: number;
 }
@@ -25,9 +25,9 @@ export interface Metadata {
      */
     key: string;
     /**
-     * The frequency in % at which this metadata has been seen on documents.
+     * The number of times the metadata has been seen in the sampled items.
      */
-    frequency: number;
+    count: number;
     /**
      * Subset of sample values for the metadata.
      */


### PR DESCRIPTION
* Renamed `frequency` property of the interface `Metadata` with `count`.

Items of type `Metadata` seem to contain a `count` property instead of `frequency`.

Result when testing the API:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/105073504/213726747-3ebb3c31-418e-40bf-9ad4-9bec0926b32f.png">

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
