### PR TITLE
feat(search): add getDocument method

### DIFF
--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -2,8 +2,10 @@ import {ListFieldValuesBodyQueryParams, PostSearchQuerySuggestBodyParams} from '
 import API from '../../APICore.js';
 import Ressource from '../Resource.js';
 import {
+    SingleItemParameters,
     ItemPreviewHtmlParameters,
     RestQueryParams,
+    RestQueryResult,
     RestTokenParams,
     SearchListFieldsParams,
     SearchListFieldsResponse,
@@ -71,6 +73,18 @@ export default class Search extends Ressource {
                 organizationId: params.organizationId ?? this.api.organizationId,
             }),
             {responseBodyFormat: 'text'}
+        );
+    }
+
+    /**
+     * Get item in JSON format
+     */
+    getDocument(params: SingleItemParameters) {
+        return this.api.get<RestQueryResult>(
+            this.buildPath(`${Search.baseUrl}/document`, {
+                ...params,
+                organizationId: params.organizationId ?? this.api.organizationId,
+            })
         );
     }
 }

--- a/src/resources/Search/SearchInterfaces.ts
+++ b/src/resources/Search/SearchInterfaces.ts
@@ -2915,3 +2915,10 @@ export interface SearchResponse {
      */
     [key: string]: unknown;
 }
+
+export interface SingleItemParameters extends PostSearchQueryStringParams {
+    /**
+     * The unique ID of the document.
+     */
+    uniqueId: string;
+}

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -154,4 +154,12 @@ describe('Search', () => {
             });
         });
     });
+
+    describe('getDocument', () => {
+        it('makes a GET call to the /document endpoint', () => {
+            search.getDocument({uniqueId: 'document-id'});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`/rest/search/v2/document?uniqueId=document-id`);
+        });
+    });
 });


### PR DESCRIPTION
Adding the `search.getDocument` method which retrieves a single item from the index using its `uniqueId`

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
