### PR TITLE
fix(APICore): let AbortError be thrown

### DIFF
--- a/src/APICore.ts
+++ b/src/APICore.ts
@@ -64,35 +64,7 @@ export default class API {
     }
 
     async get<T = Record<string, unknown>>(url: string, args?: CoveoPlatformClientRequestInit): Promise<T> {
-        try {
-            return await this.request<T>(url, this.buildRequestInit('GET', args), args?.responseBodyFormat);
-        } catch (error) {
-            // Warning: the logic below does not do what the original author intended/mentions.
-            // It will fullfil the promise with `undefined`, instead of keeping it pending.
-            if (error.name === 'AbortError') {
-                return undefined as T; // We don't want to resolve or reject the promise
-            } else {
-                throw error;
-            }
-        }
-    }
-
-    /**
-     * @deprecated Use `get` with `{responseBodyFormat: 'blob'}` argument instead. Will be removed in version 45
-     */
-    async getFile(url: string, args?: CoveoPlatformClientRequestInit): Promise<Blob> {
-        try {
-            return await this.request(url, this.buildRequestInit('GET', args), 'blob');
-        } catch (error) {
-            // Warning: the logic below does not do what the original author intended/mentions.
-            // It will fullfil the promise with `undefined`, instead of keeping it pending.
-            if (error.name === 'AbortError') {
-                // We don't want to resolve or reject the promise
-                return undefined as unknown as Blob;
-            } else {
-                throw error;
-            }
-        }
+        return await this.request<T>(url, this.buildRequestInit('GET', args), args?.responseBodyFormat);
     }
 
     async post<T = Record<string, unknown>>(


### PR DESCRIPTION
## Problem 

As we can see here https://github.com/coveo/platform-client/blob/master/src/APICore.ts#L73, when a request is aborted, the client resolves the promise with `undefined`. This is a wrong approach to handling abort errors, because we are essentially lying to the caller. For example, the return type could be something like `Promise<PageModel<Something>>`, but in reality we can return `Promise<undefined>` when an abort occurs. Since the type declaration does not reflect that `undefined` is a possible return value, the code in user land can't know it must handle that edge case.

## Solution

`AbortError` will now be thrown instead of catching it and resolving the `GET` request with `undefined`. This is a more natural way of handling abort errors. We let the user take care of how it should be done. If the users still wants to handle it at large by resolving with `undefined` like before, they can do so by creating a response handler that does that.

For example:

```ts
const myHandler: ResponseHandler = {
    canProcess: () => true,
    process: async <T>(response: Response): Promise<T> => {
        try {
            const responseJson = await response.json();
            // whatever here
        } catch (error) {
            if (error.name === 'AbortError') {
                // Handle the aborted request here
                return undefined as T // like before
            } else {
                throw error;
            }
        }
    },
};
```

## Maintenance chore

Removed the deprecated `.getFile` method from `APICore` class. The user can use `.get` with option `responseBodyFormat: 'blob'` instead. It has been deprecated for a while now, since I am doing a breaking change I figured it would be time to remove it.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
