### PR TITLE
fix(resource): fix search list fields to allow empty pipeline

### DIFF
--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -24,10 +24,14 @@ export default class Search extends Ressource {
 
     listFields(params?: SearchListFieldsParams) {
         return this.api.get<SearchListFieldsResponse>(
-            this.buildPath(`${Search.baseUrl}/fields`, {
-                ...params,
-                organizationId: params?.organizationId ?? this.api.organizationId,
-            }),
+            this.buildPath(
+                `${Search.baseUrl}/fields`,
+                {
+                    ...params,
+                    organizationId: params?.organizationId ?? this.api.organizationId,
+                },
+                {skipEmptyString: false}, // otherwise we cannot use the empty pipeline (`pipeline=`)
+            ),
         );
     }
 

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -70,6 +70,14 @@ describe('Search', () => {
             );
         });
 
+        it('makes a get call to v2 search with its params to fetch the list of fields with an empty pipeline', () => {
+            search.listFields({viewAllContent: true, organizationId: 'my-org', pipeline: ''});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Search.baseUrl}/fields?viewAllContent=true&organizationId=my-org&pipeline=`,
+            );
+        });
+
         it('adds the organizationId query param from the config if missing in the arguments', () => {
             const tempOrganizationId = api.organizationId;
             // change the value of organizationId on the mock


### PR DESCRIPTION
### Description

[SEARCHAPI-9086](https://coveord.atlassian.net/browse/SEARCHAPI-9086)

We need to be able to pass the empty pipeline to this call otherwise it's the default pipeline being used when no parameters are passed.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[SEARCHAPI-9086]: https://coveord.atlassian.net/browse/SEARCHAPI-9086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ