### PR TITLE
fix(core): support user requestinit arguments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 -   Node LTS
 -   NPM
 
-> Tip: This repo support `corepack`. Just enable it `corepack enable` and this repo will warn you if you try to use another package manager.
+> Tip: This repo supports `corepack`. Just enable it `corepack enable` and this repo will warn you if you try to use another package manager.
 
 ## Guidelines
 
@@ -17,7 +17,7 @@
 
 ## Commit messages
 
-**Every commit message must comply with the [Angular Commit Message Conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format) specification. We use the commit messages to automatically bump the package version according to the semantic versionning notation. Moreover, we generate changlogs for each version using those commit messages.**
+**Every commit message must comply with the [Angular Commit Message Conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format) specification. We use the commit messages to automatically bump the package version according to the semantic versioning notation. Moreover, we generate changelogs for each version using those commit messages.**
 
 -   You can either manually write a commit message that follows the convention using your favorite method.
 -   Or you can run `npm run commit-cli`. It will prompt you some questions about the nature of your changes, then it will commit your staged changes along with a generated message that follows our convention.

--- a/src/handlers/ResponseHandlerInterfaces.ts
+++ b/src/handlers/ResponseHandlerInterfaces.ts
@@ -1,4 +1,6 @@
+import {Predicate} from '../utils/types.js';
+
 export interface ResponseHandler {
-    canProcess(response: Response): boolean;
+    canProcess: Predicate<Response>;
     process<T>(response: Response): Promise<T>;
 }

--- a/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
+++ b/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
@@ -1,4 +1,4 @@
-import {WithRequiredProperty} from '../../utils/WithRequired.js';
+import {WithRequiredProperty} from '../../utils/types.js';
 import {Paginated} from '../BaseInterfaces.js';
 
 /**

--- a/src/resources/MachineLearning/ModelConfiguration/ModelConfiguration.ts
+++ b/src/resources/MachineLearning/ModelConfiguration/ModelConfiguration.ts
@@ -16,8 +16,8 @@ export default class ModelConfiguration extends Resource {
     updateAdvancedConfig(modelId: string, modelConfigFileContents: string) {
         return this.api.put<AdvancedRegistrationConfigFileCreationResponse>(
             `${ModelConfiguration.getBaseUrl(modelId)}/advanced`,
-            modelConfigFileContents,
-            {method: 'put', body: modelConfigFileContents, headers: {'Content-Type': 'application/json'}}
+            undefined,
+            {body: modelConfigFileContents, headers: {'Content-Type': 'application/json'}}
         );
     }
 }

--- a/src/resources/MachineLearning/ModelConfiguration/tests/ModelConfiguration.spec.ts
+++ b/src/resources/MachineLearning/ModelConfiguration/tests/ModelConfiguration.spec.ts
@@ -32,11 +32,10 @@ describe('ModelConfiguration', () => {
 
             modelConfig.updateAdvancedConfig(modelId, modelConfigFileContents);
             expect(api.put).toHaveBeenCalledTimes(1);
-            expect(api.put).toHaveBeenCalledWith(
-                `${ModelConfiguration.getBaseUrl(modelId)}/advanced`,
-                modelConfigFileContents,
-                {method: 'put', body: modelConfigFileContents, headers: {'Content-Type': 'application/json'}}
-            );
+            expect(api.put).toHaveBeenCalledWith(`${ModelConfiguration.getBaseUrl(modelId)}/advanced`, undefined, {
+                body: modelConfigFileContents,
+                headers: {'Content-Type': 'application/json'},
+            });
         });
     });
 });

--- a/src/resources/Pipelines/ResultRankings/ResultRankings.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankings.ts
@@ -44,8 +44,8 @@ export default class ResultRankings extends Resource {
             this.buildPath(ResultRankings.getResultRankingsUrl(pipelineId, resultRankingsId), {
                 organizationId: this.api.organizationId,
             }),
-            resultRanking,
-            {method: 'put', body: resultRanking, headers: {'Content-Type': 'application/json'}}
+            undefined,
+            {body: resultRanking, headers: {'Content-Type': 'application/json'}}
         );
     }
 
@@ -75,8 +75,8 @@ export default class ResultRankings extends Resource {
             this.buildPath(ResultRankings.getBaseUrl(pipelineId), {
                 organizationId: this.api.organizationId,
             }),
-            resultRanking,
-            {method: 'post', body: resultRanking, headers: {'Content-Type': 'application/json'}}
+            undefined,
+            {body: resultRanking, headers: {'Content-Type': 'application/json'}}
         );
     }
 

--- a/src/resources/Pipelines/ResultRankings/tests/ResultRankings.spec.ts
+++ b/src/resources/Pipelines/ResultRankings/tests/ResultRankings.spec.ts
@@ -105,8 +105,8 @@ describe('Result Rankings', () => {
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(
                 ResultRankings.getResultRankingsUrl(pipelineId, resultRankingId),
-                json,
-                {method: 'put', body: json, headers: {'Content-Type': 'application/json'}}
+                undefined,
+                {body: json, headers: {'Content-Type': 'application/json'}}
             );
         });
     });
@@ -169,8 +169,7 @@ describe('Result Rankings', () => {
 
             resultRankings.createJSON(pipelineId, json);
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(ResultRankings.getBaseUrl(pipelineId), json, {
-                method: 'post',
+            expect(api.post).toHaveBeenCalledWith(ResultRankings.getBaseUrl(pipelineId), undefined, {
                 body: json,
                 headers: {'Content-Type': 'application/json'},
             });

--- a/src/resources/PushApi/PushApi.ts
+++ b/src/resources/PushApi/PushApi.ts
@@ -31,7 +31,6 @@ export default class PushApi extends Resource {
         return this.serverlessApi.delete<void>(
             this.buildPath(`${PushApi.baseUrl}/${securityProviderId}/permissions`, options),
             {
-                method: 'delete',
                 body: JSON.stringify(securityIdentity),
                 headers: {'Content-Type': 'application/json'},
             }

--- a/src/resources/PushApi/tests/PushApi.spec.ts
+++ b/src/resources/PushApi/tests/PushApi.spec.ts
@@ -68,7 +68,6 @@ describe('PushAPI', () => {
                 expect(serverlessApi.delete).toHaveBeenCalledWith(url, {
                     body: '{"identity":{"name":"Test Identity","additionalInfo":{},"type":"GROUP"}}',
                     headers: {'Content-Type': 'application/json'},
-                    method: 'delete',
                 });
             });
         });

--- a/src/utils/Retriever.ts
+++ b/src/utils/Retriever.ts
@@ -1,5 +1,7 @@
-export type Retrievable<T> = T | (() => T);
+import {Supplier} from './types.js';
 
-const isFunction = <T>(x: any): x is () => T => typeof x === 'function';
+export type Retrievable<T> = T | Supplier<T>;
 
-export default <T>(parameter: Retrievable<T>): T => (isFunction(parameter) ? parameter() : parameter);
+const isSupplier = <T>(x: unknown): x is Supplier<T> => typeof x === 'function';
+
+export default <T>(parameter: Retrievable<T>): T => (isSupplier(parameter) ? parameter() : parameter);

--- a/src/utils/WithRequired.ts
+++ b/src/utils/WithRequired.ts
@@ -1,4 +1,0 @@
-export type WithRequiredProperty<Type, Key extends keyof Type> = Type &
-    {
-        [Property in Key]-?: Type[Property];
-    };

--- a/src/utils/createFetcher.ts
+++ b/src/utils/createFetcher.ts
@@ -1,0 +1,19 @@
+import {AsyncSupplier, Predicate} from './types.js';
+
+/**
+ * Creates a method to perform a fetch request. Can be retried by calling the method again.
+ *
+ * @param url The URL to use for the request.
+ * @param init The parameters to provide to the request.
+ * @param shouldReject Predicate to see if the response should be (Promise) rejected.
+ * @returns A method, taking no arguments, that may be called multiple times to repeat the request.
+ */
+export const createFetcher =
+    (url: string, init: RequestInit, shouldReject?: Predicate<Response>): AsyncSupplier<Response> =>
+    async () => {
+        const response = await fetch(url, init);
+        if (shouldReject?.(response)) {
+            throw response;
+        }
+        return response;
+    };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './createFetcher.js';
 export * from './Retriever.js';
-export * from './WithRequired.js';
+export * from './types.js';

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,17 @@
+export type WithRequiredProperty<Type, Key extends keyof Type> = Type & {
+    [Property in Key]-?: Type[Property];
+};
+
+export interface AsyncSupplier<T> {
+    (): Promise<T>;
+}
+
+export interface Supplier<T> {
+    (): T;
+}
+
+export interface Predicate<T> {
+    (value: T): boolean;
+}
+
+export interface CoveoPlatformClientRequestInit extends Omit<RequestInit, 'method'> {}


### PR DESCRIPTION
### How I ran into the issue
I wrote a custom React hook in admin-ui, that will actually abort requests instead of ignoring the result (which is what `useAsyncFn` and alike tend to do). The resource for this is not in this repository yet, as it is pending completion. (The Data Health resource definition is currently added to admin-ui, until the service endpoint is finalized and we can add it here properly).

This resource definition has direct access to the "api", and I immediately saw issue when passing a `RequestInit` object with a `signal` on it: the (http) `method` is no longer set. That is why I decided to log [UA-7571](https://coveord.atlassian.net/browse/UA-7571).

### The issue
The short summary is that default arguments where used to provide the "predefined" method, body et cetera. But if you specify your own arguments, these should get mixed with the predefined ones. Since default arguments were used, they would be replaced if you pass a value.

To illustrate the issue, look at the existing `post` implementation:
```typescript
    async post<T = Record<string, unknown>>(
        url: string,
        body: any = {},
        args: RequestInit = {method: 'post', body: JSON.stringify(body), headers: {'Content-Type': 'application/json'}}
    ): Promise<T> {
        return await this.request<T>(url, args);
    }
```

The implementation uses a default value for args. But if somebody provides a `RequestInit` `args` as third argument (to pass an abort `signal`, for example), these defaults are not "mixed in"⚠. For this `post` method, that means the `method: 'post'`, `body` fields and `Content-Type` header will not be set.

### My proposed fix
I set out to fix this, by changing the way the various parts that make up the final `RequestInit` object are mixed together. To do so, I put careful thought in which sources should take precedence over others. I landed on this order (later in the list "overwrites" what comes before):
  - `Authorization` header (filled in by default, but may be overridden by any following object).
  - "prefilled" (arguments provided by the wrapping method, e.g. `post` fills in a `body` and the `Content-Type` header).
  - `config.globalRequestSettings`
  - "user arguments" ( the optional arguments passed by users of the API).
  - `method` (provided by the wrapping method, e.g. `get` fills in `'GET'`).

Allowing people to pass in `RequestInit` args, but also asking a `body` (which we `JSON.stringify`) meant we also need to make a decision which precedes which. I landed on: if a `body` is probided in the args, it overrules any object passed. My logic is this: it allows putting "native types" directly in the args.

### Abort handling: issue found while updating the code
As mentioned before, the reason I started this fix was so I could pass in an `AbortSignal`. Then I saw how abort is actually being handled currently, which I struggled with very much. The current code, mostly introduced in #37, is unfortunate in two ways:
  - It **resolves** the API call `Promise` with `undefined`.
     1. I think it should **reject**, and the people who designed the `fetch` API agree, as the `Promise` returned by `fetch` rejects.
     2. This is not type safe, we didn't add `| undefined` to the signature.
        Handling code may get undefined in its `await`/resolve handling.
  - It makes false statements of what it does in the comments

I didn't actually change the code in this PR (yet). As mentioned before, I think it should **reject** on abort, but that would be a breaking change. So I just added health warnings to the code and the test. The test only passes because it doesn't handle `async` at all, I made it `async` but moved the `await` until **after** the assertion, so it keeps passing.

### Uppercase method
You may notice I changed the [method](https://developer.mozilla.org/en-US/docs/Web/API/fetch#method) values to be uppercase. I was somewhat surprised with only `'PATCH'` being uppercase. Then I looked up the doc:
> Any string which is a case-insensitive match for one of the methods in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-overview) will be uppercased automatically. If you want to use a custom method (like PATCH), you should uppercase it yourself.

I thought it would be clearer to stick to uppercase, to avoid somebody accidentally breaking `'PATCH'` because they wanted to align the casing used.

### Tested locally
I tested this locally in admin-ui using a symlink, also removing the [method patch](/coveo/admin-ui/blob/df9ad4e5149babb324644e5af0745169b56941da/core/api/src/resources/UAReadDataHealthResource.ts#L16) I introduced to work around this issue. The admin-ui works perfectly with these changes.

Typing quickly in one of the data health filters did make me realize one thing:
  - I should probably debounce the update, to prevent spamming the back end in case a user types
  - As I mentioned, abort indeed resolves with `undefined`. I do not handle this properly in the Data Health UI yet 🤦‍♂️.
    ```
    Uncaught TypeError: Cannot read properties of undefined (reading '0')
        at DataHealthLatestEventsTab.js?t=1679057760842:303:26
        at Array.map (<anonymous>)
        …
    ```

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] ~My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))~ Not applicable, fix/refactor.
-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] Commits containing breaking changes a properly identified as such
-   [X] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant) → No relevant changes, did fix some typo's.
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[UA-7571]: https://coveord.atlassian.net/browse/UA-7571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ