### PR TITLE
feat(ml): Define interface for Model's extraConfig

### DIFF
--- a/src/resources/MachineLearning/MachineLearningInterfaces.ts
+++ b/src/resources/MachineLearning/MachineLearningInterfaces.ts
@@ -39,6 +39,7 @@ export interface ExtraConfig {
     recommendationStrategy?: string;
     urlReplacePatterns?: UrlReplacePatterns[];
     parsingMode?: string;
+    [key: string]: any;
 }
 
 export interface RegistrationModel extends GranularResource {

--- a/src/resources/MachineLearning/MachineLearningInterfaces.ts
+++ b/src/resources/MachineLearning/MachineLearningInterfaces.ts
@@ -2,6 +2,45 @@ import {GranularResource} from '../BaseInterfaces.js';
 import {IntervalUnit} from '../Enums.js';
 import {MLModel} from './index.js';
 
+interface QueryReplacePatterns {
+    pattern: string;
+    ordering: string;
+}
+
+interface UrlReplacePatterns {
+    pattern: string;
+    replace: string;
+}
+
+interface PageViewFiltered {
+    contentType: {
+        Value: string[];
+    };
+}
+
+interface CommerceSupport {
+    enabled: boolean;
+}
+
+export interface ExtraConfig {
+    recommendedContentTypeFilter?: string[];
+    eventConfigsTemplates?: string[];
+    PageViewFiltered?: PageViewFiltered;
+    automaticContextDiscovery?: boolean;
+    blacklist?: string[];
+    commerceSupport?: CommerceSupport;
+    filterFields?: string[];
+    recommendProductGroup?: boolean;
+    testConfiguration?: boolean;
+    userContextFields?: string[];
+    whitelist?: string[];
+    blackList?: string[];
+    queryReplacePatterns?: QueryReplacePatterns[];
+    recommendationStrategy?: string;
+    urlReplacePatterns?: UrlReplacePatterns[];
+    parsingMode?: string;
+}
+
 export interface RegistrationModel extends GranularResource {
     // The id of the engine
     engineId: string;
@@ -28,9 +67,7 @@ export interface RegistrationModel extends GranularResource {
     // The additional command line parameters that can be passed to the drill
     commandLineParameters?: string[];
     // The additional configuration that can be passed to the model
-    extraConfig?: {
-        [key: string]: any;
-    };
+    extraConfig?: ExtraConfig;
     /**
      * The filter to apply to the common event dimensions (shared by all event types) in the export.
      * Multiple filter parameters are joined with the AND operator

--- a/src/resources/MachineLearning/Models/ModelsInterfaces.ts
+++ b/src/resources/MachineLearning/Models/ModelsInterfaces.ts
@@ -2,6 +2,7 @@ import {GranularResource} from '../../BaseInterfaces.js';
 import {IntervalUnit, ModelActivenessState, ModelStatus} from '../../Enums.js';
 import {AssociatedPipelineModel} from '../../Pipelines/index.js';
 import {MLModelInfo, MLModelTypeInfo} from '../ModelInformation/index.js';
+import {ExtraConfig} from '../MachineLearningInterfaces.js';
 
 export interface MLModel<T extends MLModelTypeInfo = never> extends MLModelInfo<T>, ModelAttributes, GranularResource {
     orgId: string;
@@ -23,9 +24,7 @@ export interface MLModel<T extends MLModelTypeInfo = never> extends MLModelInfo<
     exportOffset?: string;
     status: ModelStatus;
     commandLineParameters?: string[];
-    extraConfig?: {
-        [key: string]: any;
-    };
+    extraConfig?: ExtraConfig;
     commonFilter?: string;
     customEventFilter?: string;
     searchEventFilter?: string;


### PR DESCRIPTION
Add an interface for model's extraConfig, previously it uses `[key: string]: any` which is not very clear

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
