### PR TITLE
fix(pipeline): do not set filename when appending a str

### DIFF
--- a/src/resources/Pipelines/Statements/Statements.ts
+++ b/src/resources/Pipelines/Statements/Statements.ts
@@ -31,9 +31,12 @@ export default class Statements extends Resource {
     }
 
     importCSV(pipelineId: string, csvFile: File | string, options?: ExportStatementParams) {
-        const fileName = typeof csvFile === 'string' ? 'raw-string' : csvFile.name;
         const formData = new FormData();
-        formData.append('file', csvFile, fileName);
+        if (typeof csvFile === 'string') {
+            formData.append('file', csvFile);
+        } else {
+            formData.append('file', csvFile, csvFile.name);
+        }
 
         return this.api.postForm(
             this.buildPath(`${Statements.getBaseUrl(pipelineId)}/import`, {

--- a/src/resources/Pipelines/Statements/tests/Statements.spec.ts
+++ b/src/resources/Pipelines/Statements/tests/Statements.spec.ts
@@ -165,7 +165,7 @@ describe('Statements', () => {
                 mockedFormData
             );
             expect(mockedFormData.append).toHaveBeenCalledTimes(1);
-            expect(mockedFormData.append).toHaveBeenCalledWith('file', content, 'raw-string');
+            expect(mockedFormData.append).toHaveBeenCalledWith('file', content);
         });
     });
 


### PR DESCRIPTION
Relates to the build failure of #678 
Based on W3C spec & MDN:
- https://developer.mozilla.org/en-US/docs/Web/API/FormData/append
- https://xhr.spec.whatwg.org/#dom-formdata-append
- https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-form-data-set

the 3rd arg is ignored when the 2nd is a string.

proof of bug: 
https://www.typescriptlang.org/play?#code/MYewdgzgLgBAhjAvDMBTA7jAYiATgWwBE4o4AKASgG4AoAejpgAEoIBaASwHMw9Ua4AOjgAHEajAATMgHIAZhwA2qGQBoYMkSFJQQajVp16KNGqEghlgxSC5khEqLg6oIlCkA

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
