### PR TITLE
feat(sources): add StringFilterType enum

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -231,6 +231,11 @@ export enum FilterStatusType {
     ERROR = 'ERROR',
 }
 
+export enum StringFilterType {
+    WILDCARD = 'WILDCARD',
+    EXACTMATCH = 'EXACTMATCH'
+}
+
 export enum UpdateStatusCategory {
     MINOR = 'MINOR',
     CRITICAL = 'CRITICAL',

--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -231,11 +231,6 @@ export enum FilterStatusType {
     ERROR = 'ERROR',
 }
 
-export enum StringFilterType {
-    WILDCARD = 'WILDCARD',
-    EXACTMATCH = 'EXACTMATCH'
-}
-
 export enum UpdateStatusCategory {
     MINOR = 'MINOR',
     CRITICAL = 'CRITICAL',

--- a/src/resources/Sources/SourcesInterfaces.ts
+++ b/src/resources/Sources/SourcesInterfaces.ts
@@ -1,4 +1,4 @@
-import {GranularResource, Paginated} from '../BaseInterfaces.js';
+import { GranularResource, Paginated } from '../BaseInterfaces.js';
 import {
     FilterHostType,
     FilterLastOperationResultType,
@@ -10,10 +10,11 @@ import {
     SourceSecurityOption,
     SourceType,
     SourceVisibility,
+    StringFilterType,
 } from '../Enums.js';
-import {SecurityProvider, SecurityProviderModel} from '../SecurityCache/SecurityCacheInterfaces.js';
+import { SecurityProvider, SecurityProviderModel } from '../SecurityCache/SecurityCacheInterfaces.js';
+import { MappingModel } from './SourcesMappings/index.js';
 import * as SourcesSubInterface from './SourcesSubInterfaces/index.js';
-import {MappingModel} from './SourcesMappings/index.js';
 
 export * from './SourcesSubInterfaces/index.js';
 
@@ -33,6 +34,7 @@ export interface ListSourcesParams extends ListParams {
     filterLastOperationResultType?: FilterLastOperationResultType;
     filterLastOperationType?: FilterLastOperationType;
     filterStatusType?: FilterStatusType;
+    stringFilterType?: StringFilterType;
 }
 
 export interface ExtendedConfig {

--- a/src/resources/Sources/SourcesInterfaces.ts
+++ b/src/resources/Sources/SourcesInterfaces.ts
@@ -1,4 +1,4 @@
-import { GranularResource, Paginated } from '../BaseInterfaces.js';
+import {GranularResource, Paginated} from '../BaseInterfaces.js';
 import {
     FilterHostType,
     FilterLastOperationResultType,
@@ -9,10 +9,10 @@ import {
     SourceOperationalStatus,
     SourceSecurityOption,
     SourceType,
-    SourceVisibility
+    SourceVisibility,
 } from '../Enums.js';
-import { SecurityProvider, SecurityProviderModel } from '../SecurityCache/SecurityCacheInterfaces.js';
-import { MappingModel } from './SourcesMappings/index.js';
+import {SecurityProvider, SecurityProviderModel} from '../SecurityCache/SecurityCacheInterfaces.js';
+import {MappingModel} from './SourcesMappings/index.js';
 import * as SourcesSubInterface from './SourcesSubInterfaces/index.js';
 
 export * from './SourcesSubInterfaces/index.js';
@@ -33,7 +33,7 @@ export interface ListSourcesParams extends ListParams {
     filterLastOperationResultType?: FilterLastOperationResultType;
     filterLastOperationType?: FilterLastOperationType;
     filterStatusType?: FilterStatusType;
-    stringFilterType?: "WILDCARD" | "EXACTMATCH";
+    stringFilterType?: 'WILDCARD' | 'EXACTMATCH';
 }
 
 export interface ExtendedConfig {

--- a/src/resources/Sources/SourcesInterfaces.ts
+++ b/src/resources/Sources/SourcesInterfaces.ts
@@ -9,8 +9,7 @@ import {
     SourceOperationalStatus,
     SourceSecurityOption,
     SourceType,
-    SourceVisibility,
-    StringFilterType,
+    SourceVisibility
 } from '../Enums.js';
 import { SecurityProvider, SecurityProviderModel } from '../SecurityCache/SecurityCacheInterfaces.js';
 import { MappingModel } from './SourcesMappings/index.js';
@@ -34,7 +33,7 @@ export interface ListSourcesParams extends ListParams {
     filterLastOperationResultType?: FilterLastOperationResultType;
     filterLastOperationType?: FilterLastOperationType;
     filterStatusType?: FilterStatusType;
-    stringFilterType?: StringFilterType;
+    stringFilterType?: "WILDCARD" | "EXACTMATCH";
 }
 
 export interface ExtendedConfig {

--- a/src/resources/Sources/tests/Sources.spec.ts
+++ b/src/resources/Sources/tests/Sources.spec.ts
@@ -4,7 +4,7 @@ import {ActivityOperation} from '../../Enums.js';
 import {ScheduleModel} from '../../SecurityCache/index.js';
 import Sources from '../Sources.js';
 import SourcesFields from '../SourcesFields/SourcesFields.js';
-import {CreateSourceModel, RawSourceConfig} from '../SourcesInterfaces.js';
+import {CreateSourceModel, ListSourcesParams, RawSourceConfig} from '../SourcesInterfaces.js';
 import SourcesMappings from '../SourcesMappings/SourcesMappings.js';
 
 jest.mock('../../../APICore.js');
@@ -44,6 +44,15 @@ describe('Sources', () => {
             source.listOperationalStatus();
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Sources.baseUrl}/sourceoperationalstatus`);
+        });
+
+        it('should make a GET call with the correct stringFilterType', () => {
+            const params = {
+                stringFilterType: 'EXACTMATCH',
+            } as ListSourcesParams;
+            source.list(params);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Sources.baseUrl}/pages`, params);
         });
     });
 

--- a/src/resources/Sources/tests/Sources.spec.ts
+++ b/src/resources/Sources/tests/Sources.spec.ts
@@ -52,7 +52,9 @@ describe('Sources', () => {
             } as ListSourcesParams;
             source.list(params);
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Sources.baseUrl}/pages`, params);
+            expect(api.get).toHaveBeenCalledWith(`${Sources.baseUrl}/pages`, {
+                stringFilterType: 'EXACTMATCH',
+            });
         });
     });
 

--- a/src/resources/Sources/tests/Sources.spec.ts
+++ b/src/resources/Sources/tests/Sources.spec.ts
@@ -52,9 +52,7 @@ describe('Sources', () => {
             } as ListSourcesParams;
             source.list(params);
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Sources.baseUrl}/pages`, {
-                stringFilterType: 'EXACTMATCH',
-            });
+            expect(api.get).toHaveBeenCalledWith(`${Sources.baseUrl}/pages?stringFilterType=EXACTMATCH`);
         });
     });
 


### PR DESCRIPTION
CTCORE-9562

This PR adds the new stringFilterType param to the `ListSourcesParams` interface with accompanying `StringFilterType` enum. 

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
