### PR TITLE
fix(resource): allow empty string as query param value

### DIFF
--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -1,6 +1,8 @@
 import API from '../APICore.js';
 import queryString from '#query-string';
 
+const defaultOptions: queryString.StringifyOptions = {skipEmptyString: true, skipNull: true, sort: false};
+
 class Resource {
     static baseUrl: string;
 
@@ -9,15 +11,15 @@ class Resource {
         protected serverlessApi: API,
     ) {}
 
-    protected buildPath(route: string, parameters?: any): string {
-        return route + this.convertObjectToQueryString(parameters);
+    protected buildPath(route: string, parameters?: any, options?: queryString.StringifyOptions): string {
+        return route + this.convertObjectToQueryString(parameters, options);
     }
 
-    private convertObjectToQueryString(parameters: any): string {
+    private convertObjectToQueryString(parameters: any, userOptions?: queryString.StringifyOptions): string {
         if (!parameters) {
             return '';
         } else {
-            const requestURL = queryString.stringify(parameters, {skipEmptyString: true, skipNull: true, sort: false});
+            const requestURL = queryString.stringify(parameters, {...defaultOptions, ...userOptions});
             return requestURL.length ? `?${requestURL}` : '';
         }
     }

--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -1,19 +1,19 @@
-import {ListFieldValuesBodyQueryParams, PostSearchQuerySuggestBodyParams} from './index.js';
 import API from '../../APICore.js';
 import Ressource from '../Resource.js';
 import {
-    SingleItemParameters,
     ItemPreviewHtmlParameters,
+    RestFacetSearchParameters,
+    RestFacetSearchResponse,
     RestQueryParams,
     RestQueryResult,
     RestTokenParams,
     SearchListFieldsParams,
     SearchListFieldsResponse,
     SearchResponse,
+    SingleItemParameters,
     TokenModel,
-    RestFacetSearchParameters,
-    RestFacetSearchResponse,
 } from './SearchInterfaces.js';
+import {ListFieldValuesBodyQueryParams, PostSearchQuerySuggestBodyParams} from './index.js';
 
 export default class Search extends Ressource {
     static baseUrl = `/rest/search/v2`;
@@ -87,12 +87,29 @@ export default class Search extends Ressource {
     /**
      * Get an item's preview in HTML format
      */
-    previewHTML(params: ItemPreviewHtmlParameters) {
-        return this.api.get<string>(
+    previewHTML({
+        enableNavigation,
+        findNext,
+        findPrevious,
+        organizationId,
+        page,
+        requestedOutputSize,
+        uniqueId,
+        viewAllContent,
+        ...body
+    }: ItemPreviewHtmlParameters) {
+        return this.api.post<string>(
             this.buildPath(`${Search.baseUrl}/html`, {
-                ...params,
-                organizationId: params.organizationId ?? this.api.organizationId,
+                enableNavigation,
+                findNext,
+                findPrevious,
+                page,
+                requestedOutputSize,
+                uniqueId,
+                viewAllContent,
+                organizationId: organizationId ?? this.api.organizationId,
             }),
+            body,
             {responseBodyFormat: 'text'},
         );
     }
@@ -102,10 +119,14 @@ export default class Search extends Ressource {
      */
     getDocument(params: SingleItemParameters) {
         return this.api.get<RestQueryResult>(
-            this.buildPath(`${Search.baseUrl}/document`, {
-                ...params,
-                organizationId: params.organizationId ?? this.api.organizationId,
-            }),
+            this.buildPath(
+                `${Search.baseUrl}/document`,
+                {
+                    ...params,
+                    organizationId: params.organizationId ?? this.api.organizationId,
+                },
+                {skipEmptyString: false}, // otherwise we cannot use the empty pipeline (`pipeline=`)
+            ),
         );
     }
 

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -161,11 +161,15 @@ describe('Search', () => {
 
     describe('previewHTML', () => {
         it('makes a GET call to the /html endpoint', () => {
-            search.previewHTML({uniqueId: 'document-id'});
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`/rest/search/v2/html?uniqueId=document-id`, {
-                responseBodyFormat: 'text',
-            });
+            search.previewHTML({uniqueId: 'document-id', pipeline: ''});
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(
+                `/rest/search/v2/html?uniqueId=document-id`,
+                {pipeline: ''},
+                {
+                    responseBodyFormat: 'text',
+                },
+            );
         });
     });
 
@@ -174,6 +178,12 @@ describe('Search', () => {
             search.getDocument({uniqueId: 'document-id'});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`/rest/search/v2/document?uniqueId=document-id`);
+        });
+
+        it('allows specifying the empty pipeline', () => {
+            search.getDocument({uniqueId: 'document-id', pipeline: ''});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`/rest/search/v2/document?uniqueId=document-id&pipeline=`);
         });
     });
 


### PR DESCRIPTION
Making a few corrections to the `Search` API calls to `/document` and `/html` endpoints:
- Added missing query parameters on `getDocument` (they were missing on the swagger doc as well, see SEARCHAPI-8913)
- Allow to pass in the empty pipeline as parameter to `getDocument` (previously empty string query params we're removed so it was not possible)
- Use POST endpoint for `previewHTML` instead of GET. Allows to pass in the full rest parameters in the body, which unlocks all the available features of this endpoint.

I also cleaned up the interfaces a bit by declaring a shared params interface and reusing it where possible. This way we avoid having to repeat the lengthy jsdocs everywhere. Still not perfect, but now we have a few repetitions less 🤷 

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
    Soon (see SEARCHAPI-8913)
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
