### PR TITLE
fix(field): search should send param in body

### DIFF
--- a/src/resources/Fields/Fields.ts
+++ b/src/resources/Fields/Fields.ts
@@ -47,6 +47,6 @@ export default class Field extends Resource {
     }
 
     search(params?: FieldListingOptions) {
-        return this.api.post<PageModel<FieldModel>>(this.buildPath(`${Field.baseUrl}/search`, params));
+        return this.api.post<PageModel<FieldModel>>(this.buildPath(`${Field.baseUrl}/search`), params);
     }
 }

--- a/src/resources/Fields/tests/Fields.spec.ts
+++ b/src/resources/Fields/tests/Fields.spec.ts
@@ -123,7 +123,7 @@ describe('Field', () => {
 
             field.search(params);
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(`${Field.baseUrl}/search`);
+            expect(api.post).toHaveBeenCalledWith(`${Field.baseUrl}/search`, {});
         });
 
         it('should make a POST call to the specific Field url with the facetsOnly parameter set as true', () => {
@@ -131,7 +131,7 @@ describe('Field', () => {
 
             field.search(params);
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(`${Field.baseUrl}/search?order=ASC`);
+            expect(api.post).toHaveBeenCalledWith(`${Field.baseUrl}/search`, params);
         });
     });
 });

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -6,7 +6,7 @@ class Resource {
 
     constructor(protected api: API, protected serverlessApi: API) {}
 
-    protected buildPath(route: string, parameters: any): string {
+    protected buildPath(route: string, parameters?: any): string {
         return route + this.convertObjectToQueryString(parameters);
     }
 


### PR DESCRIPTION
Fixes #684

search is a post, put those params in the body.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
