### PR TITLE
feat(workspace): add new endpoint to retrieve resources by status

### DIFF
--- a/src/resources/Projects/Project.ts
+++ b/src/resources/Projects/Project.ts
@@ -1,7 +1,7 @@
 import API from '../../APICore.js';
 import {PageModel} from '../BaseInterfaces.js';
 import Resource from '../Resource.js';
-import {ResourceModel, ResourceParams} from '../Resources/index.js';
+import {ResourceModel, ResourceParams, ResourceStatus} from '../Resources/index.js';
 import {ListProjectParams, ProjectModel, BaseProjectModel, ProjectResourceType} from './ProjectInterfaces.js';
 
 export default class Project extends Resource {
@@ -58,10 +58,22 @@ export default class Project extends Resource {
     }
 
     /**
+     * Returns resource IDs grouped by resource status, for a given project.
+     *
+     * @param {string} projectId
+     * @returns {Promise<Record<ResourceStatus, Record<ProjectResourceType, string[]>>>} A series of resource IDs grouped by their status and resource type.
+     */
+    listResourcesByStatus(projectId: string): Promise<Record<ResourceStatus, Record<ProjectResourceType, string[]>>> {
+        return this.api.get<Record<ResourceStatus, Record<ProjectResourceType, string[]>>>(
+            this.buildPath(`${Project.baseUrl}/${projectId}/resources`),
+        );
+    }
+
+    /**
      * Returns a paginated list of resources associated to a project.
      *
-     * @param projectId
-     * @param resourceType
+     * @param {string} projectId
+     * @param {ProjectResourceType} resourceType
      * @param {ResourceParams} params
      * @returns {Promise<PageModel<ResourceModel>>} A paginated list of resources associated to a project.
      */

--- a/src/resources/Projects/tests/Project.spec.ts
+++ b/src/resources/Projects/tests/Project.spec.ts
@@ -95,6 +95,14 @@ describe('Project', () => {
         });
     });
 
+    describe('listResourcesByType', () => {
+        it('should make a GET call to the correct Project URL', () => {
+            project.listResourcesByStatus(mockProjectId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Project.baseUrl}/${mockProjectId}/resources`);
+        });
+    });
+
     describe('listResources', () => {
         it('should make a GET call to the correct Project URL', () => {
             project.listResources(mockProjectId, mockRandomResourceType);

--- a/src/resources/Resources/ResourcesInterfaces.ts
+++ b/src/resources/Resources/ResourcesInterfaces.ts
@@ -1,5 +1,7 @@
 import {Paginated} from '../BaseInterfaces.js';
 
+export type ResourceStatus = 'existingResources' | 'deletedResources';
+
 export interface ResourceModel {
     /**
      * The unique identifier of a resource within a project


### PR DESCRIPTION
# [TSP-58](https://coveord.atlassian.net/browse/TSP-58)

Added a new endpoint that retrieves resources by status for a given project (see [Swagger](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Workspace#/Projects/rest_organizations_paramId_projects_paramId_resources_get) for more details).

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[TSP-58]: https://coveord.atlassian.net/browse/TSP-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ