### PR TITLE
feat(ml): add missing model types for genqa

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -910,6 +910,9 @@ export enum ModelTypes {
     CaseClassification = 'caseclassification',
     SmartSnippets = 'mlquestionanswering',
     UserActionHistory = 'useractionhistory',
+    IntentAwareProductRanking = 'intentranking',
+    RelevanceGenerativeAnswering = 'genqa',
+    SemanticSearch = 'embeddings',
 }
 
 export enum LicenseSection {


### PR DESCRIPTION
### Description

[SEARCHAPI-9039](https://coveord.atlassian.net/browse/SEARCHAPI-9039)

Add missing ML model types in `Enum.ts`. 

- `IntentAwareProductRanking = 'intentranking'`
- `RelevanceGenerativeAnswering = 'genqa'`
- `SemanticSearch = 'embeddings'`

I looked in the [backend](https://github.com/coveo/ml-config-service/blob/master/coveo-cloud-ml-config-server/src/main/java/com/coveo/cloud/mlconfig/services/MLWorkflowNameConstant.java) to confirm the values.

 I also had a discussion with UI ML team about it. They told me they have a duplicated enum in the [admin-ui](https://github.com/coveo/admin-ui/blob/master/pages/model/src/constants/ModelConstants.ts#L34).

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[SEARCHAPI-9039]: https://coveord.atlassian.net/browse/SEARCHAPI-9039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ