### PR TITLE
fix(statements): fix exportCSV return type

### DIFF
--- a/src/resources/Pipelines/Statements/Statements.ts
+++ b/src/resources/Pipelines/Statements/Statements.ts
@@ -21,7 +21,7 @@ export default class Statements extends Resource {
         );
     }
 
-    exportCSV(pipelineId: string, options?: ExportStatementParams) {
+    exportCSV(pipelineId: string, options?: ExportStatementParams): Promise<Blob> {
         return this.api.get(
             this.buildPath(`${Statements.getBaseUrl(pipelineId)}/export`, {
                 organizationId: this.api.organizationId,


### PR DESCRIPTION
`statements.exportCSV` method should return a `Blob`, not a `Record<string, unknown>`.

My bad, it was a small overlook on my part related to the new `responseBodyFormat` argument.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
