### PR TITLE
fix: add dataHealth to UsageAnalytics resource class

### DIFF
--- a/src/resources/UsageAnalytics/UsageAnalytics.ts
+++ b/src/resources/UsageAnalytics/UsageAnalytics.ts
@@ -8,9 +8,11 @@ import Filters from './Read/Filters/Filters.js';
 import Reports from './Read/Reports/Reports.js';
 import Snowflake from './Read/Snowflake/Snowflake.js';
 import Statistics from './Read/Statistics/Statistics.js';
+import DataHealth from './Read/DataHealth/DataHealth.js';
 
 export default class UsageAnalytics extends Resource {
     administration: Administration;
+    dataHealth: DataHealth;
     dataShare: DataShare;
     dimensions: Dimensions;
     exports: Exports;
@@ -26,6 +28,7 @@ export default class UsageAnalytics extends Resource {
         super(api, serverlessApi);
 
         this.administration = new Administration(api, serverlessApi);
+        this.dataHealth = new DataHealth(api, serverlessApi);
         this.dataShare = new DataShare(api, serverlessApi);
         this.dimensions = new Dimensions(api, serverlessApi);
         this.exports = new Exports(api, serverlessApi);


### PR DESCRIPTION
## [UA-8052](https://coveord.atlassian.net/browse/UA-8052?atlOrigin=eyJpIjoiZmJhZTk5ZGU4MjcxNGU5NTkyMWRlMDFkMjczMGRhODUiLCJwIjoiaiJ9)

Add missing entry to UsageAnalytics resource class

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[UA-8052]: https://coveord.atlassian.net/browse/UA-8052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ