### PR TITLE
[CTCORE-9017] fix(Privilege): fix wrong access model interface definition

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -13,10 +13,7 @@ export enum PrivilegeHolderType {
 /**
  * @deprecated use `PrivilegeHolderType` instead.
  */
-export enum PrivilegeholderType {
-    API_KEY = 'API_KEY',
-    GROUP = 'GROUP',
-}
+export type PrivilegeholderType = PrivilegeHolderType;
 
 export enum AuthProvider {
     SALESFORCE = 'SALESFORCE',

--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -5,7 +5,7 @@ export enum AccessLevel {
     NONE = 'NONE',
 }
 
-export enum PrivilegeholderType {
+export enum PrivilegeHolderType {
     API_KEY = 'API_KEY',
     GROUP = 'GROUP',
 }

--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -10,6 +10,14 @@ export enum PrivilegeHolderType {
     GROUP = 'GROUP',
 }
 
+/**
+ * @deprecated use `PrivilegeHolderType` instead.
+ */
+export enum PrivilegeholderType {
+    API_KEY = 'API_KEY',
+    GROUP = 'GROUP',
+}
+
 export enum AuthProvider {
     SALESFORCE = 'SALESFORCE',
     SALESFORCE_SANDBOX = 'SALESFORCE_SANDBOX',

--- a/src/resources/OrganizationAccess/AccessInterfaces.ts
+++ b/src/resources/OrganizationAccess/AccessInterfaces.ts
@@ -23,7 +23,7 @@ export interface AccessParams {
 
 export type GroupAccessModel = {
     /*
-     * The access level granted by the access model.
+     * The access level granted by this group.
      */
     accessLevel: AccessLevel;
     /*
@@ -31,7 +31,7 @@ export type GroupAccessModel = {
      */
     callerPartOf: boolean;
     /*
-     * The display name of the group.
+     * The display name of this group.
      */
     displayName: string;
     /*
@@ -43,34 +43,34 @@ export type GroupAccessModel = {
      */
     privilegeHolderType: PrivilegeHolderType.GROUP;
     /*
-     * The list of resources ids this access model has edit access level on.
+     * The list of resources ids this group has edit access level on.
      */
     resourceIdsWithEditLevel?: string[];
 };
 
 export type ApiKeyAccessModel = {
     /*
-     * The access level granted by the access model.
+     * The access level granted by this API key.
      */
     accessLevel: AccessLevel;
     /*
-     * The creation date of the api key.
+     * The creation date of this API key.
      */
     createdDate: string;
     /*
-     * The display name of the api key.
+     * The display name of this API key.
      */
     displayName: string;
     /*
-     * The id of the api key.
+     * The id of this API key.
      */
     id: string;
     /*
-     * Represent the api key access model type.
+     * Represent the API key access model type.
      */
     privilegeHolderType: PrivilegeHolderType.API_KEY;
     /*
-     * The list of resources ids this access model has edit access level on.
+     * The list of resources ids this API key has edit access level on.
      */
     resourceIdsWithEditLevel?: string[];
 };

--- a/src/resources/OrganizationAccess/AccessInterfaces.ts
+++ b/src/resources/OrganizationAccess/AccessInterfaces.ts
@@ -1,4 +1,4 @@
-import {AccessLevel, PrivilegeholderType} from '../Enums.js';
+import {AccessLevel, PrivilegeHolderType} from '../Enums.js';
 export interface AccessParams {
     /*
      * The access level an API key must have to be included in the response.
@@ -22,9 +22,32 @@ export interface AccessParams {
 }
 
 export interface AccessModel {
-    accessLevel: AccessLevel[];
-    callerPartOf: boolean;
+    /*
+     * The access level for this privilege.
+     */
+    accessLevel: AccessLevel;
+    /*
+     * Whether the calling user is part of this group.
+     */
+    callerPartOf?: boolean;
+    /*
+     * The creation date of this privilege.
+     */
+    createdDate?: string;
+    /*
+     * The display name of this privilege.
+     */
     displayName: string;
+    /*
+     * The id of this privilege.
+     */
     id: string;
-    privilegeholderType: PrivilegeholderType;
+    /*
+     * The type of this privilege.
+     */
+    privilegeHolderType: PrivilegeHolderType;
+    /*
+     * The list of sources id this privilege is applied to.
+     */
+    resourceIdsWithEditLevel?: string[];
 }

--- a/src/resources/OrganizationAccess/AccessInterfaces.ts
+++ b/src/resources/OrganizationAccess/AccessInterfaces.ts
@@ -21,33 +21,58 @@ export interface AccessParams {
     privilegeTargetDomain: string;
 }
 
-export interface AccessModel {
+export type GroupAccessModel = {
     /*
-     * The access level for this privilege.
+     * The access level granted by the access model.
      */
     accessLevel: AccessLevel;
     /*
      * Whether the calling user is part of this group.
      */
-    callerPartOf?: boolean;
+    callerPartOf: boolean;
     /*
-     * The creation date of this privilege.
-     */
-    createdDate?: string;
-    /*
-     * The display name of this privilege.
+     * The display name of the group.
      */
     displayName: string;
     /*
-     * The id of this privilege.
+     * The id of the group.
      */
     id: string;
     /*
-     * The type of this privilege.
+     * Represent the group access model type.
      */
-    privilegeHolderType: PrivilegeHolderType;
+    privilegeHolderType: PrivilegeHolderType.GROUP;
     /*
-     * The list of sources id this privilege is applied to.
+     * The list of resources ids this access model has edit access level on.
      */
     resourceIdsWithEditLevel?: string[];
-}
+};
+
+export type ApiKeyAccessModel = {
+    /*
+     * The access level granted by the access model.
+     */
+    accessLevel: AccessLevel;
+    /*
+     * The creation date of the api key.
+     */
+    createdDate: string;
+    /*
+     * The display name of the api key.
+     */
+    displayName: string;
+    /*
+     * The id of the api key.
+     */
+    id: string;
+    /*
+     * Represent the api key access model type.
+     */
+    privilegeHolderType: PrivilegeHolderType.API_KEY;
+    /*
+     * The list of resources ids this access model has edit access level on.
+     */
+    resourceIdsWithEditLevel?: string[];
+};
+
+export type AccessModel = GroupAccessModel | ApiKeyAccessModel;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CTCORE-9017


BREAKING CHANGE: Adjusted wrong AccessModel interface

* fix: PrivilegeholderType enum got renamed to PrivilegeHolderType

* fix: the AccessLevel property is not an array anymore

* fix: added missing properties to the AccessModel interface

The AdminUi repo is adjusted to match this PR. I'll update the platformClient dependency once this PR is merged and create the PR to fix this in the AdminUi.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
