### PR TITLE
feat(search): add exportQuery method

### DIFF
--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -52,6 +52,25 @@ export default class Search extends Ressource {
         );
     }
 
+    /**
+     * Exports search results to a Microsoft Excel™ spreadsheet
+     *
+     * @param restQueryParameters Parameters of the query
+     * @returns A .xlsx file containing the search results of the specified query
+     */
+    exportQuery(restQueryParameters: RestQueryParams) {
+        const {viewAllContent, ...bodyParameters} = restQueryParameters;
+
+        return this.api.post<Blob>(
+            this.buildPath(Search.baseUrl, {
+                organizationId: this.api.organizationId,
+                viewAllContent: viewAllContent ? 1 : undefined,
+            }),
+            {...bodyParameters, format: 'xlsx'},
+            {responseBodyFormat: 'blob'}
+        );
+    }
+
     querySuggestPost(restQuerySuggestParameters: PostSearchQuerySuggestBodyParams) {
         return this.api.post<any>(
             this.buildPath(`${Search.baseUrl}/querySuggest`, {

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -136,6 +136,19 @@ describe('Search', () => {
         });
     });
 
+    describe('exportQuery', () => {
+        it('makes a post call to the query endpoint with xlsx format', () => {
+            const queryParams = {q: ''};
+            search.exportQuery(queryParams);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(
+                Search.baseUrl,
+                {q: '', format: 'xlsx'},
+                {responseBodyFormat: 'blob'}
+            );
+        });
+    });
+
     describe('querySuggestPost', () => {
         it('should make a post call to the querySuggest endpoint', () => {
             const queryParams = {q: ''};


### PR DESCRIPTION
Adding a specific method for exporting a query response to Excel format. The reason why I am creating a new method and not reusing the existing `query` method is that I need the response body format to be a blob in order to download it as a file.


Linked this branch to the admin-ui and implemented the export to Excel feature, and made sure it works:

https://github.com/coveo/platform-client/assets/35579930/f15052c2-5eed-4d5f-8410-ecfb09f7b5b5

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
