### PR TITLE
fix(crawling-module): typo in logRequestsEnable for CrawlingModuleStatus interface

### DIFF
--- a/src/resources/CrawlingModule/CrawlingModuleInterfaces.ts
+++ b/src/resources/CrawlingModule/CrawlingModuleInterfaces.ts
@@ -17,7 +17,7 @@ export interface CrawlingModuleStatus {
      * Whether remote log requests are enabled or not.
      * This enables the client to query logs directly from the platform.
      */
-    logRequestEnable: boolean;
+    logRequestsEnable: boolean;
     /**
      * Frequency at which the setup polls for updates.
      */


### PR DESCRIPTION

[CTINFRA-3207]
 typo in logRequestsEnable for CrawlingModuleStatus interface
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[CTINFRA-3207]: https://coveord.atlassian.net/browse/CTINFRA-3207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ