### PR TITLE
fix(search): properly type getFieldValues return type

### DIFF
--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -1,7 +1,8 @@
 import API from '../../APICore.js';
-import Ressource from '../Resource.js';
+import Resource from '../Resource.js';
 import {
     ItemPreviewHtmlParameters,
+    ListFieldValuesResponse,
     RestFacetSearchParameters,
     RestFacetSearchResponse,
     RestQueryParams,
@@ -15,7 +16,7 @@ import {
 } from './SearchInterfaces.js';
 import {ListFieldValuesBodyQueryParams, PostSearchQuerySuggestBodyParams} from './index.js';
 
-export default class Search extends Ressource {
+export default class Search extends Resource {
     static baseUrl = `/rest/search/v2`;
 
     createToken(tokenParams: RestTokenParams) {
@@ -36,7 +37,7 @@ export default class Search extends Ressource {
     }
 
     getFieldValues(fieldName: string, params?: ListFieldValuesBodyQueryParams) {
-        return this.api.get<any>(
+        return this.api.get<ListFieldValuesResponse>(
             this.buildPath(`${Search.baseUrl}/values`, {
                 field: encodeURI(`${fieldName}`),
                 ...params,

--- a/src/resources/Search/SearchInterfaces.ts
+++ b/src/resources/Search/SearchInterfaces.ts
@@ -453,6 +453,16 @@ export interface ListFieldValuesBodyQueryParams extends SharedFieldsParams {
     analytics?: RestAnalyticsRequest;
 }
 
+export interface ListFieldValuesItem {
+    value: string;
+    lookupValue: string;
+    numberOfResults: number;
+}
+
+export interface ListFieldValuesResponse {
+    values: ListFieldValuesItem[];
+}
+
 /**
  * Defines the body parameters of the search request.
  */


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

![image](https://github.com/coveo/platform-client/assets/35579930/334126c6-4e45-45c7-909d-df17e4cc4c46)

https://platform.cloud.coveo.com/docs/?urls.primaryName=Search%20API#/Search%20V2/valuesGet


### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
