### PR TITLE
feat(endpoints): expose Endpoints default export

### DIFF
--- a/src/Entry.ts
+++ b/src/Entry.ts
@@ -8,4 +8,5 @@ export * from './utils/index.js';
 export * from './Endpoints.js';
 
 export {default as API} from './APICore.js';
+export {default as getEndpoint} from './Endpoints.js';
 export default PlatformClient;


### PR DESCRIPTION
Re-export the default export of Endpoints so it can be publicly accessed by external packages. Replaces #667.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
