### PR TITLE
feat(search, facet): add endpoint to search facets

### DIFF
--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -11,6 +11,8 @@ import {
     SearchListFieldsResponse,
     SearchResponse,
     TokenModel,
+    RestFacetSearchParameters,
+    RestFacetSearchResponse,
 } from './SearchInterfaces.js';
 
 export default class Search extends Ressource {
@@ -104,6 +106,21 @@ export default class Search extends Ressource {
                 ...params,
                 organizationId: params.organizationId ?? this.api.organizationId,
             }),
+        );
+    }
+
+    /**
+     * Executes a facet search request.
+     */
+    searchFacet(params: RestFacetSearchParameters) {
+        const {viewAllContent, organizationId, ...bodyParameters} = params;
+
+        return this.api.post<RestFacetSearchResponse>(
+            this.buildPath(`${Search.baseUrl}/facet`, {
+                organizationId: organizationId ?? this.api.organizationId,
+                viewAllContent,
+            }),
+            bodyParameters,
         );
     }
 }

--- a/src/resources/Search/SearchInterfaces.ts
+++ b/src/resources/Search/SearchInterfaces.ts
@@ -2922,3 +2922,114 @@ export interface SingleItemParameters extends PostSearchQueryStringParams {
      */
     uniqueId: string;
 }
+
+export interface RestFacetSearchParameters extends PostSearchQueryStringParams {
+    /**
+     * The name of the field against which to execute the facet search request.
+     */
+    field: string;
+    /**
+     * The kind of facet against which the search request is being made.
+     *
+     * **Allowed values:**
+     * - `specific`
+     * - `hierarchical`
+     *
+     * Default: `specific`
+     */
+    type?: 'specific' | 'hierarchical';
+    /**
+     * A list of index field values to filter out from the facet search results.
+     */
+    ignoreValues?: string[];
+    /**
+     * The maximum number of values to fetch.
+     *
+     * Default: 10
+     */
+    numberOfValues?: number;
+    /**
+     * The string to match.
+     *
+     * Note: Typically, this should be set to the text entered by the end-user in the facet search box, to which one or more wildcard characters (*) may be added.
+     */
+    query?: string;
+    /**
+     * A dictionary that maps index field values to facet value display names.
+     *
+     * Note: When specifying display captions for hierarchical facet values, you can use full values (e.g., all;electronics;laptops), and/or for "leaf" values (e.g., laptops) as keys. If a hierchical facet value can be mapped to two different display captions, the most specific mapping (i.e., the one whose key is the full value) applies.
+     *
+     * Examples:
+     * - Specific (i.e., scalar) facet values: `{"#FF8000": "Orange", "#8000FF": "Purple"}`
+     * - Hierarchical facet values:`{"all;electronics;laptops": "Laptops", "smartphones": "Smart Phones"}`
+     */
+    captions?: Record<string, string>;
+    /**
+     * Search context.
+     */
+    searchContext?: RestQueryParams;
+    /**
+     * A list of paths to filter out from the hierarchical facet search results.
+     */
+    ignorePaths?: string[];
+    /**
+     * Whether to exclude folded result parents when estimating the result count for each facet value.
+     *
+     * Note: The target folding field must be a facet field with the Use cache for nested queries options enabled (see [Add or Edit a Field](https://docs.coveo.com/en/1982/index-content/add-or-edit-a-field)).
+     *
+     * Default: `false`
+     */
+    filterFacetCount?: boolean;
+    /**
+     * The character to use to split field values into a hierarchical sequence.
+     *
+     * Example:
+     *
+     * For a multi-value field containing the following values:
+     *
+     * `c; c>folder2; c>folder2>folder3;`
+     *
+     * The delimiting character is `>`.
+     *
+     * For a hierarchical field containing the following values:
+     *
+     * `c;folder2;folder3;`
+     *
+     * The delimiting character is `;`.
+     */
+    delimitingCharacter?: string;
+    /**
+     * The base path shared by all values for the facet against which the search request is being made. This parameter is only taken into account when the specified facet `type` is `hiearchical`.
+     *
+     * If a `basePath` is specified, the search request will be executed against hierarchical values that begin with that base path only (i.e., other hierarchical values will be filtered out).
+     *
+     * Note: This parameter has no effect unless the facet `type` is `hierarchical`.
+     */
+    basePath?: string[];
+}
+
+export interface RestFacetSearchResultValue {
+    /**
+     * The custom facet value display name, as specified in the `captions` argument of the facet search request.
+     */
+    displayValue: string;
+    /**
+     * The original facet value, as retrieved from the field in the index.
+     */
+    rawValue: string;
+    /**
+     * An estimate number of result items matching both the current query and the filter expression that would get generated if the facet value were selected.
+     */
+    count: number;
+}
+
+export interface RestFacetSearchResponse {
+    /**
+     * The returned facet values.
+     */
+    values: RestFacetSearchResultValue[];
+    /**
+     * Whether additional facet values matching the request are available.
+     */
+    moreValuesAvailable: boolean;
+}

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -1,6 +1,7 @@
 import API from '../../../APICore.js';
 import {RestUserIdType} from '../../Enums.js';
 import Search from '../Search.js';
+import {RestFacetSearchParameters} from '../SearchInterfaces.js';
 
 jest.mock('../../../APICore.js');
 
@@ -173,6 +174,46 @@ describe('Search', () => {
             search.getDocument({uniqueId: 'document-id'});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`/rest/search/v2/document?uniqueId=document-id`);
+        });
+    });
+
+    describe('searchFacet', () => {
+        const searchFacetRequest: RestFacetSearchParameters = {
+            field: 'field',
+            type: 'hierarchical',
+            ignoreValues: ['ignored_value'],
+            numberOfValues: 15,
+            query: 'query',
+            captions: {'all;electronics;laptops": "Laptops"': 'caption1'},
+            searchContext: {},
+            ignorePaths: ['ignored_path'],
+            filterFacetCount: false,
+            delimitingCharacter: ';',
+            basePath: ['base_path'],
+        };
+        it('makes a post call to the search facet endpoint', () => {
+            search.searchFacet({...searchFacetRequest, organizationId: 'specific-org-id', viewAllContent: true});
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenLastCalledWith(
+                `/rest/search/v2/facet?organizationId=specific-org-id&viewAllContent=true`,
+                searchFacetRequest,
+            );
+        });
+        it('adds the organizationId query param from the config if missing in the arguments', () => {
+            const tempOrganizationId = api.organizationId;
+            // change the value of organizationId on the mock
+            Object.defineProperty(api, 'organizationId', {value: 'my-org', writable: true});
+
+            search.searchFacet(searchFacetRequest);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenLastCalledWith(
+                `/rest/search/v2/facet?organizationId=my-org`,
+                searchFacetRequest,
+            );
+
+            // reset organizationId to old value
+            Object.defineProperty(api, 'organizationId', {value: tempOrganizationId, writable: true});
         });
     });
 });


### PR DESCRIPTION
### 📖 Description

Add endpoint to search facet values for a given facet.

See the endpoint in [Swagger](https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20API#/Search%20V2/facetSearch).

### 🧪 Testing

🎬 Linked `platform-client` to my local `admin-ui` instance and plugged the endpoint with the search action of a facet.

⚠️ For the purpose of this test, I didn't make it so the list reflected the API call's results. I only inspected the network tab to make sure the results returned looked good.

https://github.com/coveo/platform-client/assets/133259861/98431de8-321e-4d1e-90a2-576186f2dca9
 
### Acceptance Criteria

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
    - See the endpoint in [Swagger](https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20API#/Search%20V2/facetSearch).
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
