### PR TITLE
refactor(extensions): correct validateScript's return type

### DIFF
--- a/src/resources/Extensions/Extensions.ts
+++ b/src/resources/Extensions/Extensions.ts
@@ -1,6 +1,6 @@
 import API from '../../APICore.js';
 import Resource from '../Resource.js';
-import {CreateExtension, ExtensionCompileCode, ExtensionModel} from './ExtensionsInterfaces.js';
+import {CreateExtension, ExtensionCompileCode, ExtensionCompileResult, ExtensionModel} from './ExtensionsInterfaces.js';
 
 export default class Extension extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/extensions`;
@@ -39,6 +39,6 @@ export default class Extension extends Resource {
      * @param {ExtensionCompileCode} extensionCode The code to compile
      */
     validateCode(extensionCode: ExtensionCompileCode) {
-        return this.api.post<ExtensionCompileCode>(`${Extension.baseUrl}/test/compile`, extensionCode);
+        return this.api.post<ExtensionCompileResult>(`${Extension.baseUrl}/test/compile`, extensionCode);
     }
 }


### PR DESCRIPTION
# [CI-265](https://coveord.atlassian.net/browse/CI-265)

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->
I added the `validateScript` call in this previous [PR](https://github.com/coveo/platform-client/pull/627) but made a mistake when precising its return value.

* Corrected the `validateScript` call's return type from `ExtensionCompileCode` to `ExtensionCompileResult` (see [Swagger](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Extension#/Indexing%20Pipeline%20Extensions/rest_organizations_paramId_extensions_test_compile_post)).


### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[CI-265]: https://coveord.atlassian.net/browse/CI-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ