### PR TITLE
fix(APICore): forward responseBodyFormat to response handlers

### DIFF
--- a/src/APICore.ts
+++ b/src/APICore.ts
@@ -213,19 +213,19 @@ export default class API {
         args: CoveoPlatformClientRequestInit | undefined,
         prefilled?: RequestInit
     ): RequestInit {
-        delete args?.responseBodyFormat;
+        const {responseBodyFormat, ...requestArgs} = args ?? {};
         const globalRequestSettings = this.config.globalRequestSettings;
 
         const init: RequestInit = {
             ...prefilled,
             ...globalRequestSettings,
-            ...args,
+            ...requestArgs,
             method,
             headers: {
                 Authorization: `Bearer ${this.accessToken}`,
                 ...prefilled?.headers,
                 ...globalRequestSettings?.headers,
-                ...args?.headers,
+                ...requestArgs?.headers,
             },
         };
 


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

This fix makes sure `responseBodyFormat` argument reaches the response handlers. The `args` object was getting mutated by the call to `delete`, preventing `responseBodyFormat` argument to have any value other than `'json'` when reaching the response handlers. Added some missing UT coverage for it.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
