### PR TITLE
Add search /html endpoint

### DIFF
--- a/src/handlers/ResponseHandlerInterfaces.ts
+++ b/src/handlers/ResponseHandlerInterfaces.ts
@@ -1,6 +1,19 @@
 import {Predicate} from '../utils/types.js';
 
+/**
+ * Each format represents one of the [Response object instance methods](https://developer.mozilla.org/en-US/docs/Web/API/Response#instance_methods).
+ */
+export type ResponseBodyFormat = 'json' | 'text' | 'blob' | 'formData' | 'arrayBuffer';
+
 export interface ResponseHandler {
+    /**
+     * Whether this handler can process the request.
+     */
     canProcess: Predicate<Response>;
-    process<T>(response: Response): Promise<T>;
+    /**
+     *
+     * @param response The [response object](https://developer.mozilla.org/en-US/docs/Web/API/Response) to the request.
+     * @param responseBodyFormat The format of the response body that is to be returned from the request.
+     */
+    process<T>(response: Response, responseBodyFormat?: ResponseBodyFormat): Promise<T>;
 }

--- a/src/handlers/ResponseHandlers.ts
+++ b/src/handlers/ResponseHandlers.ts
@@ -1,5 +1,5 @@
 import {Predicate} from '../utils/types.js';
-import {ResponseHandler} from './ResponseHandlerInterfaces.js';
+import {ResponseBodyFormat, ResponseHandler} from './ResponseHandlerInterfaces.js';
 
 /** Check whether the response status is `204 No Content`. */
 export const isNoContent: Predicate<Response> = (response) => response.status === 204;
@@ -13,16 +13,12 @@ const noContent: ResponseHandler = {
 
 const success: ResponseHandler = {
     canProcess: isAnyOkStatus,
-    process: async <T>(response: Response): Promise<T> => {
-        if (response.headers.get('Content-Type')?.includes('application/json')) {
-            return await response.json();
-        } else {
-            // We're assuming that T is going to be properly typed to `string` if the content type isn't json
-            return (await response.text()) as T;
-        }
-    },
+    process: async (response, responseBodyFormat = 'json') => response[responseBodyFormat](),
 };
 
+/**
+ * @deprecated Use `success` handler with `responseBodyFormat` `'blob'` instead. Will be removed in version 45
+ */
 const successBlob: ResponseHandler = {
     canProcess: isAnyOkStatus,
     process: async <T>(response: Response): Promise<T> => (await response.blob()) as T,
@@ -59,13 +55,17 @@ const getErrorPropsFromAliases = (responseJson: object, aliasList: string[]): st
 const defaultResponseHandlers = Object.freeze([noContent, success, error]);
 export const ResponseHandlers = Object.freeze({noContent, success, successBlob, error});
 
-export default async <T>(response: Response, customHandlers?: readonly ResponseHandler[] | null): Promise<T> => {
+export default async <T>(
+    response: Response,
+    customHandlers?: readonly ResponseHandler[] | null,
+    responseBodyFormat?: ResponseBodyFormat
+): Promise<T> => {
     const handlers = customHandlers?.length ? customHandlers : defaultResponseHandlers;
     const handler = handlers.find((candidate) => candidate.canProcess(response));
     if (!handler) {
         throw new Error('No suitable response handler found');
     }
-    return await handler.process<T>(response);
+    return await handler.process<T>(response, responseBodyFormat);
 };
 
 /**

--- a/src/handlers/ResponseHandlers.ts
+++ b/src/handlers/ResponseHandlers.ts
@@ -13,12 +13,19 @@ const noContent: ResponseHandler = {
 
 const success: ResponseHandler = {
     canProcess: isAnyOkStatus,
-    process: async <T>(response: Response): Promise<T> => await response.json(),
+    process: async <T>(response: Response): Promise<T> => {
+        if (response.headers.get('Content-Type')?.includes('application/json')) {
+            return await response.json();
+        } else {
+            // We're assuming that T is going to be properly typed to `string` if the content type isn't json
+            return (await response.text()) as T;
+        }
+    },
 };
 
 const successBlob: ResponseHandler = {
     canProcess: isAnyOkStatus,
-    process: async <T>(response: Response): Promise<T> => await (response.blob() as any),
+    process: async <T>(response: Response): Promise<T> => (await response.blob()) as T,
 };
 
 const error: ResponseHandler = {

--- a/src/handlers/tests/ResponseHandlers.spec.ts
+++ b/src/handlers/tests/ResponseHandlers.spec.ts
@@ -7,14 +7,37 @@ describe('ResponseHandlers', () => {
         expect(ret).toEqual({});
     });
 
-    it('should return a promise resolved with the response body when the response status is between 200 and 299', async () => {
+    it('should return a promise resolved with the response body in JSON format when the response status is between 200 and 299 and the content-type is JSON', async () => {
         const data = {someData: 'thank you!'};
-
-        const okResponse = new Response(JSON.stringify(data), {status: 200});
+        const okResponse = new Response(JSON.stringify(data), {
+            status: 200,
+            headers: {'Content-Type': 'application/json;charset=utf-8'},
+        });
         const ret1 = await handleResponse(okResponse);
         expect(ret1).toEqual(data);
 
-        const stillOkResponse = new Response(JSON.stringify(data), {status: 299});
+        const stillOkResponse = new Response(JSON.stringify(data), {
+            status: 299,
+            headers: {'Content-Type': 'application/json;charset=utf-8'},
+        });
+        const ret2 = await handleResponse(stillOkResponse);
+        expect(ret2).toEqual(data);
+    });
+
+    it('returns a promise resolved with the response body in text format when the response status is between 200 and 299 the content-type is not JSON', async () => {
+        const data =
+            '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8" /><title>test</title></head><body>test</body></html>';
+        const okResponse = new Response(data, {
+            status: 200,
+            headers: {'Content-Type': 'text/html;charset=utf-8'},
+        });
+        const ret1 = await handleResponse(okResponse);
+        expect(ret1).toEqual(data);
+
+        const stillOkResponse = new Response(data, {
+            status: 299,
+            headers: {'Content-Type': 'text/html;charset=utf-8'},
+        });
         const ret2 = await handleResponse(stillOkResponse);
         expect(ret2).toEqual(data);
     });

--- a/src/handlers/tests/ResponseHandlers.spec.ts
+++ b/src/handlers/tests/ResponseHandlers.spec.ts
@@ -1,45 +1,36 @@
 import handleResponse, {CoveoPlatformClientError, ResponseHandlers} from '../ResponseHandlers.js';
 
 describe('ResponseHandlers', () => {
-    it('should return a promise resolved with an empty object when the response status code is 204', async () => {
-        const noContentResponse = new Response(null, {status: 204});
-        const ret = await handleResponse(noContentResponse);
-        expect(ret).toEqual({});
+    describe('no content', () => {
+        it('returns a promise resolved with an empty object when the response status code is 204', async () => {
+            const noContentResponse = new Response(null, {status: 204});
+            const ret = await handleResponse(noContentResponse);
+            expect(ret).toEqual({});
+        });
     });
 
-    it('should return a promise resolved with the response body in JSON format when the response status is between 200 and 299 and the content-type is JSON', async () => {
-        const data = {someData: 'thank you!'};
-        const okResponse = new Response(JSON.stringify(data), {
-            status: 200,
-            headers: {'Content-Type': 'application/json;charset=utf-8'},
+    describe.each([200, 299])('when the response status code is between 200 and 299 (success)', (status) => {
+        it(`${status} returns a promise resolved with the response body in JSON format`, async () => {
+            const data = {someData: 'thank you!'};
+            const okResponse = new Response(JSON.stringify(data), {status});
+            const result = await handleResponse(okResponse);
+            expect(result).toEqual(data);
         });
-        const ret1 = await handleResponse(okResponse);
-        expect(ret1).toEqual(data);
 
-        const stillOkResponse = new Response(JSON.stringify(data), {
-            status: 299,
-            headers: {'Content-Type': 'application/json;charset=utf-8'},
+        it(`${status} returns a promise resolved with the response body in text format if responseBodyFormat = "text"`, async () => {
+            const data =
+                '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8" /><title>test</title></head><body>test</body></html>';
+            const okResponse = new Response(data, {status});
+            const result = await handleResponse(okResponse, null, 'text');
+            expect(result).toEqual(data);
         });
-        const ret2 = await handleResponse(stillOkResponse);
-        expect(ret2).toEqual(data);
-    });
 
-    it('returns a promise resolved with the response body in text format when the response status is between 200 and 299 the content-type is not JSON', async () => {
-        const data =
-            '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8" /><title>test</title></head><body>test</body></html>';
-        const okResponse = new Response(data, {
-            status: 200,
-            headers: {'Content-Type': 'text/html;charset=utf-8'},
+        it(`${status} returns a promise resolved with the response body in blob format if responseBodyFormat = "blob"`, async () => {
+            const okResponse = new Response('some content', {status});
+            const expectedResult = await okResponse.clone().blob();
+            const result = await handleResponse(okResponse, null, 'blob');
+            expect(result).toEqual(expectedResult);
         });
-        const ret1 = await handleResponse(okResponse);
-        expect(ret1).toEqual(data);
-
-        const stillOkResponse = new Response(data, {
-            status: 299,
-            headers: {'Content-Type': 'text/html;charset=utf-8'},
-        });
-        const ret2 = await handleResponse(stillOkResponse);
-        expect(ret2).toEqual(data);
     });
 
     describe('when the status is not between 200 and 299', () => {

--- a/src/resources/Pipelines/Statements/Statements.ts
+++ b/src/resources/Pipelines/Statements/Statements.ts
@@ -22,11 +22,12 @@ export default class Statements extends Resource {
     }
 
     exportCSV(pipelineId: string, options?: ExportStatementParams) {
-        return this.api.getFile(
+        return this.api.get(
             this.buildPath(`${Statements.getBaseUrl(pipelineId)}/export`, {
                 organizationId: this.api.organizationId,
                 ...options,
-            })
+            }),
+            {responseBodyFormat: 'blob'}
         );
     }
 

--- a/src/resources/Pipelines/Statements/tests/Statements.spec.ts
+++ b/src/resources/Pipelines/Statements/tests/Statements.spec.ts
@@ -40,9 +40,10 @@ describe('Statements', () => {
             };
 
             statements.exportCSV(pipelineId, options);
-            expect(api.getFile).toHaveBeenCalledTimes(1);
-            expect(api.getFile).toHaveBeenCalledWith(
-                `${Statements.getBaseUrl(pipelineId)}/export?feature=${options.feature}`
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Statements.getBaseUrl(pipelineId)}/export?feature=${options.feature}`,
+                {responseBodyFormat: 'blob'}
             );
         });
     });

--- a/src/resources/ResourceSnapshots/ResourceSnapshots.ts
+++ b/src/resources/ResourceSnapshots/ResourceSnapshots.ts
@@ -61,8 +61,9 @@ export default class ResourceSnapshots extends Resource {
      * @returns {Promise<Blob>} A newly created Blob object which contains the zipped snapshot
      */
     export(snapshotId: string, options?: ExportSnapshotContentOptions): Promise<Blob> {
-        return this.api.getFile(this.buildPath(`${ResourceSnapshots.baseUrl}/${snapshotId}/content`, options), {
+        return this.api.get(this.buildPath(`${ResourceSnapshots.baseUrl}/${snapshotId}/content`, options), {
             headers: {accept: 'application/zip'},
+            responseBodyFormat: 'blob',
         });
     }
 

--- a/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
+++ b/src/resources/ResourceSnapshots/tests/ResourceSnapshots.spec.ts
@@ -136,9 +136,10 @@ describe('ResourceSnapshots', () => {
 
             resourceSnapshots.export(snapshotToGetId);
 
-            expect(api.getFile).toHaveBeenCalledTimes(1);
-            expect(api.getFile).toHaveBeenCalledWith(`${ResourceSnapshots.baseUrl}/${snapshotToGetId}/content`, {
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${ResourceSnapshots.baseUrl}/${snapshotToGetId}/content`, {
                 headers: {accept: 'application/zip'},
+                responseBodyFormat: 'blob',
             });
         });
 
@@ -150,10 +151,10 @@ describe('ResourceSnapshots', () => {
 
             resourceSnapshots.export(snapshotToGetId, exportSnapshotContentOptions);
 
-            expect(api.getFile).toHaveBeenCalledTimes(1);
-            expect(api.getFile).toHaveBeenCalledWith(
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
                 `${ResourceSnapshots.baseUrl}/${snapshotToGetId}/content?contentFormat=SPLIT_PER_TYPE`,
-                {headers: {accept: 'application/zip'}}
+                {headers: {accept: 'application/zip'}, responseBodyFormat: 'blob'}
             );
         });
     });

--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -2,6 +2,7 @@ import {ListFieldValuesBodyQueryParams, PostSearchQuerySuggestBodyParams} from '
 import API from '../../APICore.js';
 import Ressource from '../Resource.js';
 import {
+    ItemPreviewHtmlParameters,
     RestQueryParams,
     RestTokenParams,
     SearchListFieldsParams,
@@ -56,6 +57,18 @@ export default class Search extends Ressource {
                 organizationId: this.api.organizationId,
             }),
             restQuerySuggestParameters
+        );
+    }
+
+    /**
+     * Get an item's preview in HTML format
+     */
+    previewHTML(params: ItemPreviewHtmlParameters) {
+        return this.api.get<string>(
+            this.buildPath(`${Search.baseUrl}/html`, {
+                ...params,
+                organizationId: params.organizationId ?? this.api.organizationId,
+            })
         );
     }
 }

--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -68,7 +68,8 @@ export default class Search extends Ressource {
             this.buildPath(`${Search.baseUrl}/html`, {
                 ...params,
                 organizationId: params.organizationId ?? this.api.organizationId,
-            })
+            }),
+            {responseBodyFormat: 'text'}
         );
     }
 }

--- a/src/resources/Search/SearchInterfaces.ts
+++ b/src/resources/Search/SearchInterfaces.ts
@@ -71,20 +71,21 @@ export interface TokenModel {
 export type RestQueryParams = PostSearchBodyQueryParams & PostSearchQueryStringParams;
 
 export interface PostSearchQueryStringParams {
+    /**
+     * The unique identifier of the target Coveo Cloud organization.
+     * Specifying a value for this parameter is only necessary when you are authenticating the API call with an OAuth2 token.
+     */
+    organizationId?: string;
+    /**
+     * Whether to bypass document permissions. Only effective if the access token grants the Search - View all content privilege.
+     */
     viewAllContent?: boolean | number;
 }
 
 /**
  * Defines the body parameters of the list field values request.
  */
-
-export interface ListFieldValuesBodyQueryParams {
-    /**
-     * The unique identifier of the target Coveo Cloud organization.
-     * Specifying a value for this parameter is only necessary when you are authenticating the API call with an OAuth2 token.
-     */
-    organizationId?: string;
-
+export interface ListFieldValuesBodyQueryParams extends PostSearchQueryStringParams {
     /**
      * Whether to treat accentuated characters as non-accentuated characters when retrieving field values (e.g., treat é, è, ê, etc., as e).
      *
@@ -2413,4 +2414,21 @@ export interface RestUserActionsParameters {
      * @example `c7ab60e2-e6b8-41e8-be6a-ad5c8edc662e`
      */
     tagViewsOfUser?: string;
+}
+
+export interface ItemPreviewHtmlParameters extends PostSearchQueryStringParams {
+    /**
+     * The unique ID of the document.
+     */
+    uniqueId: string;
+    enableNavigation?: boolean;
+    findNext?: number;
+    findPrevious?: number;
+    page?: number;
+    /**
+     * The approximate number of bytes to request in the HTML response.
+     *
+     * @default 0 // meaning that the entire HTML document is requested
+     */
+    requestedOutputSize?: number;
 }

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -149,7 +149,9 @@ describe('Search', () => {
         it('makes a GET call to the /html endpoint', () => {
             search.previewHTML({uniqueId: 'document-id'});
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`/rest/search/v2/html?uniqueId=document-id`);
+            expect(api.get).toHaveBeenCalledWith(`/rest/search/v2/html?uniqueId=document-id`, {
+                responseBodyFormat: 'text',
+            });
         });
     });
 });

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -144,4 +144,12 @@ describe('Search', () => {
             expect(api.post).toHaveBeenCalledWith(`${Search.baseUrl}/querySuggest`, queryParams);
         });
     });
+
+    describe('previewHTML', () => {
+        it('makes a GET call to the /html endpoint', () => {
+            search.previewHTML({uniqueId: 'document-id'});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`/rest/search/v2/html?uniqueId=document-id`);
+        });
+    });
 });

--- a/src/tests/APICore.spec.ts
+++ b/src/tests/APICore.spec.ts
@@ -66,9 +66,7 @@ describe('APICore', () => {
     describe('calling the right endpoint', () => {
         beforeEach(() => {
             jest.clearAllMocks();
-            fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                headers: {'Content-Type': 'application/json'},
-            });
+            fetchMock.mockResponseOnce(JSON.stringify(testData.response));
         });
 
         it('should call the default endpoint if no environment, region, and host is specified', async () => {
@@ -123,9 +121,7 @@ describe('APICore', () => {
         it('should retry on throttle', async () => {
             fetchMock
                 .mockResponseOnce('too fast there cowboy!', {status: 429})
-                .mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                .mockResponseOnce(JSON.stringify(testData.response));
             await api.get(testData.route);
 
             expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -133,9 +129,7 @@ describe('APICore', () => {
 
         describe('get', () => {
             it('should do a simple GET request', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 const response = await api.get<typeof testData.response>(testData.route);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -154,18 +148,14 @@ describe('APICore', () => {
             });
 
             it('should bind GET requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 await api.get(testData.route);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeInstanceOf(AbortSignal);
             });
 
             it('user arguments can set anything but the method', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 await api.get(testData.route, {
                     window: null,
                     credentials: 'include',
@@ -182,9 +172,7 @@ describe('APICore', () => {
             });
 
             it('user signal can abort', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 const userAbort = new AbortController();
                 await api.get(testData.route, {signal: userAbort.signal});
 
@@ -200,6 +188,9 @@ describe('APICore', () => {
             });
         });
 
+        /**
+         * @deprecated Will be removed in version 45
+         */
         describe('getFile', () => {
             it('should do a GET request to the specified url and resolve with a blob', async () => {
                 fetchMock.mockResponseOnce(JSON.stringify(testData.response));
@@ -230,9 +221,7 @@ describe('APICore', () => {
 
         describe('post', () => {
             it('should do a simple POST request', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 const response = await api.post(testData.route, testData.body);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -246,18 +235,14 @@ describe('APICore', () => {
             });
 
             it('should not bind POST requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 await api.post(testData.route, testData.body);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeUndefined();
             });
 
             it('user arguments can set anything but the method', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 const userAbort = new AbortController();
                 const body: BodyInit = 'RAW STRING';
 
@@ -283,9 +268,7 @@ describe('APICore', () => {
             const formMock: jest.Mocked<FormData> = jest.fn() as any;
 
             it('should do a simple POST request using form data', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 const response = await api.postForm(testData.route, formMock);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -299,9 +282,7 @@ describe('APICore', () => {
             });
 
             it('should not bind POST requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 await api.postForm(testData.route, formMock);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeUndefined();
@@ -310,9 +291,7 @@ describe('APICore', () => {
 
         describe('put', () => {
             it('should do a simple PUT request', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 const response = await api.put(testData.route, testData.body);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -326,18 +305,14 @@ describe('APICore', () => {
             });
 
             it('should not bind PUT requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 await api.put(testData.route, testData.body);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeUndefined();
             });
 
             it('user arguments can set anything but the method', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 const userAbort = new AbortController();
                 const body: BodyInit = 'RAW STRING';
 
@@ -361,9 +336,7 @@ describe('APICore', () => {
 
         describe('patch', () => {
             it('should do a simple PATCH request', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 const response = await api.patch(testData.route, testData.body);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -377,18 +350,14 @@ describe('APICore', () => {
             });
 
             it('should not bind PATCH requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 await api.patch(testData.route, testData.body);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeUndefined();
             });
 
             it('user arguments can set anything but the method', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 const userAbort = new AbortController();
                 const body: BodyInit = 'RAW STRING';
 
@@ -412,9 +381,7 @@ describe('APICore', () => {
 
         describe('delete', () => {
             it('should do a simple DELETE request', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 const response = await api.delete(testData.route);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -426,18 +393,14 @@ describe('APICore', () => {
             });
 
             it('should not bind DELETE requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 await api.delete(testData.route);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeUndefined();
             });
 
             it('user arguments can set anything but the method', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 await api.delete(testData.route, {
                     window: null,
                     credentials: 'include',
@@ -456,9 +419,7 @@ describe('APICore', () => {
 
         describe('when calling abortGetRequests', () => {
             it('should abort pending get requests', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 await api.get(testData.route);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal?.aborted).toBe(false);
@@ -468,9 +429,7 @@ describe('APICore', () => {
 
             it('should abort pending get requests even with user abort', async () => {
                 const userAbort = new AbortController();
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 await api.get(testData.route, {signal: userAbort.signal});
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal?.aborted).toBe(false);
@@ -480,9 +439,7 @@ describe('APICore', () => {
             });
 
             it('should not abort get requests that are being sent after the abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-                    headers: {'Content-Type': 'application/json'},
-                });
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
                 await api.abortGetRequests();
                 await api.get(testData.route);
                 const init = fetchMock.mock.calls[0][1];
@@ -524,9 +481,7 @@ describe('APICore', () => {
     });
 
     it('should give priority to custom response handlers when specified', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
-            headers: {'Content-Type': 'application/json'},
-        });
+        fetchMock.mockResponseOnce(JSON.stringify(testData.response));
         const CustomResponseHandler: ResponseHandler = {
             canProcess: (response: Response): boolean => response.ok,
             process: jest.fn(),
@@ -608,17 +563,9 @@ describe('APICore', () => {
 
             fetchMock.mockImplementation((_url: string, config: RequestInit): Promise<Response> => {
                 if (config.headers && config.headers['override']) {
-                    return Promise.resolve(
-                        new Response(JSON.stringify(responseBody), {
-                            headers: {'Content-Type': 'application/json'},
-                        })
-                    );
+                    return Promise.resolve(new Response(JSON.stringify(responseBody)));
                 }
-                return Promise.resolve(
-                    new Response(JSON.stringify(testData.response), {
-                        headers: {'Content-Type': 'application/json'},
-                    })
-                );
+                return Promise.resolve(new Response(JSON.stringify(testData.response)));
             });
 
             const api = new API({...testConfig, globalRequestSettings});
@@ -642,17 +589,9 @@ describe('APICore', () => {
 
             fetchMock.mockImplementation((_url: string, config: RequestInit): Promise<Response> => {
                 if (config.headers && config.headers['override'] === overriddenValue) {
-                    return Promise.resolve(
-                        new Response(JSON.stringify(responseBody), {
-                            headers: {'Content-Type': 'application/json'},
-                        })
-                    );
+                    return Promise.resolve(new Response(JSON.stringify(responseBody)));
                 }
-                return Promise.resolve(
-                    new Response(JSON.stringify(testData.response), {
-                        headers: {'Content-Type': 'application/json'},
-                    })
-                );
+                return Promise.resolve(new Response(JSON.stringify(testData.response)));
             });
 
             const api = new API({...testConfig, globalRequestSettings});

--- a/src/tests/APICore.spec.ts
+++ b/src/tests/APICore.spec.ts
@@ -66,7 +66,9 @@ describe('APICore', () => {
     describe('calling the right endpoint', () => {
         beforeEach(() => {
             jest.clearAllMocks();
-            fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+            fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                headers: {'Content-Type': 'application/json'},
+            });
         });
 
         it('should call the default endpoint if no environment, region, and host is specified', async () => {
@@ -121,7 +123,9 @@ describe('APICore', () => {
         it('should retry on throttle', async () => {
             fetchMock
                 .mockResponseOnce('too fast there cowboy!', {status: 429})
-                .mockResponseOnce(JSON.stringify(testData.response));
+                .mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
             await api.get(testData.route);
 
             expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -129,7 +133,9 @@ describe('APICore', () => {
 
         describe('get', () => {
             it('should do a simple GET request', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 const response = await api.get<typeof testData.response>(testData.route);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -148,14 +154,18 @@ describe('APICore', () => {
             });
 
             it('should bind GET requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 await api.get(testData.route);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeInstanceOf(AbortSignal);
             });
 
             it('user arguments can set anything but the method', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 await api.get(testData.route, {
                     window: null,
                     credentials: 'include',
@@ -172,7 +182,9 @@ describe('APICore', () => {
             });
 
             it('user signal can abort', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 const userAbort = new AbortController();
                 await api.get(testData.route, {signal: userAbort.signal});
 
@@ -218,7 +230,9 @@ describe('APICore', () => {
 
         describe('post', () => {
             it('should do a simple POST request', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 const response = await api.post(testData.route, testData.body);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -232,14 +246,18 @@ describe('APICore', () => {
             });
 
             it('should not bind POST requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 await api.post(testData.route, testData.body);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeUndefined();
             });
 
             it('user arguments can set anything but the method', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 const userAbort = new AbortController();
                 const body: BodyInit = 'RAW STRING';
 
@@ -265,7 +283,9 @@ describe('APICore', () => {
             const formMock: jest.Mocked<FormData> = jest.fn() as any;
 
             it('should do a simple POST request using form data', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 const response = await api.postForm(testData.route, formMock);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -279,7 +299,9 @@ describe('APICore', () => {
             });
 
             it('should not bind POST requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 await api.postForm(testData.route, formMock);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeUndefined();
@@ -288,7 +310,9 @@ describe('APICore', () => {
 
         describe('put', () => {
             it('should do a simple PUT request', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 const response = await api.put(testData.route, testData.body);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -302,14 +326,18 @@ describe('APICore', () => {
             });
 
             it('should not bind PUT requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 await api.put(testData.route, testData.body);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeUndefined();
             });
 
             it('user arguments can set anything but the method', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 const userAbort = new AbortController();
                 const body: BodyInit = 'RAW STRING';
 
@@ -333,7 +361,9 @@ describe('APICore', () => {
 
         describe('patch', () => {
             it('should do a simple PATCH request', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 const response = await api.patch(testData.route, testData.body);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -347,14 +377,18 @@ describe('APICore', () => {
             });
 
             it('should not bind PATCH requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 await api.patch(testData.route, testData.body);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeUndefined();
             });
 
             it('user arguments can set anything but the method', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 const userAbort = new AbortController();
                 const body: BodyInit = 'RAW STRING';
 
@@ -378,7 +412,9 @@ describe('APICore', () => {
 
         describe('delete', () => {
             it('should do a simple DELETE request', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 const response = await api.delete(testData.route);
 
                 expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -390,14 +426,18 @@ describe('APICore', () => {
             });
 
             it('should not bind DELETE requests to an abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 await api.delete(testData.route);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal).toBeUndefined();
             });
 
             it('user arguments can set anything but the method', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 await api.delete(testData.route, {
                     window: null,
                     credentials: 'include',
@@ -416,7 +456,9 @@ describe('APICore', () => {
 
         describe('when calling abortGetRequests', () => {
             it('should abort pending get requests', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 await api.get(testData.route);
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal?.aborted).toBe(false);
@@ -426,7 +468,9 @@ describe('APICore', () => {
 
             it('should abort pending get requests even with user abort', async () => {
                 const userAbort = new AbortController();
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 await api.get(testData.route, {signal: userAbort.signal});
                 const init = fetchMock.mock.calls[0][1];
                 expect(init?.signal?.aborted).toBe(false);
@@ -436,7 +480,9 @@ describe('APICore', () => {
             });
 
             it('should not abort get requests that are being sent after the abort signal', async () => {
-                fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+                fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+                    headers: {'Content-Type': 'application/json'},
+                });
                 await api.abortGetRequests();
                 await api.get(testData.route);
                 const init = fetchMock.mock.calls[0][1];
@@ -478,7 +524,9 @@ describe('APICore', () => {
     });
 
     it('should give priority to custom response handlers when specified', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify(testData.response));
+        fetchMock.mockResponseOnce(JSON.stringify(testData.response), {
+            headers: {'Content-Type': 'application/json'},
+        });
         const CustomResponseHandler: ResponseHandler = {
             canProcess: (response: Response): boolean => response.ok,
             process: jest.fn(),
@@ -560,9 +608,17 @@ describe('APICore', () => {
 
             fetchMock.mockImplementation((_url: string, config: RequestInit): Promise<Response> => {
                 if (config.headers && config.headers['override']) {
-                    return Promise.resolve(new Response(JSON.stringify(responseBody)));
+                    return Promise.resolve(
+                        new Response(JSON.stringify(responseBody), {
+                            headers: {'Content-Type': 'application/json'},
+                        })
+                    );
                 }
-                return Promise.resolve(new Response(JSON.stringify(testData.response)));
+                return Promise.resolve(
+                    new Response(JSON.stringify(testData.response), {
+                        headers: {'Content-Type': 'application/json'},
+                    })
+                );
             });
 
             const api = new API({...testConfig, globalRequestSettings});
@@ -586,9 +642,17 @@ describe('APICore', () => {
 
             fetchMock.mockImplementation((_url: string, config: RequestInit): Promise<Response> => {
                 if (config.headers && config.headers['override'] === overriddenValue) {
-                    return Promise.resolve(new Response(JSON.stringify(responseBody)));
+                    return Promise.resolve(
+                        new Response(JSON.stringify(responseBody), {
+                            headers: {'Content-Type': 'application/json'},
+                        })
+                    );
                 }
-                return Promise.resolve(new Response(JSON.stringify(testData.response)));
+                return Promise.resolve(
+                    new Response(JSON.stringify(testData.response), {
+                        headers: {'Content-Type': 'application/json'},
+                    })
+                );
             });
 
             const api = new API({...testConfig, globalRequestSettings});

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,5 @@
+import {ResponseBodyFormat} from '../handlers/ResponseHandlerInterfaces.js';
+
 export interface AsyncSupplier<T> {
     (): Promise<T>;
 }
@@ -10,4 +12,6 @@ export interface Predicate<T> {
     (value: T): boolean;
 }
 
-export interface CoveoPlatformClientRequestInit extends Omit<RequestInit, 'method'> {}
+export interface CoveoPlatformClientRequestInit extends Omit<RequestInit, 'method'> {
+    responseBodyFormat?: ResponseBodyFormat;
+}


### PR DESCRIPTION
Adding the [`GET /rest/search/v2/html`](https://docs.coveo.com/en/13/api-reference/search-api#tag/Search-V2/operation/htmlGet) endpoint on the `Platform.search` resource.

Usage:
```ts
const html = await Platform.search.previewHTML({uniqueId: '🆔'});
```

~#### Disclaimer 1~

~I had to modify the default `success` response handler, because it would parse any response as JSON. This particular endpoint's response is `text/html`, therefore it cannot be parsed as JSON.~

~To circumvent this issue, I added a condition to only call `response.json()` if the `Content-Type` header matches `application/json`. In the opposite case it will call `response.text()` instead. I am aware this solution isn't perfect, but it is in fact a step in the right direction considering what we were doing.~

⬆️ Fixed by adding `responseBodyFormat` arg, see last (third) commit

#### Disclaimer 2

I did not add all parameters listed in the documentation of the `/html` endpoint, as I have found and reported problems with this documentation while implementing this endpoint. Also, the amount of parameters is suspiciously long. Therefore I am not confident this documentation represents the truth. As a precaution, I suggest to add only those that we're certain are meaningful for now and add to that later if need be.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
