### PR TITLE
feat(ml): remove SmartSnippets CRUD endpoint

### DIFF
--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfiguration.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfiguration.ts
@@ -1,9 +1,7 @@
 import API from '../../../APICore.js';
-import {New} from '../../BaseInterfaces.js';
 import Resource from '../../Resource.js';
 import {DocumentGroupPreviewParams} from '../DocumentInterfaces.js';
 import {
-    SmartSnippetsConfigurationModel,
     SmartSnippetsContentFields,
     SmartSnippetsContentFieldsParams,
     SmartSnippetsDocumentGroupPreview,
@@ -13,29 +11,9 @@ import {
 
 export default class SmartSnippetsConfiguration extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/smartsnippets`;
-    static modelUrl = `${SmartSnippetsConfiguration.baseUrl}/model`;
     static contentFieldsUrl = `${SmartSnippetsConfiguration.baseUrl}/contentfields`;
     static documentTypesUrl = `${SmartSnippetsConfiguration.baseUrl}/documenttypes`;
     static previewUrl = `${SmartSnippetsConfiguration.baseUrl}/preview`;
-
-    create(configModel: New<SmartSnippetsConfigurationModel, 'modelId'>) {
-        return this.api.post<SmartSnippetsConfigurationModel>(SmartSnippetsConfiguration.modelUrl, configModel);
-    }
-
-    delete(modelId: string) {
-        return this.api.delete(`${SmartSnippetsConfiguration.modelUrl}/${modelId}`);
-    }
-
-    get(modelId: string) {
-        return this.api.get<SmartSnippetsConfigurationModel>(`${SmartSnippetsConfiguration.modelUrl}/${modelId}`);
-    }
-
-    update(configModel: SmartSnippetsConfigurationModel) {
-        return this.api.put<SmartSnippetsConfigurationModel>(
-            `${SmartSnippetsConfiguration.modelUrl}/${configModel.modelId}`,
-            configModel,
-        );
-    }
 
     contentFields(params: SmartSnippetsContentFieldsParams) {
         return this.api.post<SmartSnippetsContentFields>(SmartSnippetsConfiguration.contentFieldsUrl, params);

--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/SmartSnippetsConfigurationInterfaces.ts
@@ -12,34 +12,6 @@ export interface DocumentType {
     documentType: string;
 }
 
-export interface SmartSnippetsConfigurationModel {
-    /**
-     * The unique ID of the model.
-     */
-    modelId: string;
-    /**
-     * The model name to display.
-     * Example: My First Model
-     */
-    modelDisplayName: string;
-    /**
-     * The sources to consider.
-     */
-    sources: string[];
-    /**
-     * An array of filtering conditions.
-     */
-    filterConditions: FilterConditions[];
-    /**
-     * An array of css selectors to evaluate content to exclude.
-     */
-    cssSelectorsToExclude?: string[];
-    /**
-     * The document type for which content is in custom index fields.
-     */
-    documentTypes?: DocumentType[];
-}
-
 export interface SmartSnippetsDocumentGroupPreview {
     /**
      * The query that was used to fetch document information.

--- a/src/resources/MachineLearning/SmartSnippetsConfiguration/tests/SmartSnippetsConfiguration.spec.ts
+++ b/src/resources/MachineLearning/SmartSnippetsConfiguration/tests/SmartSnippetsConfiguration.spec.ts
@@ -1,10 +1,7 @@
 import API from '../../../../APICore.js';
 import {DocumentGroupPreviewParams} from '../../DocumentInterfaces.js';
 import SmartSnippetsConfiguration from '../SmartSnippetsConfiguration.js';
-import {
-    SmartSnippetsConfigurationModel,
-    SmartSnippetsContentFieldsParams,
-} from '../SmartSnippetsConfigurationInterfaces.js';
+import {SmartSnippetsContentFieldsParams} from '../SmartSnippetsConfigurationInterfaces.js';
 
 jest.mock('../../../../APICore.js');
 
@@ -15,77 +12,9 @@ describe('SmartSnippetsConfiguration', () => {
     const api = new APIMock() as jest.Mocked<API>;
     const serverlessApi = new APIMock() as jest.Mocked<API>;
 
-    const modelConfigs: SmartSnippetsConfigurationModel[] = [
-        {
-            modelId: 'test-model-id',
-            modelDisplayName: 'Model Name 1',
-            sources: ['1st-source', '2nd-source'],
-            filterConditions: [],
-        },
-        {
-            modelId: 'test-model-id',
-            modelDisplayName: 'Model Name 1',
-            sources: ['1st-source', '2nd-source'],
-            filterConditions: [],
-            cssSelectorsToExclude: ['div.mock[id="this-is-a-test"]', '#wow'],
-            documentTypes: [
-                {
-                    contentFields: ['field-1', 'field-2'],
-                    documentType: 'HTMLFile',
-                },
-            ],
-        },
-    ];
-
     beforeEach(() => {
         jest.clearAllMocks();
         smartSnippetsConfig = new SmartSnippetsConfiguration(api, serverlessApi);
-    });
-
-    describe('create', () => {
-        modelConfigs.forEach((modelConfig, index) => {
-            it(`should make a POST call to the Smart Snippets Configuration base url with config ${index}`, () => {
-                const {modelId: _, ...newConfig} = modelConfig;
-                smartSnippetsConfig.create(newConfig);
-
-                expect(api.post).toHaveBeenCalledTimes(1);
-                expect(api.post).toHaveBeenCalledWith(SmartSnippetsConfiguration.modelUrl, newConfig);
-            });
-        });
-    });
-
-    describe('delete', () => {
-        it('should make a DELETE call to the specific Smart Snippets Configuration url', () => {
-            const configToDeleteId = 'config-to-be-deleted';
-            smartSnippetsConfig.delete(configToDeleteId);
-
-            expect(api.delete).toHaveBeenCalledTimes(1);
-            expect(api.delete).toHaveBeenCalledWith(`${SmartSnippetsConfiguration.modelUrl}/${configToDeleteId}`);
-        });
-    });
-
-    describe('get', () => {
-        it('should make a GET call to the specific Smart Snippets Configuration url', () => {
-            const configToGetId = 'config-to-be-fetched';
-            smartSnippetsConfig.get(configToGetId);
-
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${SmartSnippetsConfiguration.modelUrl}/${configToGetId}`);
-        });
-    });
-
-    describe('update', () => {
-        modelConfigs.forEach((modelConfig, index) => {
-            it(`should make a PUT call to the specific Smart Snippets Configuration url for config ${index}`, () => {
-                smartSnippetsConfig.update(modelConfig);
-
-                expect(api.put).toHaveBeenCalledTimes(1);
-                expect(api.put).toHaveBeenCalledWith(
-                    `${SmartSnippetsConfiguration.modelUrl}/${modelConfig.modelId}`,
-                    modelConfig,
-                );
-            });
-        });
     });
 
     describe('contentFields', () => {


### PR DESCRIPTION
remove SmartSnippets CRUD endpoints, CRUD operation of this model will be using /rest/organizations/{organizationId}/machinelearning/model instead

BREAKING CHANGE: remove SmartSnippets CRUD endpoint

There are 4 endpoints deprecated from machine learning configuration:
https://platform.cloud.coveo.com/docs?urls.primaryName=Machine%20Learning%20Configuration#/Smart%20Snippets%20Configuration/rest_organizations_paramId_machinelearning_configuration_smartsnippets_model_paramId_get

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
