### PR TITLE
feat(sources): add new endpoint to retrieve list of sources according to a list of IDs

### DIFF
--- a/src/resources/Sources/Sources.ts
+++ b/src/resources/Sources/Sources.ts
@@ -55,6 +55,22 @@ export default class Sources extends Resource {
         );
     }
 
+    /**
+     * Returns a list of sources according to an operational status and a list of source IDs
+     *
+     * @param {ListOperationalStatusSourcesParams} params
+     * @returns {Promise<PageModel<SourceModel, 'sourceModels'>>} A paginated list of IDs
+     */
+    listOperationalStatusBySourceIds(
+        params?: ListOperationalStatusSourcesParams,
+        sourceIds?: string[],
+    ): Promise<PageModel<SourceModel, 'sourceModels'>> {
+        return this.api.post<PageModel<SourceModel, 'sourceModels'>>(
+            this.buildPath(`${Sources.baseUrl}/sourceoperationalstatus/ids`, params),
+            sourceIds,
+        );
+    }
+
     createFromRaw(rawSourceConfig: RawSourceConfig, options?: CreateSourceOptions) {
         return this.api.post<{id: string}>(this.buildPath(`${Sources.baseUrl}/raw`, options), rawSourceConfig);
     }

--- a/src/resources/Sources/tests/Sources.spec.ts
+++ b/src/resources/Sources/tests/Sources.spec.ts
@@ -4,7 +4,12 @@ import {ActivityOperation} from '../../Enums.js';
 import {ScheduleModel} from '../../SecurityCache/index.js';
 import Sources from '../Sources.js';
 import SourcesFields from '../SourcesFields/SourcesFields.js';
-import {CreateSourceModel, ListSourcesParams, RawSourceConfig} from '../SourcesInterfaces.js';
+import {
+    CreateSourceModel,
+    ListOperationalStatusSourcesParams,
+    ListSourcesParams,
+    RawSourceConfig,
+} from '../SourcesInterfaces.js';
 import SourcesMappings from '../SourcesMappings/SourcesMappings.js';
 
 jest.mock('../../../APICore.js');
@@ -53,6 +58,23 @@ describe('Sources', () => {
             source.list(params);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Sources.baseUrl}/pages?stringFilterType=EXACTMATCH`);
+        });
+    });
+
+    describe('listOperationalStatusBySourceIds', () => {
+        it('should make a POST call to the specific Sources url', () => {
+            const mockParams = {
+                page: 0,
+                perPage: 50,
+            } as ListOperationalStatusSourcesParams;
+            const mockSourceIds = ['source-1', 'source-2'];
+
+            source.listOperationalStatusBySourceIds(mockParams, mockSourceIds);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(
+                `${Sources.baseUrl}/sourceoperationalstatus/ids?page=0&perPage=50`,
+                mockSourceIds,
+            );
         });
     });
 


### PR DESCRIPTION
This PR is done in continuation of this [addition](https://github.com/coveo/sourceservice/pull/2257/files#diff-6722c6517924714b4ce0034638b911676e206b842acbacfa1c08c01053d4915d). 

* Adding a new endpoint that returns the models specified in the body. 
   * It is basically the same as the `listOperationalStatus` call. However, it's a POST request and accepts a list of source IDs in its body.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
