### PR TITLE
feat(catalogs): add catalogIds and sourceIds to CatalogsListOptions

### DIFF
--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -11,6 +11,14 @@ export interface CatalogsListOptions {
      * The number of catalogs to list per page.
      */
     pageSize?: number;
+    /**
+     * List of the unique identifiers of the catalog to show.
+     */
+    catalogIds?: string[];
+    /**
+     * List of the unique identifiers of the sources.
+     */
+    sourceIds?: string[];
 }
 
 export type CatalogConfigurationsListOptions = Omit<CatalogsListOptions, 'filter'>;


### PR DESCRIPTION
CTCORE-9876

This adds `catalogIds` and `sourceIds` to the CatalogsListOptions to reflect the new parameters in the Swagger: 
![image](https://github.com/coveo/platform-client/assets/50966943/1cca27be-b57c-4de4-ad78-ce18666f4759)

Can anyone clarify whether this is a breaking change or not?
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
