### PR TITLE
SVCINT-2683 feat: add next gen search page API

### DIFF
--- a/src/resources/IPXInterfaces/IPXInterface.ts
+++ b/src/resources/IPXInterfaces/IPXInterface.ts
@@ -15,12 +15,12 @@ export default class IPXInterface extends Resource {
         return this.api.post<IPXInterfaceConfiguration>(IPXInterface.baseUrl, ipxInterfaceConfig);
     }
 
-    delete(IPXInterfaceId: string) {
-        return this.api.delete(`${IPXInterface.baseUrl}/${IPXInterfaceId}`);
+    delete(ipxInterfaceId: string) {
+        return this.api.delete(`${IPXInterface.baseUrl}/${ipxInterfaceId}`);
     }
 
-    get(IPXInterfaceId: string) {
-        return this.api.get<IPXInterfaceConfiguration>(`${IPXInterface.baseUrl}/${IPXInterfaceId}`);
+    get(ipxInterfaceId: string) {
+        return this.api.get<IPXInterfaceConfiguration>(`${IPXInterface.baseUrl}/${ipxInterfaceId}`);
     }
 
     update(ipxInterfaceConfig: IPXInterfaceConfiguration) {
@@ -29,7 +29,23 @@ export default class IPXInterface extends Resource {
         return this.api.put<IPXInterfaceConfiguration>(`${IPXInterface.baseUrl}/${id}`, body);
     }
 
-    loader(IPXInterfaceId: string) {
-        return this.api.get<IPXInterfaceConfiguration>(`${IPXInterface.baseUrl}/${IPXInterfaceId}/loader`);
+    getLoader(ipxInterfaceId: string) {
+        return this.api.get<IPXInterfaceConfiguration>(`${IPXInterface.baseUrl}/${ipxInterfaceId}/loader`);
+    }
+
+    generatePreview(ipxInterfaceConfig: IPXInterfaceConfiguration) {
+        return this.api.post<string>(`${IPXInterface.baseUrl}/${ipxInterfaceConfig.id}/preview`, ipxInterfaceConfig);
+    }
+
+    getEditInterface(ipxInterfaceId: string) {
+        return this.api.get<string>(`${IPXInterface.baseUrl}/${ipxInterfaceId}/edit`);
+    }
+
+    getLoginPage(ipxInterfaceId: string) {
+        return this.api.get<string>(`${IPXInterface.baseUrl}/${ipxInterfaceId}/login`);
+    }
+
+    getToken(ipxInterfaceId: string) {
+        return this.api.get<{token: string}>(`${IPXInterface.baseUrl}/${ipxInterfaceId}/token`);
     }
 }

--- a/src/resources/IPXInterfaces/IPXInterface.ts
+++ b/src/resources/IPXInterfaces/IPXInterface.ts
@@ -24,9 +24,10 @@ export default class IPXInterface extends Resource {
     }
 
     update(ipxInterfaceConfig: IPXInterfaceConfiguration) {
-        const {id, ...body} = ipxInterfaceConfig;
-
-        return this.api.put<IPXInterfaceConfiguration>(`${IPXInterface.baseUrl}/${id}`, body);
+        return this.api.put<IPXInterfaceConfiguration>(
+            `${IPXInterface.baseUrl}/${ipxInterfaceConfig.id}`,
+            ipxInterfaceConfig,
+        );
     }
 
     getLoader(ipxInterfaceId: string) {

--- a/src/resources/IPXInterfaces/tests/IPXInterface.spec.ts
+++ b/src/resources/IPXInterfaces/tests/IPXInterface.spec.ts
@@ -193,10 +193,54 @@ describe('IPXInterface', () => {
         it('should make a GET call to the IPXInterface base url appended with /loader', () => {
             const id = 'IPInterface-id-to-get';
 
-            ipxInterface.loader(id);
+            ipxInterface.getLoader(id);
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${IPXInterface.baseUrl}/${id}/loader`);
+        });
+    });
+
+    describe('generatePreview', () => {
+        it('should make a POST call to the IPXInterface base url appended with /preview', () => {
+            const id = 'IPInterface-id-to-preview';
+
+            ipxInterface.generatePreview({...config, id});
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${IPXInterface.baseUrl}/${id}/preview`, config);
+        });
+    });
+
+    describe('getEditInterface', () => {
+        it('should make a GET call to the IPXInterface base url appended with /edit', () => {
+            const id = 'IPInterface-id-to-edit';
+
+            ipxInterface.getEditInterface(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${IPXInterface.baseUrl}/${id}/edit`);
+        });
+    });
+
+    describe('getLoginPage', () => {
+        it('should make a GET call to the IPXInterface base url appended with /login', () => {
+            const id = 'IPInterface-id-to-login';
+
+            ipxInterface.getLoginPage(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${IPXInterface.baseUrl}/${id}/login`);
+        });
+    });
+
+    describe('getToken', () => {
+        it('should make a GET call to the IPXInterface base url appended with /token', () => {
+            const id = 'IPInterface-id-to-get-token';
+
+            ipxInterface.getToken(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${IPXInterface.baseUrl}/${id}/token`);
         });
     });
 });

--- a/src/resources/IPXInterfaces/tests/IPXInterface.spec.ts
+++ b/src/resources/IPXInterfaces/tests/IPXInterface.spec.ts
@@ -174,7 +174,7 @@ describe('IPXInterface', () => {
             ipxInterface.update({...config, id});
 
             expect(api.put).toHaveBeenCalledTimes(1);
-            expect(api.put).toHaveBeenCalledWith(`${IPXInterface.baseUrl}/${id}`, config);
+            expect(api.put).toHaveBeenCalledWith(`${IPXInterface.baseUrl}/${id}`, {...config, id});
         });
     });
 
@@ -207,7 +207,7 @@ describe('IPXInterface', () => {
             ipxInterface.generatePreview({...config, id});
 
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(`${IPXInterface.baseUrl}/${id}/preview`, config);
+            expect(api.post).toHaveBeenCalledWith(`${IPXInterface.baseUrl}/${id}/preview`, {...config, id});
         });
     });
 

--- a/src/resources/NextGenSearchPages/NextGenSearchPages.model.ts
+++ b/src/resources/NextGenSearchPages/NextGenSearchPages.model.ts
@@ -1,0 +1,149 @@
+import { HostedInterfaceConfiguration, HostedInterfaceOption, HostedInterfaceResultTemplate, HostedInterfaceResultTemplateBadge, IAccesses, ISortCriteria } from "../index.js";
+
+export enum SearchPageResultActions {
+    copyToClipboard = 'copyToClipboard',
+    quickview = 'quickview',
+}
+
+export interface SearchPageResultTemplate extends Omit<HostedInterfaceResultTemplate, 'badge'> {
+    /**
+     * The badge to display.
+     */
+    badges: HostedInterfaceResultTemplateBadge[];
+    /**
+     * Whether the description is enabled.
+     */
+    descriptionEnabled: boolean;
+    /**
+     * Size of the image.
+     */
+    imageSize?: string;
+    /**
+     * Actions to display.
+     */
+    resultActions: Record<SearchPageResultActions, HostedInterfaceOption>;
+}
+
+export enum SearchPageLayout {
+    List = 'list',
+    Grid = 'grid',
+}
+
+export interface SearchPageColors {
+    /**
+     * Accent1 color.
+     */
+    accent1: string;
+
+    /**
+     * Accent2 color.
+     */
+    accent2: string;
+
+    /**
+     * The background color.
+     */
+    background: string;
+
+    /**
+     * The titles color.
+     */
+    titles: string;
+
+    /**
+     * The text color.
+     */
+    normalText: string;
+
+    /**
+     * The navigation background color.
+     */
+    navigationBackground: string;
+}
+
+export interface SearchPageStyle {
+    /**
+     * The colors of the Search Page.
+     */
+    colors: SearchPageColors;
+
+    /**
+     * The font-family of the Search Page.
+     */
+    fontFamily: string;
+}
+
+export interface SearchPageSettings {
+    /**
+     * An option enabling the use of smart snippets.
+     */
+    smartSnippets: HostedInterfaceOption;
+    /**
+     * An option enabling the use of the query history.
+     */
+    queryHistory: HostedInterfaceOption;
+    /**
+     * An option enabling the use of the query suggestions.
+     */
+    querySuggestions: HostedInterfaceOption;
+    /**
+     * An option enabling the use of the people also ask feature.
+     */
+    peopleAlsoAsk: HostedInterfaceOption;
+    /**
+     * An option enabling the use of the generative question answering feature.
+     */
+    genQA: HostedInterfaceOption;
+}
+
+export interface SearchPageInterfaceConfiguration extends Omit<HostedInterfaceConfiguration, 'tabs'> {
+    /**
+     * The list of result templates defined for the Search Page.
+     */
+    resultTemplates: SearchPageResultTemplate[];
+
+    /**
+     * The list of sort criteria defined for the Search Page.
+     */
+    sortCriteria: ISortCriteria[];
+
+    /**
+     * The access rules defined for the Search Page.
+     */
+    accesses: IAccesses;
+
+    /**
+     * The layout of the Search Page.
+     */
+    layout: SearchPageLayout;
+
+    /**
+     * The style configuration.
+     */
+    style: SearchPageStyle;
+
+    /**
+     * The settings configuration.
+     */
+    settings: SearchPageSettings;
+
+    /**
+     * The date of creation of the interface
+     */
+    created: string;
+
+    /**
+     * The original author of the interface
+     */
+    createdBy: string;
+
+    /**
+     * The date of the interface's latest update
+     */
+    updated: string;
+
+    /**
+     * The author of the interface's latest update
+     */
+    updatedBy: string;
+}

--- a/src/resources/NextGenSearchPages/NextGenSearchPages.model.ts
+++ b/src/resources/NextGenSearchPages/NextGenSearchPages.model.ts
@@ -1,4 +1,12 @@
-import { HostedInterfaceConfiguration, HostedInterfaceOption, HostedInterfaceResultTemplate, HostedInterfaceResultTemplateBadge, IAccesses, ISortCriteria } from "../index.js";
+import {
+    HostedInterfaceConfiguration,
+    HostedInterfaceOption,
+    HostedInterfaceResultTemplate,
+    HostedInterfaceResultTemplateBadge,
+    IAccesses,
+    ISortCriteria,
+    New,
+} from '../index.js';
 
 export enum SearchPageResultActions {
     copyToClipboard = 'copyToClipboard',
@@ -147,3 +155,8 @@ export interface SearchPageInterfaceConfiguration extends Omit<HostedInterfaceCo
      */
     updatedBy: string;
 }
+
+export type NewSearchPageInterfaceConfiguration = Omit<
+    New<SearchPageInterfaceConfiguration>,
+    'created' | 'createdBy' | 'updated' | 'updatedBy'
+>;

--- a/src/resources/NextGenSearchPages/NextGenSearchPages.ts
+++ b/src/resources/NextGenSearchPages/NextGenSearchPages.ts
@@ -1,0 +1,77 @@
+import API from "../../APICore.js";
+import Resource from "../Resource.js";
+import { IAccesses, ListHostedInterfacesParams, New, PageModel } from "../index.js";
+import { SearchPageInterfaceConfiguration } from "./NextGenSearchPages.model.js";
+
+export class NextGenSearchPageResource extends Resource {
+    static getBaseUrl = `/rest/organizations/${API.orgPlaceholder}/searchpage/v1/interfaces`;
+
+    list(options?: ListHostedInterfacesParams): Promise<PageModel<SearchPageInterfaceConfiguration>> {
+        return this.api.get<PageModel<SearchPageInterfaceConfiguration>>(this.buildPath(NextGenSearchPageResource.getBaseUrl, options));
+    }
+    
+    create(searchPageConfiguration: New<SearchPageInterfaceConfiguration>): Promise<SearchPageInterfaceConfiguration> {
+        return this.api.post<SearchPageInterfaceConfiguration>(NextGenSearchPageResource.getBaseUrl, searchPageConfiguration);
+    }
+
+    delete(searchPageId: string): Promise<void> {
+        return this.api.delete(`${NextGenSearchPageResource.baseUrl}/${searchPageId}`);
+    }    
+    
+    get(searchPageId: string): Promise<SearchPageInterfaceConfiguration> {
+        return this.api.get<SearchPageInterfaceConfiguration>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}`);
+    }
+
+    update(searchPageConfiguration: SearchPageInterfaceConfiguration): Promise<SearchPageInterfaceConfiguration> {
+        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageConfiguration.id}`, searchPageConfiguration);
+    }
+
+    generatePreview(searchPageConfiguration: SearchPageInterfaceConfiguration): Promise<string> {
+        return this.api.post<string>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageConfiguration.id}/preview`, searchPageConfiguration);
+    }
+
+    getView(searchPageId: string): Promise<string> {
+        return this.api.get<string>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/preview`);
+    }
+
+    getToken(searchPageId: string): Promise<{token: string}> {
+        return this.api.get<{token: string}>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/token`);
+    }
+
+    getEditInterface(searchPageId: string): Promise<string> {
+        return this.api.get<string>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/edit`);
+    }
+
+    getLoader(searchPageId: string): Promise<string> {
+        return this.api.get<string>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/loader`);
+    }
+
+    getLoginPage(searchPageId: string): Promise<string> {
+        return this.api.get<string>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/login`);
+    }
+
+    getAccesses(searchPageId: string): Promise<IAccesses> {
+        return this.api.get<IAccesses>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses`);
+    }
+
+    updateAccesses(searchPageId: string, accesses: IAccesses): Promise<SearchPageInterfaceConfiguration> {
+        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses`, accesses);
+    }
+
+    getAccessesUsers(searchPageId: string): Promise<string[]> {
+        return this.api.get<string[]>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses/users`);
+    }
+
+    updateAccessesUsers(searchPageId: string, users: string[]): Promise<SearchPageInterfaceConfiguration> {
+        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses/users`, users);
+    }
+
+    addAccessesUsers(searchPageId: string, users: string[], notify?: boolean, message?: string): Promise<SearchPageInterfaceConfiguration> {
+        const body = message ? {users, message} : {users};
+        return this.api.post<SearchPageInterfaceConfiguration>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses/users${notify ? '?notify=1' : ''}`, body);
+    }
+
+    requestAccess(searchPageId: string): Promise<void> {
+        return this.api.post<void>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses/request`);
+    }
+}

--- a/src/resources/NextGenSearchPages/NextGenSearchPages.ts
+++ b/src/resources/NextGenSearchPages/NextGenSearchPages.ts
@@ -1,33 +1,44 @@
-import API from "../../APICore.js";
-import Resource from "../Resource.js";
-import { IAccesses, ListHostedInterfacesParams, New, PageModel } from "../index.js";
-import { SearchPageInterfaceConfiguration } from "./NextGenSearchPages.model.js";
+import API from '../../APICore.js';
+import Resource from '../Resource.js';
+import {IAccesses, ListHostedInterfacesParams, PageModel} from '../index.js';
+import {NewSearchPageInterfaceConfiguration, SearchPageInterfaceConfiguration} from './NextGenSearchPages.model.js';
 
 export default class NextGenSearchPages extends Resource {
     static getBaseUrl = `/rest/organizations/${API.orgPlaceholder}/searchpage/v1/interfaces`;
 
     list(options?: ListHostedInterfacesParams): Promise<PageModel<SearchPageInterfaceConfiguration>> {
-        return this.api.get<PageModel<SearchPageInterfaceConfiguration>>(this.buildPath(NextGenSearchPages.getBaseUrl, options));
+        return this.api.get<PageModel<SearchPageInterfaceConfiguration>>(
+            this.buildPath(NextGenSearchPages.getBaseUrl, options),
+        );
     }
-    
-    create(searchPageConfiguration: New<SearchPageInterfaceConfiguration>): Promise<SearchPageInterfaceConfiguration> {
+
+    create(searchPageConfiguration: NewSearchPageInterfaceConfiguration): Promise<SearchPageInterfaceConfiguration> {
         return this.api.post<SearchPageInterfaceConfiguration>(NextGenSearchPages.getBaseUrl, searchPageConfiguration);
     }
 
     delete(searchPageId: string): Promise<void> {
         return this.api.delete(`${NextGenSearchPages.baseUrl}/${searchPageId}`);
-    }    
-    
+    }
+
     get(searchPageId: string): Promise<SearchPageInterfaceConfiguration> {
         return this.api.get<SearchPageInterfaceConfiguration>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}`);
     }
 
-    update(searchPageConfiguration: SearchPageInterfaceConfiguration): Promise<SearchPageInterfaceConfiguration> {
-        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPages.getBaseUrl}/${searchPageConfiguration.id}`, searchPageConfiguration);
+    update(
+        searchPageId: string,
+        searchPageConfiguration: NewSearchPageInterfaceConfiguration,
+    ): Promise<SearchPageInterfaceConfiguration> {
+        return this.api.put<SearchPageInterfaceConfiguration>(
+            `${NextGenSearchPages.getBaseUrl}/${searchPageId}`,
+            searchPageConfiguration,
+        );
     }
 
-    generatePreview(searchPageConfiguration: SearchPageInterfaceConfiguration): Promise<string> {
-        return this.api.post<string>(`${NextGenSearchPages.getBaseUrl}/${searchPageConfiguration.id}/preview`, searchPageConfiguration);
+    generatePreview(searchPageConfiguration: NewSearchPageInterfaceConfiguration & {id: string}): Promise<string> {
+        return this.api.post<string>(
+            `${NextGenSearchPages.getBaseUrl}/${searchPageConfiguration.id}/preview`,
+            searchPageConfiguration,
+        );
     }
 
     getView(searchPageId: string): Promise<string> {
@@ -55,7 +66,10 @@ export default class NextGenSearchPages extends Resource {
     }
 
     updateAccesses(searchPageId: string, accesses: IAccesses): Promise<SearchPageInterfaceConfiguration> {
-        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses`, accesses);
+        return this.api.put<SearchPageInterfaceConfiguration>(
+            `${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses`,
+            accesses,
+        );
     }
 
     getAccessesUsers(searchPageId: string): Promise<string[]> {
@@ -63,12 +77,23 @@ export default class NextGenSearchPages extends Resource {
     }
 
     updateAccessesUsers(searchPageId: string, users: string[]): Promise<SearchPageInterfaceConfiguration> {
-        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses/users`, users);
+        return this.api.put<SearchPageInterfaceConfiguration>(
+            `${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses/users`,
+            users,
+        );
     }
 
-    addAccessesUsers(searchPageId: string, users: string[], notify?: boolean, message?: string): Promise<SearchPageInterfaceConfiguration> {
+    addAccessesUsers(
+        searchPageId: string,
+        users: string[],
+        notify?: boolean,
+        message?: string,
+    ): Promise<SearchPageInterfaceConfiguration> {
         const body = message ? {users, message} : {users};
-        return this.api.post<SearchPageInterfaceConfiguration>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses/users${notify ? '?notify=1' : ''}`, body);
+        return this.api.post<SearchPageInterfaceConfiguration>(
+            `${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses/users${notify ? '?notify=1' : ''}`,
+            body,
+        );
     }
 
     requestAccess(searchPageId: string): Promise<void> {

--- a/src/resources/NextGenSearchPages/NextGenSearchPages.ts
+++ b/src/resources/NextGenSearchPages/NextGenSearchPages.ts
@@ -3,75 +3,75 @@ import Resource from "../Resource.js";
 import { IAccesses, ListHostedInterfacesParams, New, PageModel } from "../index.js";
 import { SearchPageInterfaceConfiguration } from "./NextGenSearchPages.model.js";
 
-export class NextGenSearchPageResource extends Resource {
+export default class NextGenSearchPages extends Resource {
     static getBaseUrl = `/rest/organizations/${API.orgPlaceholder}/searchpage/v1/interfaces`;
 
     list(options?: ListHostedInterfacesParams): Promise<PageModel<SearchPageInterfaceConfiguration>> {
-        return this.api.get<PageModel<SearchPageInterfaceConfiguration>>(this.buildPath(NextGenSearchPageResource.getBaseUrl, options));
+        return this.api.get<PageModel<SearchPageInterfaceConfiguration>>(this.buildPath(NextGenSearchPages.getBaseUrl, options));
     }
     
     create(searchPageConfiguration: New<SearchPageInterfaceConfiguration>): Promise<SearchPageInterfaceConfiguration> {
-        return this.api.post<SearchPageInterfaceConfiguration>(NextGenSearchPageResource.getBaseUrl, searchPageConfiguration);
+        return this.api.post<SearchPageInterfaceConfiguration>(NextGenSearchPages.getBaseUrl, searchPageConfiguration);
     }
 
     delete(searchPageId: string): Promise<void> {
-        return this.api.delete(`${NextGenSearchPageResource.baseUrl}/${searchPageId}`);
+        return this.api.delete(`${NextGenSearchPages.baseUrl}/${searchPageId}`);
     }    
     
     get(searchPageId: string): Promise<SearchPageInterfaceConfiguration> {
-        return this.api.get<SearchPageInterfaceConfiguration>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}`);
+        return this.api.get<SearchPageInterfaceConfiguration>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}`);
     }
 
     update(searchPageConfiguration: SearchPageInterfaceConfiguration): Promise<SearchPageInterfaceConfiguration> {
-        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageConfiguration.id}`, searchPageConfiguration);
+        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPages.getBaseUrl}/${searchPageConfiguration.id}`, searchPageConfiguration);
     }
 
     generatePreview(searchPageConfiguration: SearchPageInterfaceConfiguration): Promise<string> {
-        return this.api.post<string>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageConfiguration.id}/preview`, searchPageConfiguration);
+        return this.api.post<string>(`${NextGenSearchPages.getBaseUrl}/${searchPageConfiguration.id}/preview`, searchPageConfiguration);
     }
 
     getView(searchPageId: string): Promise<string> {
-        return this.api.get<string>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/preview`);
+        return this.api.get<string>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/preview`);
     }
 
     getToken(searchPageId: string): Promise<{token: string}> {
-        return this.api.get<{token: string}>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/token`);
+        return this.api.get<{token: string}>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/token`);
     }
 
     getEditInterface(searchPageId: string): Promise<string> {
-        return this.api.get<string>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/edit`);
+        return this.api.get<string>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/edit`);
     }
 
     getLoader(searchPageId: string): Promise<string> {
-        return this.api.get<string>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/loader`);
+        return this.api.get<string>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/loader`);
     }
 
     getLoginPage(searchPageId: string): Promise<string> {
-        return this.api.get<string>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/login`);
+        return this.api.get<string>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/login`);
     }
 
     getAccesses(searchPageId: string): Promise<IAccesses> {
-        return this.api.get<IAccesses>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses`);
+        return this.api.get<IAccesses>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses`);
     }
 
     updateAccesses(searchPageId: string, accesses: IAccesses): Promise<SearchPageInterfaceConfiguration> {
-        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses`, accesses);
+        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses`, accesses);
     }
 
     getAccessesUsers(searchPageId: string): Promise<string[]> {
-        return this.api.get<string[]>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses/users`);
+        return this.api.get<string[]>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses/users`);
     }
 
     updateAccessesUsers(searchPageId: string, users: string[]): Promise<SearchPageInterfaceConfiguration> {
-        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses/users`, users);
+        return this.api.put<SearchPageInterfaceConfiguration>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses/users`, users);
     }
 
     addAccessesUsers(searchPageId: string, users: string[], notify?: boolean, message?: string): Promise<SearchPageInterfaceConfiguration> {
         const body = message ? {users, message} : {users};
-        return this.api.post<SearchPageInterfaceConfiguration>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses/users${notify ? '?notify=1' : ''}`, body);
+        return this.api.post<SearchPageInterfaceConfiguration>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses/users${notify ? '?notify=1' : ''}`, body);
     }
 
     requestAccess(searchPageId: string): Promise<void> {
-        return this.api.post<void>(`${NextGenSearchPageResource.getBaseUrl}/${searchPageId}/accesses/request`);
+        return this.api.post<void>(`${NextGenSearchPages.getBaseUrl}/${searchPageId}/accesses/request`);
     }
 }

--- a/src/resources/NextGenSearchPages/index.ts
+++ b/src/resources/NextGenSearchPages/index.ts
@@ -1,0 +1,2 @@
+export * from './NextGenSearchPages.js'
+export * from './NextGenSearchPages.model.js'

--- a/src/resources/NextGenSearchPages/tests/NextGenSearchPages.spec.ts
+++ b/src/resources/NextGenSearchPages/tests/NextGenSearchPages.spec.ts
@@ -1,0 +1,329 @@
+import API from '../../../APICore.js';
+import {
+    HostedInterfaceConditionOperator,
+    NewSearchPageInterfaceConfiguration,
+    SearchPageLayout,
+    SortingBy,
+} from '../../../Entry.js';
+import NextGenSearchPages from '../NextGenSearchPages.js';
+jest.mock('../../../APICore.js');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('NextGenSearchPages', () => {
+    let nextGenSearchPages: NextGenSearchPages;
+
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+    const config: NewSearchPageInterfaceConfiguration = {
+        name: 'some search page name',
+        facets: [
+            {
+                field: 'somefield',
+                label: 'Some Field',
+                displayValuesAs: 'checkbox',
+            },
+            {
+                field: 'someotherfield',
+                label: 'Some Other Field',
+                displayValuesAs: 'link',
+            },
+        ],
+        resultTemplates: [
+            {
+                name: 'template',
+                conditions: [
+                    {
+                        conditionType: HostedInterfaceConditionOperator.MustMatch,
+                        field: 'sourcetype',
+                        values: ['youtube'],
+                    },
+                    {
+                        conditionType: HostedInterfaceConditionOperator.IsDefined,
+                        field: 'ytlikecount',
+                    },
+                ],
+                badges: [
+                    {
+                        field: 'documenttype',
+                        color: '#cc0000',
+                    },
+                ],
+                details: [
+                    {
+                        field: 'documenttype',
+                        label: 'Document Type',
+                    },
+                ],
+                descriptionEnabled: true,
+                resultActions: {
+                    copyToClipboard: {enabled: true},
+                    quickview: {enabled: true},
+                },
+            },
+        ],
+        sortCriteria: [
+            {
+                by: SortingBy.RELEVANCY,
+                label: 'Relevancy',
+            },
+            {
+                by: SortingBy.DATE,
+                label: 'Date',
+            },
+            {
+                by: SortingBy.FIELD,
+                label: 'Field',
+                field: 'somefield',
+            },
+        ],
+        accesses: {
+            users: ['user1', 'user2'],
+            domains: ['domain1', 'domain2'],
+            sharingDomainEnabled: true,
+            sharingLinkEnabled: true,
+        },
+        layout: SearchPageLayout.List,
+        style: {
+            colors: {
+                accent1: '#ffffff',
+                accent2: '#000000',
+                background: '#ffffff',
+                titles: '#000000',
+                normalText: '#000000',
+                navigationBackground: '#ffffff',
+            },
+            fontFamily: 'Arial',
+        },
+        settings: {
+            smartSnippets: {enabled: true},
+            queryHistory: {enabled: true},
+            querySuggestions: {enabled: true},
+            peopleAlsoAsk: {enabled: true},
+            genQA: {enabled: true},
+        },
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        nextGenSearchPages = new NextGenSearchPages(api, serverlessApi);
+    });
+
+    describe('list', () => {
+        it('should make a GET call with all parameters', () => {
+            nextGenSearchPages.list({page: 2, perPage: 10, filter: 'Accounting', order: 'asc'});
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${NextGenSearchPages.getBaseUrl}?page=2&perPage=10&filter=Accounting&order=asc`,
+            );
+        });
+
+        it('should make a GET call with page', () => {
+            nextGenSearchPages.list({page: 2});
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}?page=2`);
+        });
+
+        it('should make a GET call with perPage', () => {
+            nextGenSearchPages.list({perPage: 10});
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}?perPage=10`);
+        });
+
+        it('should make a GET call with filter', () => {
+            nextGenSearchPages.list({filter: 'Accounting'});
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}?filter=Accounting`);
+        });
+
+        it('should make a GET call with order', () => {
+            nextGenSearchPages.list({order: 'asc'});
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}?order=asc`);
+        });
+    });
+
+    describe('create', () => {
+        it('should make a POST call to the NextGenSearchPages base url', () => {
+            nextGenSearchPages.create(config);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(NextGenSearchPages.getBaseUrl, config);
+        });
+    });
+
+    describe('delete', () => {
+        it('should make a DELETE call to the NextGenSearchPages base url', () => {
+            const id = 'NextGenSearchPages-id-to-delete';
+
+            nextGenSearchPages.delete(id);
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${NextGenSearchPages.baseUrl}/${id}`);
+        });
+    });
+
+    describe('get', () => {
+        it('should make a GET call to the NextGenSearchPages base url', () => {
+            const id = 'NextGenSearchPages-id-to-get';
+
+            nextGenSearchPages.get(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}`);
+        });
+    });
+
+    describe('update', () => {
+        it('should make a PUT call to the NextGenSearchPages base url', () => {
+            const id = 'NextGenSearchPages-id-to-update';
+
+            nextGenSearchPages.update(id, config);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}`, config);
+        });
+    });
+
+    describe('generatePreview', () => {
+        it('should make a POST call to the NextGenSearchPages base url appended with /preview', () => {
+            const id = 'NextGenSearchPages-id-to-preview';
+
+            nextGenSearchPages.generatePreview({...config, id});
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}/preview`, {...config, id});
+        });
+    });
+
+    describe('getView', () => {
+        it('should make a GET call to the NextGenSearchPages base url appended with /preview', () => {
+            const id = 'NextGenSearchPages-id-to-get';
+
+            nextGenSearchPages.getView(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}/preview`);
+        });
+    });
+
+    describe('getToken', () => {
+        it('should make a GET call to the NextGenSearchPages base url appended with /token', () => {
+            const id = 'NextGenSearchPages-id-to-get';
+
+            nextGenSearchPages.getToken(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}/token`);
+        });
+    });
+
+    describe('getEditInterface', () => {
+        it('should make a GET call to the NextGenSearchPages base url appended with /edit', () => {
+            const id = 'NextGenSearchPages-id-to-edit';
+
+            nextGenSearchPages.getEditInterface(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}/edit`);
+        });
+    });
+
+    describe('getLoader', () => {
+        it('should make a GET call to the NextGenSearchPages base url appended with /loader', () => {
+            const id = 'NextGenSearchPages-id-to-get';
+
+            nextGenSearchPages.getLoader(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}/loader`);
+        });
+    });
+
+    describe('getLoginPage', () => {
+        it('should make a GET call to the NextGenSearchPages base url appended with /login', () => {
+            const id = 'NextGenSearchPages-id-to-login';
+
+            nextGenSearchPages.getLoginPage(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}/login`);
+        });
+    });
+
+    describe('getAccesses', () => {
+        it('should make a GET call to the NextGenSearchPages base url appended with /accesses', () => {
+            const id = 'NextGenSearchPages-id-to-get';
+
+            nextGenSearchPages.getAccesses(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}/accesses`);
+        });
+    });
+
+    describe('updateAccesses', () => {
+        it('should make a PUT call to the NextGenSearchPages base url appended with /accesses', () => {
+            const id = 'NextGenSearchPages-id-to-update';
+
+            nextGenSearchPages.updateAccesses(id, config.accesses);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}/accesses`, config.accesses);
+        });
+    });
+
+    describe('getAccessesUsers', () => {
+        it('should make a GET call to the NextGenSearchPages base url appended with /accesses/users', () => {
+            const id = 'NextGenSearchPages-id-to-get';
+
+            nextGenSearchPages.getAccessesUsers(id);
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}/accesses/users`);
+        });
+    });
+
+    describe('updateAccessesUsers', () => {
+        it('should make a PUT call to the NextGenSearchPages base url appended with /accesses/users', () => {
+            const id = 'NextGenSearchPages-id-to-update';
+
+            nextGenSearchPages.updateAccessesUsers(id, config.accesses.users);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `${NextGenSearchPages.getBaseUrl}/${id}/accesses/users`,
+                config.accesses.users,
+            );
+        });
+    });
+
+    describe('addAccessesUsers', () => {
+        it('should make a POST call to the NextGenSearchPages base url appended with /accesses/users', () => {
+            const id = 'NextGenSearchPages-id-to-add';
+
+            nextGenSearchPages.addAccessesUsers(id, config.accesses.users);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}/accesses/users`, {
+                users: config.accesses.users,
+            });
+        });
+    });
+
+    describe('requestAccess', () => {
+        it('should make a POST call to the NextGenSearchPages base url appended with /accesses/request', () => {
+            const id = 'NextGenSearchPages-id-to-request';
+
+            nextGenSearchPages.requestAccess(id);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${NextGenSearchPages.getBaseUrl}/${id}/accesses/request`);
+        });
+    });
+});

--- a/src/resources/PlatformResources.ts
+++ b/src/resources/PlatformResources.ts
@@ -40,6 +40,7 @@ import SchemaService from './SchemaService/SchemaService.js';
 import Search from './Search/Search.js';
 import SearchInterfaces from './SearchInterfaces/SearchInterfaces.js';
 import SearchPages from './SearchPages/SearchPages.js';
+import NextGenSearchPages from './NextGenSearchPages/NextGenSearchPages.js';
 import SearchUsageMetrics from './SearchUsageMetrics/SearchUsageMetrics.js';
 import SecurityCache from './SecurityCache/SecurityCache.js';
 import Sources from './Sources/Sources.js';
@@ -94,6 +95,7 @@ const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'search', resource: Search},
     {key: 'searchInterfaces', resource: SearchInterfaces},
     {key: 'searchPages', resource: SearchPages},
+    {key: 'nextGenSearchPages', resource: NextGenSearchPages},
     {key: 'searchUsageMetrics', resource: SearchUsageMetrics},
     {key: 'securityCache', resource: SecurityCache},
     {key: 'source', resource: Sources},
@@ -153,6 +155,7 @@ class PlatformResources {
     search: Search;
     searchInterfaces: SearchInterfaces;
     searchPages: SearchPages;
+    nextGenSearchPages: NextGenSearchPages;
     searchUsageMetrics: SearchUsageMetrics;
     securityCache: SecurityCache;
     source: Sources;

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -41,6 +41,7 @@ export * from './SchemaService/index.js';
 export * from './Search/index.js';
 export * from './SearchInterfaces/index.js';
 export * from './SearchPages/index.js';
+export * from './NextGenSearchPages/index.js';
 export * from './SearchUsageMetrics/index.js';
 export * from './SecurityCache/index.js';
 export * from './Sources/index.js';


### PR DESCRIPTION
SVCINT-2683

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

Goes with [this PR](https://github.com/coveo/search-interface-service/pull/1378)

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
