### PR TITLE
fix: add buttonTargetSelector field

### DIFF
--- a/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
+++ b/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
@@ -375,7 +375,7 @@ export interface IPXButtonModel {
         verticalPosition: ButtonPositionVerticalResponseModel;
     };
     /**
-     * The button's css selector, which defines where the button is rendered.
+     * The button's CSS selector, which defines where the button is rendered.
      * If unset, it defaults to "" and renders outside of any other element.
      */
     buttonTargetSelector: string;

--- a/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
+++ b/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
@@ -374,5 +374,9 @@ export interface IPXButtonModel {
          */
         verticalPosition: ButtonPositionVerticalResponseModel;
     };
+    /**
+     * The button's css selector, which defines where the button is rendered.
+     * If unset, it defaults to "" and renders outside of any other element.
+     */
     buttonTargetSelector: string;
 }

--- a/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
+++ b/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
@@ -375,8 +375,8 @@ export interface IPXButtonModel {
         verticalPosition: ButtonPositionVerticalResponseModel;
     };
     /**
-     * The button's CSS selector, which defines where the button is rendered.
-     * If unset, it defaults to "" and renders outside of any other element.
+     * The button host's CSS selector, which defines where the button is rendered.
+     * If unset, it defaults to "" and renders a floating button in the `<body>`.
      * @default `""`
     */
     buttonTargetSelector: string;

--- a/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
+++ b/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
@@ -374,4 +374,5 @@ export interface IPXButtonModel {
          */
         verticalPosition: ButtonPositionVerticalResponseModel;
     };
+    buttonTargetSelector: string;
 }

--- a/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
+++ b/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
@@ -377,6 +377,7 @@ export interface IPXButtonModel {
     /**
      * The button's CSS selector, which defines where the button is rendered.
      * If unset, it defaults to "" and renders outside of any other element.
-     */
+     * @default `""`
+    */
     buttonTargetSelector: string;
 }


### PR DESCRIPTION
[SVCINT-2087](https://coveord.atlassian.net/browse/SVCINT-2087)

This field was always present, but never defined in the interface.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[SVCINT-2087]: https://coveord.atlassian.net/browse/SVCINT-2087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ