### PR TITLE
feat(limits): add call to retrieve a specific limit status

### DIFF
--- a/src/resources/Limits/Limits.ts
+++ b/src/resources/Limits/Limits.ts
@@ -7,6 +7,7 @@ import {
     LimitHistoryOptions,
     LimitsModel,
     LimitType,
+    LimitModel,
 } from './LimitsInterfaces.js';
 
 export default class Limits extends Resource {
@@ -14,6 +15,8 @@ export default class Limits extends Resource {
     static getWithSection = (sectionName: LicenseSection) => `${Limits.getBaseUrl()}/${sectionName}`;
     static getWithSectionAndHistory = (sectionName: LicenseSection, limitKey: string) =>
         `${Limits.getWithSection(sectionName)}/${limitKey}/history`;
+    static getSpecificLimit = (sectionName: LicenseSection, limitKey: string) =>
+        `${Limits.getWithSection(sectionName)}/${limitKey}`;
 
     get(sectionName: LicenseSection) {
         return this.api.get<LimitsModel>(Limits.getWithSection(sectionName));
@@ -25,6 +28,16 @@ export default class Limits extends Resource {
 
     getAllPerLimitType(limitType: LimitType) {
         return this.api.get<AllLimitsModel>(this.buildPath(Limits.getBaseUrl(), {limitType: limitType}));
+    }
+
+    /**
+     * Shows the status of a specific limit in an organization
+     *
+     * @param sectionName The name of the target license section
+     * @param limitKey The unique identifier of the target limit status to show
+     */
+    getSpecificLimitStatus(sectionName: LicenseSection, limitKey: string) {
+        return this.api.get<LimitModel>(`${Limits.getSpecificLimit(sectionName, limitKey)}`);
     }
 
     getHistoryLimit(sectionName: LicenseSection, limitKey: string, options?: LimitHistoryOptions) {

--- a/src/resources/Limits/Limits.ts
+++ b/src/resources/Limits/Limits.ts
@@ -37,7 +37,7 @@ export default class Limits extends Resource {
      * @param limitKey The unique identifier of the target limit status to show
      */
     getSpecificLimitStatus(sectionName: LicenseSection, limitKey: string) {
-        return this.api.get<LimitModel>(`${Limits.getSpecificLimit(sectionName, limitKey)}`);
+        return this.api.get<LimitModel>(Limits.getSpecificLimit(sectionName, limitKey));
     }
 
     getHistoryLimit(sectionName: LicenseSection, limitKey: string, options?: LimitHistoryOptions) {

--- a/src/resources/Limits/tests/Limits.spec.ts
+++ b/src/resources/Limits/tests/Limits.spec.ts
@@ -48,11 +48,20 @@ describe('Limits', () => {
             );
         });
     });
+
     describe('getAllPerLimitType', () => {
         it('should make a GET call to get all limits with specified limit type', () => {
             limits.getAllPerLimitType(LimitType.TECHNICAL);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`/rest/organizations/{organizationName}/limits?limitType=TECHNICAL`);
+        });
+    });
+
+    describe('getSpecificLimitStatus', () => {
+        it('should make a GET call to get a specific limit status', () => {
+            limits.getSpecificLimitStatus(LicenseSection.content, '123');
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`/rest/organizations/{organizationName}/limits/content/123`);
         });
     });
 });


### PR DESCRIPTION
# [SRC-4610](https://coveord.atlassian.net/browse/SRC-4610)

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->
* Added the `getSpecificLimitStatus` call (see [Swagger](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Platform#/Limits/rest_organizations_paramId_limits_paramId_paramId_get)).

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[SRC-4610]: https://coveord.atlassian.net/browse/SRC-4610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ