### PR TITLE
fix(mlmodelcreated): fix MLModelCreated type to match Swagger and the…

### DIFF
--- a/src/resources/MachineLearning/MachineLearningInterfaces.ts
+++ b/src/resources/MachineLearning/MachineLearningInterfaces.ts
@@ -96,9 +96,9 @@ export interface RegistrationModel extends GranularResource {
     versionMatcher?: string;
 }
 
-export interface MLModelCreated extends MLModel {
+export interface MLModelCreated extends Omit<MLModel, 'id'> {
     // The unique identifier of the target model
-    modelId?: string;
+    modelId: string;
     /**
      * The epoch date when the schedule will end.
      * If there is no end date, the schedule will last forever.


### PR DESCRIPTION
… actual API return type

The API endpoint to create a model returns an object which contains `modelId` but not `id`. This PR fixes the type declaration so that this is reflected in Typescript.

BREAKING CHANGE: Type checking will fail if any consumers of this library reference the `id` field of a `MLModelCreated` object.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
