### PR TITLE
feat(MLX): add advancedQuery for SS model

### DIFF
--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
@@ -50,6 +50,10 @@ export interface SmartSnippetsDocumentGroupPreviewParams {
      * An array of filtering conditions.
      */
     filterConditions: FilterConditions[];
+    /**
+     * The query that determines the documents to extract
+     */
+    advancedQuery: string;
 }
 
 export interface SmartSnippetsDocumentGroupPreview {
@@ -92,6 +96,10 @@ export interface SmartSnippetsContentFieldsParams {
      * An array of filtering conditions.
      */
     filterConditions: FilterConditions[];
+    /**
+     * The query that determines the documents to extract
+     */
+    advancedQuery: string;
 }
 
 export interface SmartSnippetsContentField {
@@ -121,6 +129,10 @@ export interface SmartSnippetsDocumentTypesParams {
      * An array of filtering conditions.
      */
     filterConditions: FilterConditions[];
+    /**
+     * The query that determines the documents to extract
+     */
+    advancedQuery: string;
 }
 
 export interface SmartSnippetsDocumentType {


### PR DESCRIPTION
For the new creation flow for SS model, we need to add the `advancedQuery` params for the `smartsnippets/preview`, `smartsnippets/documenttypes` and `smartsnippets/contentfields` call 
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
