### PR TITLE
refactor(catalogs): add configuration to create catalog model

### DIFF
--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -53,7 +53,7 @@ export interface CreateCatalogConfigurationModel {
     /**
      * The configuration mapping of index fields to standard commerce fields
      */
-    fieldsMapping: CatalogFieldsMapping;
+    fieldsMapping?: CatalogFieldsMapping;
 }
 
 export interface CatalogConfigurationModel {
@@ -80,11 +80,11 @@ export interface CatalogConfigurationModel {
     /**
      * The configuration mapping of index fields to standard commerce fields
      */
-    fieldsMapping: CatalogFieldsMapping;
+    fieldsMapping?: CatalogFieldsMapping;
     /**
      * Catalogs associated to the configuration
      */
-    associatedCatalogs: IAssociatedCatalogModel[];
+    associatedCatalogs?: IAssociatedCatalogModel[];
 }
 
 export interface IAssociatedCatalogModel {
@@ -203,16 +203,48 @@ export interface CatalogModel extends BaseCatalogModel {
 export type CreateCatalogModel = BaseCatalogModel &
     (
         | {
+              /**
+               * @deprecated use `configuration.product` instead.
+               */
               product?: CreateProductHierarchyModel;
+              /**
+               * @deprecated use `configuration.variant` instead.
+               */
               variant?: CreateVariantHierarchyModel;
+              /**
+               * @deprecated use `configuration.availability` instead.
+               */
               availability?: CreateAvailabilityHierarchyModel;
+              /**
+               * The related catalog configuration id
+               */
               catalogConfigurationId?: never;
+              /**
+               * The catalog configuration
+               */
+              configuration: CreateCatalogConfigurationModel;
           }
         | {
+              /**
+               * @deprecated use `configuration.product` instead.
+               */
               product?: never;
+              /**
+               * @deprecated use `configuration.variant` instead.
+               */
               variant?: never;
+              /**
+               * @deprecated use `configuration.availability` instead.
+               */
               availability?: never;
+              /**
+               * The related catalog configuration id
+               */
               catalogConfigurationId: string;
+              /**
+               * The catalog configuration
+               */
+              configuration?: never;
           }
     );
 

--- a/src/resources/Catalogs/tests/Catalog.spec.ts
+++ b/src/resources/Catalogs/tests/Catalog.spec.ts
@@ -40,9 +40,13 @@ describe('Catalog', () => {
         it('should be backward compatible with the legacy structure', () => {
             const catalogModel: New<CreateCatalogModel> = {
                 name: 'New catalog',
-                product: {
-                    idField: '@uri',
-                    objectType: 'product',
+                configuration: {
+                    id: 'configuration-to-update-id',
+                    name: 'New configuration',
+                    product: {
+                        idField: '@uri',
+                        objectType: 'product',
+                    },
                 },
             };
 
@@ -134,9 +138,13 @@ describe('Catalog', () => {
             const catalogModel: CreateCatalogModel = {
                 id: 'catalog-to-update-id',
                 name: 'Catalog to be updated',
-                product: {
-                    idField: '@uri',
-                    objectType: 'product',
+                configuration: {
+                    id: 'configuration-to-update-id',
+                    name: 'Configuration',
+                    product: {
+                        idField: '@uri',
+                        objectType: 'product',
+                    },
                 },
             };
 


### PR DESCRIPTION
Update interfaces to follow recent swagger changes [COMSDZ-300](https://coveord.atlassian.net/browse/COMSDZ-300)
- make some parameters optional on the [CatalogConfiguration](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Catalog#/Catalog%20Configurations/rest_organizations_paramId_catalogconfigurations_paramId_get:~:text=CatalogConfigurationModelWithAssociatedCatalogs,CatalogConfigurationModelWithAssociatedCatalogs)
- add configuration to the [CreateCatalogModel](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Catalog#/Catalogs/rest_organizations_paramId_catalogs_post:~:text=CreateCatalogModelReq,CreateCatalogModelReq) and add a deprecated note to the other parameters 

### Acceptance Criteria
-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[COMSDZ-300]: https://coveord.atlassian.net/browse/COMSDZ-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ