### PR TITLE
feat(index, permissions): add identity permissions endpoint

### DIFF
--- a/src/resources/Indexes/Documents/Documents.ts
+++ b/src/resources/Indexes/Documents/Documents.ts
@@ -1,10 +1,32 @@
 import API from '../../../APICore.js';
-import {DocumentPermissionModel, SinglePermissionPageModel} from '../../index.js';
+import {
+    DocumentPermissionForIdentityModel,
+    DocumentPermissionModel,
+    DocumentSecurityIdentityModel,
+    SinglePermissionPageModel,
+} from '../../index.js';
 import Resource from '../../Resource.js';
 import {ListEffectivePermissionsOptions} from './DocumentsInterfaces.js';
 
 export default class Documents extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/indexes`;
+
+    /**
+     * Get the document permission model information for a security identity.
+     *
+     * @param {string} indexId The unique identifier of the target index.
+     * @param {string} documentId The unique identifier of the item whose permissions to list.
+     * @param {DocumentSecurityIdentityModel} the security identity for which we want the permissions from.
+     *
+     */
+    getIdentityPermissions(indexId: string, documentId: string, identity: DocumentSecurityIdentityModel) {
+        return this.api.post<DocumentPermissionForIdentityModel>(
+            `${Documents.baseUrl}/${indexId}/documents/${encodeURIComponent(
+                encodeURIComponent(documentId)
+            )}/permissions/identity`,
+            identity
+        );
+    }
 
     /**
      * Lists the [permissions](https://docs.coveo.com/en/223/glossary/permission) of an [item](https://docs.coveo.com/en/210/glossary/item) in a Coveo Cloud organization index.

--- a/src/resources/Indexes/Documents/tests/Documents.spec.ts
+++ b/src/resources/Indexes/Documents/tests/Documents.spec.ts
@@ -1,5 +1,6 @@
 import API from '../../../../APICore.js';
-import {SinglePermissionState} from '../../../Enums.js';
+import {PermissionIdentityType, SinglePermissionState} from '../../../Enums.js';
+import {DocumentSecurityIdentityModel} from '../../../index.js';
 import Documents from '../Documents.js';
 
 jest.mock('../../../../APICore.js');
@@ -17,6 +18,28 @@ describe('Documents', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         documents = new Documents(api, serverlessApi);
+    });
+
+    describe('getIdentityPermissions', () => {
+        it('should make a POST call to the specific Documents url', () => {
+            const identity: DocumentSecurityIdentityModel = {
+                type: PermissionIdentityType.User,
+                provider: 'Email Security Provider',
+                name: 'test@test.coveo.com',
+                infos: [
+                    {
+                        key: 'key',
+                        value: 'value',
+                    },
+                ],
+            };
+            documents.getIdentityPermissions(INDEX_ID, DOCUMENT_ID, identity);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(
+                `${Documents.baseUrl}/${INDEX_ID}/documents/42.31537%2524file%253A%252F%252Fmovies%252Fthe-shining.txt/permissions/identity`,
+                identity
+            );
+        });
     });
 
     describe('listPermissions', () => {

--- a/src/resources/Sources/SourcesSubInterfaces/Permission.ts
+++ b/src/resources/Sources/SourcesSubInterfaces/Permission.ts
@@ -48,7 +48,7 @@ export interface SecurityIdentityInfoModel {
 export interface DetailedSecurityIdentityModel {
     name?: string;
     provider?: string;
-    type?: string;
+    type?: PermissionIdentityType;
     infos?: SecurityIdentityInfoModel[];
     declaration?: string;
     state?: SinglePermissionState;

--- a/src/resources/Sources/SourcesSubInterfaces/Permission.ts
+++ b/src/resources/Sources/SourcesSubInterfaces/Permission.ts
@@ -40,6 +40,57 @@ export interface DocumentPermissionModel {
     state?: DocumentPermissionState;
 }
 
+export interface SecurityIdentityInfoModel {
+    key?: string;
+    value?: string;
+}
+
+export interface DetailedSecurityIdentityModel {
+    name?: string;
+    provider?: string;
+    type?: string;
+    infos?: SecurityIdentityInfoModel[];
+    declaration?: string;
+    state?: SinglePermissionState;
+    createdDate?: number;
+    lastEnabledDate?: number;
+    lastUpdateDate?: number;
+    lastSuccessfulUpdateDate?: number;
+    lastStoredDate?: number;
+    orderingID?: number;
+    lastUpdateResult?: SinglePermissionResult;
+    lastUpdateErrorDetail?: string;
+}
+
+export interface DocumentSecurityIdentityModel {
+    name?: string;
+    provider?: string;
+    type?: PermissionIdentityType;
+    infos?: SecurityIdentityInfoModel[];
+}
+
+export interface PermissionSetForIdentityModel {
+    identityIsAllowed?: boolean;
+    identityIsDenied?: boolean;
+    allowAnonymous?: boolean;
+    allowedIdentitiesPaths?: DetailedSecurityIdentityModel[];
+    deniedIdentitiesPaths?: DetailedSecurityIdentityModel[];
+    name?: string;
+}
+
+export interface PermissionLevelForIdentityModel {
+    permissionSetsForIdentity?: PermissionSetForIdentityModel[];
+    name?: string;
+    identityIsAllowed?: boolean;
+    identityIsDenied?: boolean;
+}
+
+export interface DocumentPermissionForIdentityModel {
+    permissionLevelsForIdentity: PermissionLevelForIdentityModel[];
+    identityIsAllowed?: boolean;
+    identityIsDenied?: boolean;
+}
+
 export interface Permission {
     additionalInfo?: any;
     identity?: string;


### PR DESCRIPTION
# [ADUI-8967](https://coveord.atlassian.net/browse/ADUI-8967)

### 📖  Description

Add the `permissions/identity` call which allows to get the permissions for a given identity. It's currently being used in the `Permission Details` tab when inspecting a single document in the Content Browser. 

**Note**: This feature is only accessible to internal users. That being said, that endpoint doesn't seem to be documented anywhere. I looked directly in the code to validate the parameters and the models.

[IndexApi.java](https://github.com/coveo/indexservice/blob/7233a9d70d99cc15b3f7e2bc2d44c422a50409c1/coveo-cloud-services-index-api/src/main/java/com/coveo/cloud/index/api/IndexApi.java#L208)

### 🧪 Test

Linked my local `platform-client` to my local `admin-ui` and tried the endpoint on the new Content Browser.

https://github.com/coveo/platform-client/assets/133259861/fc39e461-23ca-463c-829b-078ac93ff314

### Acceptance Criteria

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
    - **This call doesn't seem to be publicly accessible on purpose. Only internal users have access to the UI that uses this endpoint (see this [JIRA](https://coveord.atlassian.net/browse/SECCACHE-486)).**
-   [ ] JSDoc annotates each property added in the exported interfaces
    - **Like I said above, that endpoint is not really documented anywhere. I added some documentation on the endpoint itself, but not the other interfaces.**
-   [X] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[ADUI-8967]: https://coveord.atlassian.net/browse/ADUI-8967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ