### PR TITLE
feat(ml): add interfaces for model listing endpoint

### DIFF
--- a/src/resources/MachineLearning/ModelListing/ModelListingConfiguration.ts
+++ b/src/resources/MachineLearning/ModelListing/ModelListingConfiguration.ts
@@ -1,0 +1,25 @@
+export interface MLListingModel {
+    modelDisplayName: string;
+    modelId: string;
+    engineId: string;
+    estimatedPreviousModelUpdateTime: number;
+    nextModelUpdateTime: number;
+    platformVersion: 1 | 2;
+    modelSizeStatistic: number;
+    readyForAssociation: boolean;
+    hasCustomerErrors: boolean;
+    modelStatusInfo: MLModelStatusInfo;
+    modelAssociations: MLModelAssociation[];
+}
+
+export interface MLModelStatusInfo {
+    modelStatus: string;
+    daysUntilArchival: number;
+}
+
+export interface MLModelAssociation {
+    parentId: string;
+    id: string;
+    name: string;
+    associationType: string;
+}

--- a/src/resources/MachineLearning/ModelListing/index.ts
+++ b/src/resources/MachineLearning/ModelListing/index.ts
@@ -1,0 +1,1 @@
+export * from './ModelListingConfiguration.js';

--- a/src/resources/MachineLearning/index.ts
+++ b/src/resources/MachineLearning/index.ts
@@ -3,6 +3,7 @@ export * from './MachineLearningInterfaces.js';
 export * from './FilterConditions.js';
 export * from './Models/index.js';
 export * from './ModelInformation/index.js';
+export * from './ModelListing/index.js';
 export * from './DNEConfiguration/index.js';
 export * from './CaseClassificationConfiguration/index.js';
 export * from './SmartSnippetsConfiguration/index.js';


### PR DESCRIPTION
According to the discussion here: https://github.com/coveo/platform-client/pull/736. Since the model listing endpoint is not deployed to prod. I want to split the PR and add the interfaces first in this PR so that I don't have to redefine these in the adui. 

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
