### PR TITLE
feat(endpoints): use named export for getEndpoint

### DIFF
--- a/src/APICore.ts
+++ b/src/APICore.ts
@@ -1,6 +1,6 @@
 import {backOff} from 'exponential-backoff';
 import {PlatformClientOptions} from './ConfigurationInterfaces.js';
-import getEndpoint, {Environment, Region} from './Endpoints.js';
+import {Environment, Region, getEndpoint} from './Endpoints.js';
 import {ResponseHandler} from './handlers/ResponseHandlerInterfaces.js';
 import handleResponse, {ResponseHandlers} from './handlers/ResponseHandlers.js';
 import {UserModel} from './resources/Users/index.js';

--- a/src/Endpoints.ts
+++ b/src/Endpoints.ts
@@ -28,7 +28,7 @@ const serverlessEndpointTemplates: Record<Environment, string> = {
     [Environment.hipaa]: 'https://apihipaa.cloud.coveo.com',
 };
 
-export default (environment = Environment.prod, region = Region.US, isServerlessHost = false): string => {
+export const getEndpoint = (environment = Environment.prod, region = Region.US, isServerlessHost = false): string => {
     const regionSuffix = region === Region.US ? '' : `-${region}`;
     const matcher = new RegExp(regionPlaceholder, 'g');
 

--- a/src/tests/APICore.spec.ts
+++ b/src/tests/APICore.spec.ts
@@ -2,7 +2,7 @@ import jestFetchMock from 'jest-fetch-mock';
 const fetchMock = jestFetchMock.default;
 import API from '../APICore.js';
 import {PlatformClientOptions} from '../ConfigurationInterfaces.js';
-import getEndpoint, {Environment, Region} from '../Endpoints.js';
+import {Environment, Region, getEndpoint} from '../Endpoints.js';
 import {ResponseHandler} from '../handlers/ResponseHandlerInterfaces.js';
 
 jest.mock('../Endpoints.js');

--- a/src/tests/Endpoint.spec.ts
+++ b/src/tests/Endpoint.spec.ts
@@ -1,4 +1,4 @@
-import getEndpoint, {Environment, Region} from '../Endpoints.js';
+import {Environment, Region, getEndpoint} from '../Endpoints.js';
 
 describe('Endpoint', () => {
     describe('platform endpoint', () => {


### PR DESCRIPTION
Use named export for getEndpoint so it can be imported by external packages. At the moment, the default export is not publicly accessible because it gets squashed by `Entry`'s own default export of the `PlatformClient` class.

BREAKING CHANGE: The default import of '@coveo/platform-client/dist/esm/Endpoints' no longer works (same for CJS).

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
