### PR TITLE
fix(platform): add Canada support to platform-client

### DIFF
--- a/src/Endpoints.ts
+++ b/src/Endpoints.ts
@@ -4,6 +4,7 @@ export enum Region {
     US = 'us',
     EU = 'eu',
     AU = 'au',
+    CA = 'ca',
 }
 
 export enum Environment {

--- a/src/tests/Endpoint.spec.ts
+++ b/src/tests/Endpoint.spec.ts
@@ -22,6 +22,7 @@ describe('Endpoint', () => {
             it('should return the endpoint corresponding to each specified environment and region', () => {
                 expect(getEndpoint(env, Region.EU)).toBe(`https://${host}-eu.cloud.coveo.com`);
                 expect(getEndpoint(env, Region.AU)).toBe(`https://${host}-au.cloud.coveo.com`);
+                expect(getEndpoint(env, Region.CA)).toBe(`https://${host}-ca.cloud.coveo.com`);
             });
         });
 
@@ -34,6 +35,7 @@ describe('Endpoint', () => {
                 expect(getEndpoint(Environment.hipaa, Region.US)).toBe('https://platformhipaa.cloud.coveo.com');
                 expect(getEndpoint(Environment.hipaa, Region.EU)).toBe('https://platformhipaa.cloud.coveo.com');
                 expect(getEndpoint(Environment.hipaa, Region.AU)).toBe('https://platformhipaa.cloud.coveo.com');
+                expect(getEndpoint(Environment.hipaa, Region.CA)).toBe('https://platformhipaa.cloud.coveo.com');
             });
         });
     });
@@ -55,6 +57,7 @@ describe('Endpoint', () => {
             it('should return the endpoint corresponding to each specified environment and region', () => {
                 expect(getEndpoint(Environment.dev, Region.EU, true)).toBe('https://apidev-eu.cloud.coveo.com');
                 expect(getEndpoint(Environment.dev, Region.AU, true)).toBe('https://apidev-au.cloud.coveo.com');
+                expect(getEndpoint(Environment.dev, Region.CA, true)).toBe('https://apidev-ca.cloud.coveo.com');
             });
         });
 
@@ -70,6 +73,7 @@ describe('Endpoint', () => {
             it('should return the endpoint corresponding to each specified environment and region', () => {
                 expect(getEndpoint(Environment.prod, Region.EU, true)).toBe('https://api-eu.cloud.coveo.com');
                 expect(getEndpoint(Environment.prod, Region.AU, true)).toBe('https://api-au.cloud.coveo.com');
+                expect(getEndpoint(Environment.prod, Region.CA, true)).toBe('https://api-ca.cloud.coveo.com');
             });
         });
 
@@ -82,6 +86,7 @@ describe('Endpoint', () => {
                 expect(getEndpoint(Environment.hipaa, Region.US, true)).toBe('https://apihipaa.cloud.coveo.com');
                 expect(getEndpoint(Environment.hipaa, Region.EU, true)).toBe('https://apihipaa.cloud.coveo.com');
                 expect(getEndpoint(Environment.hipaa, Region.AU, true)).toBe('https://apihipaa.cloud.coveo.com');
+                expect(getEndpoint(Environment.hipaa, Region.CA, true)).toBe('https://apihipaa.cloud.coveo.com');
             });
         });
     });


### PR DESCRIPTION
Adds canada region to Endpoints.ts, in order to support the region in the Admin UI.

[CTINFRA-3203]

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[CTINFRA-3203]: https://coveord.atlassian.net/browse/CTINFRA-3203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ