### PR TITLE
feat(pushapi): add method to create a file container

### DIFF
--- a/src/resources/PushApi/PushApi.ts
+++ b/src/resources/PushApi/PushApi.ts
@@ -1,6 +1,7 @@
 import API from '../../APICore.js';
 import Resource from '../Resource.js';
 import {
+    FileContainer,
     SecurityIdentityAliasModel,
     SecurityIdentityBatchConfig,
     SecurityIdentityDelete,
@@ -10,7 +11,11 @@ import {
 } from './PushApiInterfaces.js';
 
 export default class PushApi extends Resource {
-    static baseUrl = `/push/v1/organizations/${API.orgPlaceholder}/providers`;
+    static baseUrl = `/push/v1/organizations/${API.orgPlaceholder}`;
+
+    createFileContainer() {
+        return this.serverlessApi.post<FileContainer>(`${PushApi.baseUrl}/files`);
+    }
 
     createOrUpdateSecurityIdentityAlias(
         securityProviderId: string,
@@ -18,7 +23,7 @@ export default class PushApi extends Resource {
         options?: SecurityIdentityOptions,
     ) {
         return this.serverlessApi.put<void>(
-            this.buildPath(`${PushApi.baseUrl}/${securityProviderId}/mappings`, options),
+            this.buildPath(`${PushApi.baseUrl}/providers/${securityProviderId}/mappings`, options),
             alias,
         );
     }
@@ -29,7 +34,7 @@ export default class PushApi extends Resource {
         options?: SecurityIdentityOptions,
     ) {
         return this.serverlessApi.delete<void>(
-            this.buildPath(`${PushApi.baseUrl}/${securityProviderId}/permissions`, options),
+            this.buildPath(`${PushApi.baseUrl}/providers/${securityProviderId}/permissions`, options),
             {
                 body: JSON.stringify(securityIdentity),
                 headers: {'Content-Type': 'application/json'},
@@ -43,20 +48,20 @@ export default class PushApi extends Resource {
         options?: SecurityIdentityOptions,
     ) {
         return this.serverlessApi.put<void>(
-            this.buildPath(`${PushApi.baseUrl}/${securityProviderId}/permissions`, options),
+            this.buildPath(`${PushApi.baseUrl}/providers/${securityProviderId}/permissions`, options),
             securityIdentity,
         );
     }
 
     manageSecurityIdentities(securityProviderId: string, batchConfig: SecurityIdentityBatchConfig) {
         return this.serverlessApi.put<void>(
-            this.buildPath(`${PushApi.baseUrl}/${securityProviderId}/permissions/batch`, batchConfig),
+            this.buildPath(`${PushApi.baseUrl}/providers/${securityProviderId}/permissions/batch`, batchConfig),
         );
     }
 
     deleteOldSecurityIdentities(securityProviderId: string, batchDelete: SecurityIdentityDeleteOptions) {
         return this.serverlessApi.delete<void>(
-            this.buildPath(`${PushApi.baseUrl}/${securityProviderId}/permissions/olderthan`, batchDelete),
+            this.buildPath(`${PushApi.baseUrl}/providers/${securityProviderId}/permissions/olderthan`, batchDelete),
         );
     }
 }

--- a/src/resources/PushApi/PushApi.ts
+++ b/src/resources/PushApi/PushApi.ts
@@ -2,6 +2,7 @@ import API from '../../APICore.js';
 import Resource from '../Resource.js';
 import {
     FileContainer,
+    FileContainerOptions,
     SecurityIdentityAliasModel,
     SecurityIdentityBatchConfig,
     SecurityIdentityDelete,
@@ -13,8 +14,8 @@ import {
 export default class PushApi extends Resource {
     static baseUrl = `/push/v1/organizations/${API.orgPlaceholder}`;
 
-    createFileContainer() {
-        return this.serverlessApi.post<FileContainer>(`${PushApi.baseUrl}/files`);
+    createFileContainer(options?: FileContainerOptions) {
+        return this.serverlessApi.post<FileContainer>(this.buildPath(`${PushApi.baseUrl}/files`, options));
     }
 
     createOrUpdateSecurityIdentityAlias(

--- a/src/resources/PushApi/PushApiInterfaces.ts
+++ b/src/resources/PushApi/PushApiInterfaces.ts
@@ -6,6 +6,15 @@ export interface FileContainer {
     requiredHeaders: Record<string, string>;
 }
 
+export interface FileContainerOptions {
+    /**
+     * Whether to generate the presigned URL using the virtual hosted-style URL.
+     *
+     * Example of a virtual hosted-style url: `https://coveo-nprod-customer-data.s3.us-east-1.amazonaws.com/proda/blobstore/mycoveocloudv2organizationg8tp8wu3/b5e8767e-8f0d-4a89-9095-1127915c89c7[...]`
+     */
+    useVirtualHostedStyleUrl?: boolean;
+}
+
 export interface SecurityIdentityAliasModel extends SecurityIdentityBase {
     mappings: AliasMappings;
 }

--- a/src/resources/PushApi/PushApiInterfaces.ts
+++ b/src/resources/PushApi/PushApiInterfaces.ts
@@ -1,5 +1,11 @@
 import {SinglePermissionResult, SinglePermissionIdentityType} from '../Enums.js';
 
+export interface FileContainer {
+    uploadUri: string;
+    fileId: string;
+    requiredHeaders: Record<string, string>;
+}
+
 export interface SecurityIdentityAliasModel extends SecurityIdentityBase {
     mappings: AliasMappings;
 }

--- a/src/resources/PushApi/tests/PushApi.spec.ts
+++ b/src/resources/PushApi/tests/PushApi.spec.ts
@@ -28,7 +28,19 @@ describe('PushAPI', () => {
     });
 
     describe('createFileContainer', () => {
-        it('should make a POST call to /push/v1/organizations/{organizationName}/files', async () => {
+        test.each([
+            ['/push/v1/organizations/{organizationName}/files', undefined],
+            ['/push/v1/organizations/{organizationName}/files', {}],
+            [
+                '/push/v1/organizations/{organizationName}/files?useVirtualHostedStyleUrl=true',
+                {useVirtualHostedStyleUrl: true},
+            ],
+            [
+                '/push/v1/organizations/{organizationName}/files?useVirtualHostedStyleUrl=false',
+                {useVirtualHostedStyleUrl: false},
+            ],
+            ['/push/v1/organizations/{organizationName}/files', {useVirtualHostedStyleUrl: undefined}],
+        ])('should make a POST call to %s when called with %o', async (url, options) => {
             serverlessApi.post.mockImplementation(
                 async (): Promise<FileContainer> => ({
                     fileId: 'somefileid',
@@ -37,14 +49,14 @@ describe('PushAPI', () => {
                 }),
             );
 
-            const fileContainer = await pushApi.createFileContainer();
+            const fileContainer = await pushApi.createFileContainer(options);
             expect(fileContainer).toEqual({
                 fileId: 'somefileid',
                 requiredHeaders: {a: 'b', c: 'd'},
                 uploadUri: 'https://something',
             });
             expect(serverlessApi.post).toHaveBeenCalledTimes(1);
-            expect(serverlessApi.post).toHaveBeenCalledWith('/push/v1/organizations/{organizationName}/files');
+            expect(serverlessApi.post).toHaveBeenCalledWith(url);
         });
     });
 

--- a/src/resources/PushApi/tests/PushApi.spec.ts
+++ b/src/resources/PushApi/tests/PushApi.spec.ts
@@ -1,7 +1,7 @@
 import API from '../../../APICore.js';
 import {SinglePermissionIdentityType} from '../../Enums.js';
 import PushApi from '../PushApi.js';
-import {SecurityIdentityAliasModel, SecurityIdentityOptions} from '../PushApiInterfaces.js';
+import {FileContainer, SecurityIdentityAliasModel, SecurityIdentityOptions} from '../PushApiInterfaces.js';
 
 jest.mock('../../../APICore.js');
 
@@ -25,6 +25,27 @@ describe('PushAPI', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         pushApi = new PushApi(api, serverlessApi);
+    });
+
+    describe('createFileContainer', () => {
+        it('should make a POST call to /push/v1/organizations/{organizationName}/files', async () => {
+            serverlessApi.post.mockImplementation(
+                async (): Promise<FileContainer> => ({
+                    fileId: 'somefileid',
+                    requiredHeaders: {a: 'b', c: 'd'},
+                    uploadUri: 'https://something',
+                }),
+            );
+
+            const fileContainer = await pushApi.createFileContainer();
+            expect(fileContainer).toEqual({
+                fileId: 'somefileid',
+                requiredHeaders: {a: 'b', c: 'd'},
+                uploadUri: 'https://something',
+            });
+            expect(serverlessApi.post).toHaveBeenCalledTimes(1);
+            expect(serverlessApi.post).toHaveBeenCalledWith('/push/v1/organizations/{organizationName}/files');
+        });
     });
 
     describe('Security Identity', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/DT-6757

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

This PR adds a new method the `PushApi` resource to allow the creation of file containers.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
