### PR TITLE
feat(ml)!: enforce trackingIds parameter in the creation of PQS and IAPR model

### DIFF
--- a/src/resources/MachineLearning/IAPRConfiguration/IAPRConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/IAPRConfiguration/IAPRConfigurationInterfaces.ts
@@ -8,4 +8,10 @@ export interface IAPRConfigurationModel {
      * The model display name in the Coveo Administration console.
      */
     modelDisplayName: string;
+    /**
+     * The trackingIds that usage analytics events must contain for the model to use those events in its learning process. The model will use an event if it contains at least one of the specified IDs
+     *
+     * @Example: [ "sport" ]
+     */
+    trackingIds: string[];
 }

--- a/src/resources/MachineLearning/IAPRConfiguration/tests/IAPRConfiguration.spec.ts
+++ b/src/resources/MachineLearning/IAPRConfiguration/tests/IAPRConfiguration.spec.ts
@@ -21,6 +21,7 @@ describe('IAPRConfiguration', () => {
             const model: IAPRConfigurationModel = {
                 modelDisplayName: 'kiki soudane',
                 catalogId: 'catalog_mock',
+                trackingIds: ['sport'],
             };
             iaprConfig.create(model);
             expect(api.post).toHaveBeenCalledTimes(1);

--- a/src/resources/MachineLearning/PQSConfiguration/PQSConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/PQSConfiguration/PQSConfigurationInterfaces.ts
@@ -38,4 +38,10 @@ export interface PQSConfigurationModel {
      * The filter to apply to the 'Click' and 'Search' event dimensions of the UA data to learn from when rebuilding the model.
      */
     searchEventFilter?: string;
+    /**
+     * The trackingIds that usage analytics events must contain for the model to use those events in its learning process. The model will use an event if it contains at least one of the specified IDs
+     *
+     * @Example: [ "sport" ]
+     */
+    trackingIds: string[];
 }

--- a/src/resources/MachineLearning/PQSConfiguration/tests/PQSConfiguration.spec.ts
+++ b/src/resources/MachineLearning/PQSConfiguration/tests/PQSConfiguration.spec.ts
@@ -18,7 +18,11 @@ describe('PQSConfiguration', () => {
 
     describe('createPQSModel', () => {
         it('should make a POST call to the specific PQSConfiguration url', () => {
-            const model: PQSConfigurationModel = {modelDisplayName: 'kiki soudane', catalogId: 'sekia'};
+            const model: PQSConfigurationModel = {
+                modelDisplayName: 'kiki soudane',
+                catalogId: 'sekia',
+                trackingIds: ['sport'],
+            };
             pqsConfig.createPQSModel(model);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${PQSConfiguration.baseUrl}/model`, model);


### PR DESCRIPTION
BREAKING CHANGE: For creation of PQS / IAPR models, trackingIds will be a mandatory parameter to be included

- [ ] To be merged after: https://github.com/coveo/ml-config-service/pull/1754

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
