### PR TITLE
feat(catalogs): add host and locale to configuration interface

### DIFF
--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -54,6 +54,14 @@ export interface CreateCatalogConfigurationModel {
      * The configuration mapping of index fields to standard commerce fields
      */
     fieldsMapping?: CatalogFieldsMapping;
+    /**
+     * The host of the storefront to which the listing pages should be associated.
+     */
+    host?: string;
+    /**
+     * A concatenation of language, country and currency identifiers.
+     */
+    locale?: string;
 }
 
 export interface CatalogConfigurationModel {
@@ -85,6 +93,14 @@ export interface CatalogConfigurationModel {
      * Catalogs associated to the configuration
      */
     associatedCatalogs?: IAssociatedCatalogModel[];
+    /**
+     * The host of the storefront to which the listing pages should be associated.
+     */
+    host?: string;
+    /**
+     * A concatenation of language, country and currency identifiers.
+     */
+    locale?: string;
 }
 
 export interface IAssociatedCatalogModel {

--- a/src/resources/Catalogs/tests/CatalogConfigurations.spec.ts
+++ b/src/resources/Catalogs/tests/CatalogConfigurations.spec.ts
@@ -34,6 +34,8 @@ describe('CatalogConfiguration', () => {
                     objectType: 'ok',
                 },
                 fieldsMapping: {},
+                host: 'https://www.example.com',
+                locale: 'en-us-usd',
             };
 
             catalogConfiguration.create(catalogConfigurationModel);
@@ -70,6 +72,8 @@ describe('CatalogConfiguration', () => {
                     objectType: 'product',
                 },
                 fieldsMapping: {},
+                host: 'https://www.example.com',
+                locale: 'en-us-usd',
             };
 
             catalogConfiguration.update(catalogConfigurationModel);


### PR DESCRIPTION
[COMSDZ-310](https://coveord.atlassian.net/browse/COMSDZ-310)

Host and locale attributes have been added to the catalog configuration. These changes reflect model changes -> https://platformdev.cloud.coveo.com/docs?urls.primaryName=Catalog#/Catalog%20Configurations/rest_organizations_paramId_catalogconfigurations_get

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
