### PR TITLE
fix(MLX):  add ModelInformationPQS interface

### DIFF
--- a/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
+++ b/src/resources/MachineLearning/ModelInformation/ModelInformationInterfaces.ts
@@ -197,6 +197,10 @@ export interface ModelInformationQS {
     [key: string]: any;
 }
 
+export interface ModelInformationPQS extends ModelInformationQS {
+    catalogIdOpt: string;
+}
+
 export interface MetaInfoSmartSnippets extends MetaInfo {
     modelId: string;
     engineName: string;


### PR DESCRIPTION
To fix this issue [MLX-556](https://coveord.atlassian.net/browse/MLX-556)
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[MLX-556]: https://coveord.atlassian.net/browse/MLX-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ