### PR TITLE
docs(contributing): explain project scope explicitly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,23 @@
 
 > Tip: This repo supports `corepack`. Just enable it `corepack enable` and this repo will warn you if you try to use another package manager.
 
+## Scope
+
+The `@coveo/platform-client` is an open source project. Therefore by nature its scope is limited to Coveo's endpoints that are **public**, **documented**, and **stable**. Any change to an endpoint that doesn't comply to all of the criteria enumerated above will likely be rejected / heavily challenged by the maintainers of the project at the pull request stage.
+
+-   _public_: available in production.
+-   _documented_: available on [Swagger](https://platform.cloud.coveo.com/docs).
+-   _stable_: the change is not deemed to be temporary, or part of a rapid iteration process.
+
+In case your changes don't fall within the scope **yet**, but you still want to be able to use them, we recommend [extending the client](https://github.com/coveo/platform-client#extending-the-client) in your own project.
+
 ## Guidelines
 
 -   Make sure your changes are fully tested (when applicable).
 -   We tend to avoid comments in our code base, we strongly prefer good naming and code structure.
 -   Avoid pushing similar changes in different commits if it's within the same feature, because we want the changelogs to be clear and simple. To avoid that, there are at least 2 options:
     1. Squash the commits into one when merging (you need to edit the final commit message though)
-    1. amend the previous commit when making related changes (`git commit --amend --no-edit`)
+    2. amend the previous commit when making related changes (`git commit --amend --no-edit`)
 
 ## Commit messages
 


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

Added a "Scope" section in CONTRIBUTING.md. 

Lately, and in the past just generally, we have often been explaining the same thing over and over during the review process. Basically that things that aren't public or stable shouldn't be exposed in the client. 

The goal of this section is to avoid contributors spending time to do their pull request just to be sent back to their project when they get at the review stage. It will also to avoid having to repeat ourselves and just point to that doc when needed. It will make expectations clearer for everyone in general. 

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
