### PR TITLE
feat(workspace): add CRUD operations for projects and resources

### DIFF
--- a/src/resources/PlatformResources.ts
+++ b/src/resources/PlatformResources.ts
@@ -49,6 +49,8 @@ import Vaults from './Vaults/Vaults.js';
 import TableauService from './TableauService/TableauService.js';
 import HostedPages from './HostedPages/HostedPages.js';
 import SearchAnalysis from './SearchAnalysis/SearchAnalysis.js';
+import Project from './Projects/Project.js';
+import Resources from './Resources/Resources.js';
 
 const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'activity', resource: Activity},
@@ -102,6 +104,8 @@ const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'privilegeEvaluator', resource: PrivilegeEvaluator},
     {key: 'tableauService', resource: TableauService},
     {key: 'searchAnalysis', resource: SearchAnalysis},
+    {key: 'project', resource: Project},
+    {key: 'resources', resource: Resources},
 ];
 
 class PlatformResources {
@@ -156,6 +160,8 @@ class PlatformResources {
     user: User;
     vault: Vaults;
     tableauService: TableauService;
+    project: Project;
+    resources: Resources;
 
     registerAll() {
         resourcesMap.forEach(({key, resource}) => {

--- a/src/resources/Projects/Project.ts
+++ b/src/resources/Projects/Project.ts
@@ -1,0 +1,77 @@
+import API from '../../APICore.js';
+import {PageModel} from '../BaseInterfaces.js';
+import Resource from '../Resource.js';
+import {ResourceModel, ResourceParams} from '../Resources/index.js';
+import {ListProjectParams, ProjectModel, BaseProjectModel, ProjectResourceType} from './ProjectInterfaces.js';
+
+export default class Project extends Resource {
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/projects`;
+
+    /**
+     * Returns a paginated list of projects.
+     *
+     * @param {ListProjectParams} params
+     * @returns {Promise<PageModel<ProjectModel>>} A paginated list of projects
+     */
+    list(params?: ListProjectParams): Promise<PageModel<ProjectModel>> {
+        return this.api.get<PageModel<ProjectModel>>(this.buildPath(Project.baseUrl, params));
+    }
+
+    /**
+     * Creates and returns a new project.
+     *
+     * @param {ProjectModel} project
+     * @returns {Promise<ProjectModel>} The newly created project
+     */
+    create(project: BaseProjectModel): Promise<ProjectModel> {
+        return this.api.post<ProjectModel>(this.buildPath(Project.baseUrl), project);
+    }
+
+    /**
+     * Updates a project with the model sent and returns the updated project.
+     *
+     * @param {string} projectId
+     * @param {ProjectModel} updateProjectModel
+     * @returns {Promise<ProjectModel>} The updated project
+     */
+    update(projectId: string, updateProjectModel: ProjectModel): Promise<ProjectModel> {
+        return this.api.put<ProjectModel>(this.buildPath(`${Project.baseUrl}/${projectId}`), updateProjectModel);
+    }
+
+    /**
+     * Returns a project.
+     *
+     * @param {string} projectId
+     * @returns {Promise<ProjectModel>} The project specified by the provided id
+     */
+    get(projectId: string): Promise<ProjectModel> {
+        return this.api.get<ProjectModel>(this.buildPath(`${Project.baseUrl}/${projectId}`));
+    }
+
+    /**
+     * Deletes a project.
+     *
+     * @param {string} projectId
+     */
+    delete(projectId: string): Promise<void> {
+        return this.api.delete(this.buildPath(`${Project.baseUrl}/${projectId}`));
+    }
+
+    /**
+     * Returns a paginated list of resources associated to a project.
+     *
+     * @param projectId
+     * @param resourceType
+     * @param {ResourceParams} params
+     * @returns {Promise<PageModel<ResourceModel>>} A paginated list of resources associated to a project.
+     */
+    listResources(
+        projectId: string,
+        resourceType: ProjectResourceType,
+        params?: ResourceParams,
+    ): Promise<PageModel<ResourceModel>> {
+        return this.api.get<PageModel<ResourceModel>>(
+            this.buildPath(`${Project.baseUrl}/${projectId}/resources/${resourceType}`, params),
+        );
+    }
+}

--- a/src/resources/Projects/ProjectInterfaces.ts
+++ b/src/resources/Projects/ProjectInterfaces.ts
@@ -1,0 +1,121 @@
+import {Paginated} from '../BaseInterfaces.js';
+import {SortingOrder} from '../Enums.js';
+
+export enum ProjectSortBy {
+    name = 'NAME',
+    createdBy = 'CREATED_BY',
+    createdDate = 'CREATED_DATE',
+    updatedBy = 'UPDATED_BY',
+    updatedDate = 'UPDATED_DATE',
+}
+
+export const projectResourceTypes = [
+    'CATALOG',
+    'CASE_ASSIST',
+    'CRAWLING_MODULE',
+    'EXTENSION',
+    'IN_PRODUCT_EXPERIENCE',
+    'INSIGHT_PANEL',
+    'ML_MODEL',
+    'QUERY_PIPELINE',
+    'SEARCH_HUB',
+    'SEARCH_PAGE',
+    'SECURITY_PROVIDER',
+    'SOURCE',
+    'UA_REPORT',
+];
+
+export type ProjectResourceType = (typeof projectResourceTypes)[number];
+
+export enum SolutionType {
+    Commerce = 'COMMERCE',
+    Other = 'OTHER',
+    Service = 'SERVICE',
+    Website = 'WEBSITE',
+    Workplace = 'WORKPLACE',
+}
+
+export interface BaseProjectModel {
+    /**
+     * The name of the project.
+     */
+    name: string;
+    /**
+     * The description of the project.
+     */
+    description: string;
+    /**
+     * The solution type of the project.
+     */
+    solutionType: SolutionType;
+    /**
+     * The list of usernames that will be points of contact for the project.
+     *
+     * @example: ['johndoe@email.com-google', 'janedoe@email.com-office265']
+     */
+    pointsOfContact?: string[];
+    /**
+     * The resources associated to the project.
+     *
+     * @example: {'SOURCE': ['sourceId1', 'sourceId2']}
+     */
+    resources?: Record<ProjectResourceType, string[]>;
+}
+
+export interface ProjectModel extends BaseProjectModel {
+    /**
+     * The unique identitifier of the project.
+     */
+    id: string;
+    /**
+     * The email of the user that created the project.
+     *
+     * @example: 'jdoe@email.com'
+     */
+    createdBy: string;
+    /**
+     * The date of the project's creation.
+     * Note: ISO-8601 format
+     *
+     * @example: '2023-06-21T14:59:26.850Z'
+     */
+    createdDate: string;
+    /**
+     * The email of the user that last updated the project.
+     *
+     * @example: 'jdoe@email.com'
+     */
+    updatedBy: string;
+    /**
+     * The date of the project's last update.
+     * Note: ISO-8601 format
+     *
+     * @example: '2023-06-21T14:59:26.850Z'
+     */
+    updatedDate: string;
+}
+
+export interface ListProjectParams extends Paginated {
+    /**
+     * The query filter to match.
+     * This allows you to search according to the project name.
+     *
+     * By default, results are not required to match a specific query filter.
+     */
+    filter?: string;
+    /**
+     * The sorting criteria to apply on the results.
+     *
+     */
+    sortBy?: ProjectSortBy;
+    /**
+     * The sorting order to apply on the results.
+     *
+     * @example: 'ASC'
+     */
+    order?: SortingOrder;
+    /**
+     * Whether to include resources when returning results.
+     */
+    includeResources?: boolean;
+}

--- a/src/resources/Projects/index.ts
+++ b/src/resources/Projects/index.ts
@@ -1,0 +1,2 @@
+export * from './Project.js';
+export * from './ProjectInterfaces.js';

--- a/src/resources/Projects/tests/Project.spec.ts
+++ b/src/resources/Projects/tests/Project.spec.ts
@@ -1,0 +1,115 @@
+import API from '../../../APICore.js';
+import Project from '../Project.js';
+import {BaseProjectModel, ProjectModel, SolutionType} from '../ProjectInterfaces.js';
+
+jest.mock('../../../APICore.js');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('Project', () => {
+    let project: Project;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+    const mockProjectId = 'randomProjectId';
+    const mockRandomResourceType = 'CATALOG';
+
+    const mockNewProject: BaseProjectModel = {
+        name: 'Pokemon Project',
+        description: 'Project about pokemons',
+        solutionType: SolutionType.Commerce,
+    };
+
+    const mockProject: ProjectModel = {
+        id: mockProjectId,
+        name: 'Pokemon Project',
+        description: 'Project about pokemons',
+        solutionType: SolutionType.Commerce,
+        createdBy: 'jdoe@example.com',
+        updatedBy: 'jdoe@example.com',
+        createdDate: '2023-07-19T02:37:23.399Z',
+        updatedDate: '2023-07-22T21:52:22.588Z',
+    };
+
+    beforeEach(() => {
+        project = new Project(api, serverlessApi);
+
+        jest.resetAllMocks();
+    });
+
+    describe('list', () => {
+        it('should make a GET call to the correct Project url', () => {
+            project.list();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(Project.baseUrl);
+        });
+
+        it('should use the passed parameters as its query paramaters', () => {
+            project.list({page: 1, perPage: 50});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Project.baseUrl}?page=1&perPage=50`);
+        });
+    });
+
+    describe('create', () => {
+        it('should make a POST call to the correct Project url', () => {
+            project.create(mockNewProject);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(Project.baseUrl, {
+                name: 'Pokemon Project',
+                description: 'Project about pokemons',
+                solutionType: SolutionType.Commerce,
+            });
+        });
+    });
+
+    describe('update', () => {
+        it('should make a PUT call to the correct Project url', () => {
+            project.update(mockProjectId, mockProject);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${Project.baseUrl}/randomProjectId`, {
+                id: mockProjectId,
+                name: 'Pokemon Project',
+                description: 'Project about pokemons',
+                solutionType: SolutionType.Commerce,
+                createdBy: 'jdoe@example.com',
+                updatedBy: 'jdoe@example.com',
+                createdDate: '2023-07-19T02:37:23.399Z',
+                updatedDate: '2023-07-22T21:52:22.588Z',
+            });
+        });
+    });
+
+    describe('get', () => {
+        it('should make a GET call to the correct Project URL', () => {
+            project.get(mockProjectId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Project.baseUrl}/randomProjectId`);
+        });
+    });
+
+    describe('delete', () => {
+        it('should make a DELETE call to the correct Project URL', () => {
+            project.delete(mockProjectId);
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${Project.baseUrl}/randomProjectId`);
+        });
+    });
+
+    describe('listResources', () => {
+        it('should make a GET call to the correct Project URL', () => {
+            project.listResources(mockProjectId, mockRandomResourceType);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Project.baseUrl}/${mockProjectId}/resources/${mockRandomResourceType}`,
+            );
+        });
+
+        it('should use the passed parameters as its query paramaters', () => {
+            project.listResources(mockProjectId, mockRandomResourceType, {page: 1, perPage: 50});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Project.baseUrl}/${mockProjectId}/resources/${mockRandomResourceType}?page=1&perPage=50`,
+            );
+        });
+    });
+});

--- a/src/resources/Resources/Resources.ts
+++ b/src/resources/Resources/Resources.ts
@@ -1,0 +1,20 @@
+import API from '../../APICore.js';
+import {PageModel} from '../BaseInterfaces.js';
+import {ProjectResourceType} from '../Projects/ProjectInterfaces.js';
+import Resource from '../Resource.js';
+import {ResourceParams, ResourceModel} from './ResourcesInterfaces.js';
+
+export default class Resources extends Resource {
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/resources`;
+
+    /**
+     * Returns a paginated list of resources.
+     *
+     * @param resourceType
+     * @param {ListProjectParams} params
+     * @returns {Promise<PageModel<ResourceModel>>} A paginated list of resources.
+     */
+    list(resourceType: ProjectResourceType, params?: ResourceParams): Promise<PageModel<ResourceModel>> {
+        return this.api.get<PageModel<ResourceModel>>(this.buildPath(`${Resources.baseUrl}/${resourceType}`, params));
+    }
+}

--- a/src/resources/Resources/ResourcesInterfaces.ts
+++ b/src/resources/Resources/ResourcesInterfaces.ts
@@ -1,0 +1,27 @@
+import {Paginated} from '../BaseInterfaces.js';
+
+export interface ResourceModel {
+    /**
+     * The unique identifier of a resource within a project
+     */
+    id: string;
+    /**
+     * The name of the resouce
+     */
+    name: string;
+    /**
+     * The type of the resource
+     */
+    type?: string;
+    /**
+     * The version of the resource
+     */
+    version?: string;
+}
+
+export interface ResourceParams extends Paginated {
+    /**
+     * Term to filter resources by id or name
+     */
+    filter?: string;
+}

--- a/src/resources/Resources/index.ts
+++ b/src/resources/Resources/index.ts
@@ -1,0 +1,2 @@
+export * from './Resources.js';
+export * from './ResourcesInterfaces.js';

--- a/src/resources/Resources/tests/Resources.spec.ts
+++ b/src/resources/Resources/tests/Resources.spec.ts
@@ -1,0 +1,34 @@
+import API from '../../../APICore.js';
+import Resources from '../Resources.js';
+
+jest.mock('../../../APICore.js');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('Resources', () => {
+    let resource: Resources;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+
+    const randomResourceType = 'SOURCE';
+
+    beforeEach(() => {
+        resource = new Resources(api, serverlessApi);
+
+        jest.resetAllMocks();
+    });
+
+    describe('list', () => {
+        it('should make a GET call to the correct Project url with the right resource type', () => {
+            resource.list(randomResourceType);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Resources.baseUrl}/SOURCE`);
+        });
+
+        it('should use the passed parameters as its query paramaters', () => {
+            resource.list(randomResourceType, {page: 1, perPage: 50});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Resources.baseUrl}/SOURCE?page=1&perPage=50`);
+        });
+    });
+});

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -49,3 +49,5 @@ export * from './UsageAnalytics/index.js';
 export * from './Vaults/index.js';
 export * from './HostedPages/index.js';
 export * from './SearchAnalysis/index.js';
+export * from './Projects/index.js';
+export * from './Resources/index.js';


### PR DESCRIPTION
# [TSP-29](https://coveord.atlassian.net/browse/TSP-29)

* Created a new `Resource` class called `Project`;
* Created a new `Resource` class called `Resources`;
* Created the basic CRUD operations of the [Workspace service](https://platform.cloud.coveo.com/docs?urls.primaryName=Workspace), such as `list`, `create`, `update`, `get` and `delete`;
* Created the necessary interfaces for these operations;
* Instantiated the new classes in `PlatformResource`.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[TSP-29]: https://coveord.atlassian.net/browse/TSP-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ