### PR TITLE
feat(insight): add duplicate config route

### DIFF
--- a/src/resources/InsightPanelConfigs/InsightPanelConfig.ts
+++ b/src/resources/InsightPanelConfigs/InsightPanelConfig.ts
@@ -3,6 +3,7 @@ import {New, PageModel} from '../BaseInterfaces.js';
 import Resource from '../Resource.js';
 import {
     InsightPanelConfigCreationParams,
+    InsightPanelConfigDuplicateParams,
     InsightPanelConfigListOptions,
     InsightPanelConfigModel,
     InsightPanelConfigUpdateParams,
@@ -31,5 +32,11 @@ export default class InsightPanelConfig extends Resource {
         const {id, ...body} = insightPanelConfig;
 
         return this.api.put<InsightPanelConfigModel>(`${InsightPanelConfig.baseUrl}/${id}`, body);
+    }
+
+    duplicate(duplicationParams: InsightPanelConfigDuplicateParams) {
+        const {id, name} = duplicationParams;
+
+        return this.api.post<InsightPanelConfigModel>(`${InsightPanelConfig.baseUrl}/${id}`, name);
     }
 }

--- a/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
+++ b/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
@@ -86,7 +86,7 @@ export interface InsightPanelConfigUpdateParams
  */
 export interface InsightPanelConfigDuplicateParams {
     /**
-     * The Insight Panel configuration ID.
+     * The ID of the Insight Panel configuration to duplicate.
      */
     id: string;
     /**

--- a/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
+++ b/src/resources/InsightPanelConfigs/InsightPanelConfigInterfaces.ts
@@ -82,6 +82,20 @@ export interface InsightPanelConfigUpdateParams
 }
 
 /**
+ * Defines the parameters required to duplicate an Insight Panel configuration.
+ */
+export interface InsightPanelConfigDuplicateParams {
+    /**
+     * The Insight Panel configuration ID.
+     */
+    id: string;
+    /**
+     * The duplicated Insight Panel configuration name.
+     */
+    name: string;
+}
+
+/**
  * Defines an Insight Panel configuration.
  */
 export interface InsightPanelConfigModel {

--- a/src/resources/InsightPanelConfigs/tests/InsightPanelConfig.spec.ts
+++ b/src/resources/InsightPanelConfigs/tests/InsightPanelConfig.spec.ts
@@ -106,4 +106,19 @@ describe('InsightPanelConfig', () => {
             expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}/${insightPanelConfigId}`);
         });
     });
+
+    describe('duplicate', () => {
+        it('should make a POST call to the specific InsightPanelConfig URL', () => {
+            const duplicateInsightPanelParams = {
+                name: 'my duplicated insight panel',
+                id: 'some-insight-panel-config',
+            };
+            const {id, name} = duplicateInsightPanelParams;
+
+            insightPanel.duplicate(duplicateInsightPanelParams);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}/${id}`, name);
+        });
+    });
 });

--- a/src/resources/InsightPanelConfigs/tests/InsightPanelConfig.spec.ts
+++ b/src/resources/InsightPanelConfigs/tests/InsightPanelConfig.spec.ts
@@ -118,7 +118,7 @@ describe('InsightPanelConfig', () => {
             insightPanel.duplicate(duplicateInsightPanelParams);
 
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}/${id}`, name);
+            expect(api.post).toHaveBeenCalledWith(`${InsightPanelConfig.baseUrl}/${id}`, name);
         });
     });
 });


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->
[SVCC-3139](https://coveord.atlassian.net/browse/SVCC-3139)
### Acceptance Criteria
Add insight panel duplication config route of the following route: 
`/organizations/:organizationId/insightconfig/v1/configs/:configId`

with a body as:
`{
  name: string;
}`
<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[SVCC-3139]: https://coveord.atlassian.net/browse/SVCC-3139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ