### PR TITLE
feat(securityCache): added FilteringMode attribute for SecurityCache.listSecurityProviderIdentities

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -467,6 +467,11 @@ export enum PermissionIdentityType {
     VirtualGroup = 'VirtualGroup',
 }
 
+export enum SecurityCacheFilteringMode {
+    PREFIX = 'PREFIX',
+    SUBSTRING = 'SUBSTRING',
+}
+
 export enum SecurityProviderReferenceType {
     SOURCE = 'SOURCE',
     SECURITY_PROVIDER = 'SECURITY_PROVIDER',

--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -40,6 +40,7 @@ export default class SecurityCache extends Ressource {
         {page, perPage, ...rest}: SecurityProviderIdentitiesFilters = {}
     ) {
         const filterModel = {
+            filteringMode: rest.filteringMode,
             filterTerm: rest.filterTerm,
             identityTypes: rest.identityTypes,
             providerIds: [providerId],

--- a/src/resources/SecurityCache/SecurityCacheInterfaces.ts
+++ b/src/resources/SecurityCache/SecurityCacheInterfaces.ts
@@ -2,6 +2,7 @@ import {Paginated} from '../BaseInterfaces.js';
 import {
     PermissionIdentityType,
     ScheduleType,
+    SecurityCacheFilteringMode,
     SecurityCacheStateOptions,
     SecurityProviderReferenceType,
     SecurityProviderType,
@@ -130,7 +131,20 @@ export interface SecurityCacheListOptions extends Paginated {
 }
 
 export interface SecurityProviderIdentitiesFilters extends Paginated {
+    /**
+     * filteringMode can take two values, SUBSTRING or PREFIX.
+     *
+     * SUBSTRING: If filterTerm is set, this mode specifies that identities that have the filterTerm at any position in their name will be returned.
+     * PREFIX: If filterTerm is set, this mode specifies that only identities that have the filterTerm at the beginning of their name will be returned.
+     */
+    filteringMode?: SecurityCacheFilteringMode;
+    /**
+     * If set, only identities that have this value in their name will be returned.
+     */
     filterTerm?: string;
+    /**
+     * If set, only identities for which their type is listed in this array will be returned.
+     */
     identityTypes?: PermissionIdentityType[];
 }
 

--- a/src/resources/SecurityCache/tests/SecurityCache.spec.ts
+++ b/src/resources/SecurityCache/tests/SecurityCache.spec.ts
@@ -5,7 +5,7 @@ import {
     SecurityProviderModel,
 } from '../index.js';
 import API from '../../../APICore.js';
-import {PermissionIdentityType} from '../../Enums.js';
+import {PermissionIdentityType, SecurityCacheFilteringMode} from '../../Enums.js';
 import SecurityCache from '../SecurityCache.js';
 
 jest.mock('../../../APICore.js');
@@ -24,11 +24,6 @@ describe('securityCache', () => {
 
     describe('list', () => {
         const providerId = 'PROVIDER_ID';
-        const securityCacheFiltersBody = {
-            filterTerm: 'test',
-            identityTypes: [PermissionIdentityType.User],
-            providerIds: [providerId],
-        };
 
         it('should make a GET call to the securityCache correct url with listMembers', () => {
             securityCache.listMembers(providerId);
@@ -55,13 +50,19 @@ describe('securityCache', () => {
 
         it('should make a POST call to the securityCache correct url with listSecurityIdentities with filters', () => {
             securityCache.listSecurityProviderIdentities(providerId, {
-                filterTerm: securityCacheFiltersBody.filterTerm,
-                identityTypes: securityCacheFiltersBody.identityTypes,
+                filteringMode: SecurityCacheFilteringMode.PREFIX,
+                filterTerm: 'test',
+                identityTypes: [PermissionIdentityType.User],
             } as SecurityProviderIdentitiesFilters);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(
                 `/rest/organizations/{organizationName}/securitycache/entities/list`,
-                securityCacheFiltersBody
+                {
+                    filteringMode: 'PREFIX',
+                    filterTerm: 'test',
+                    identityTypes: ['User'],
+                    providerIds: ['PROVIDER_ID'],
+                }
             );
         });
 


### PR DESCRIPTION
### Acceptance Criteria

Just adding a new filter for `SecurityCache.listSecurityProviderIdentities` call

Task: [CTCORE-9140](https://coveord.atlassian.net/browse/CTCORE-9140)
Swagger: [/rest/organizations/{organizationId}/securitycache/entities/list](https://platformdev.cloud.coveo.com/docs?urls.primaryName=SecurityCache#/Security%20Cache/rest_organizations_paramId_securitycache_entities_list_post)


<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[CTCORE-9140]: https://coveord.atlassian.net/browse/CTCORE-9140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ