### PR TITLE
feat(metadata): add indexedBy for Metadata interface

### DIFF
--- a/src/resources/Sources/SourcesMetadata/SourcesMetadataInterfaces.ts
+++ b/src/resources/Sources/SourcesMetadata/SourcesMetadataInterfaces.ts
@@ -1,5 +1,11 @@
 import {PageModel} from '../../BaseInterfaces.js';
 
+export enum MetadataIndexedBy {
+    NONE = 'NONE',
+    FIELD = 'FIELD',
+    MAPPING = 'MAPPING',
+}
+
 export interface MetadataPageModel extends PageModel {
     items: Metadata[];
     creationDate: number;
@@ -40,6 +46,10 @@ export interface Metadata {
      * Whether the origin is mapped or not.
      */
     isMapped: boolean;
+    /**
+     * Where is the metadata indexed
+     */
+    indexedBy: MetadataIndexedBy;
 }
 
 export interface MetadataReportStatus {

--- a/src/resources/Sources/SourcesMetadata/SourcesMetadataInterfaces.ts
+++ b/src/resources/Sources/SourcesMetadata/SourcesMetadataInterfaces.ts
@@ -47,7 +47,7 @@ export interface Metadata {
      */
     isMapped: boolean;
     /**
-     * Where is the metadata indexed
+     * How is the metadata indexed
      */
     indexedBy: MetadataIndexedBy;
 }


### PR DESCRIPTION
# [DISCO-9](https://coveord.atlassian.net/browse/DISCO-9):rocket:

Add `indexedBy` for the Metadata interface

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[DISCO-9]: https://coveord.atlassian.net/browse/DISCO-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ