### PR TITLE
feat(pipelines): add excludeAbTestTargets parameter to options

### DIFF
--- a/src/resources/Pipelines/PipelinesInterfaces.ts
+++ b/src/resources/Pipelines/PipelinesInterfaces.ts
@@ -206,6 +206,10 @@ export interface ListPipelinesOptions extends Paginated {
      * Whether to enable pagination.
      */
     enablePagination?: boolean;
+    /**
+     * Whether to exclude the A/B test targets from the result.
+     */
+    excludeAbTestTargets?: boolean;
 }
 
 export type PaginatedListPipelinesModel = Omit<PageModel<PipelineModel>, 'totalPages'>;

--- a/src/resources/Pipelines/tests/Pipelines.spec.ts
+++ b/src/resources/Pipelines/tests/Pipelines.spec.ts
@@ -17,15 +17,30 @@ describe('Pipelines', () => {
     });
 
     describe('list', () => {
-        it('should make a GET call to the Pipelines v1 url', () => {
+        it('makes a GET call to the Pipelines v1 url', () => {
             pipelines.list();
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(Pipelines.searchUrlVersion1);
         });
+        it('passes the query parameters with the request', () => {
+            pipelines.list({
+                filter: 'filter',
+                page: 0,
+                perPage: 25,
+                sortby: 'position',
+                isOrderAscending: true,
+                enablePagination: true,
+                excludeAbTestTargets: true,
+            });
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Pipelines.searchUrlVersion1}?filter=filter&page=0&perPage=25&sortby=position&isOrderAscending=true&enablePagination=true&excludeAbTestTargets=true`,
+            );
+        });
     });
 
     describe('get', () => {
-        it('should make a GET call to /rest/search/v1/admin/pipelines/:id', () => {
+        it('makes a GET call to /rest/search/v1/admin/pipelines/:id', () => {
             pipelines.get('🔥');
 
             expect(api.get).toHaveBeenCalledTimes(1);
@@ -34,7 +49,7 @@ describe('Pipelines', () => {
     });
 
     describe('delete', () => {
-        it('should make a DELETE call to /rest/search/v1/admin/pipelines/:id', () => {
+        it('makes a DELETE call to /rest/search/v1/admin/pipelines/:id', () => {
             pipelines.delete('🔥');
 
             expect(api.delete).toHaveBeenCalledTimes(1);
@@ -43,7 +58,7 @@ describe('Pipelines', () => {
     });
 
     describe('update', () => {
-        it('should make a PUT call to /rest/search/v1/admin/pipelines/:id', () => {
+        it('makes a PUT call to /rest/search/v1/admin/pipelines/:id', () => {
             const pipelineToUpdate: UpdatePipelineModel = {
                 id: '🔥',
                 name: 'fire',
@@ -56,7 +71,7 @@ describe('Pipelines', () => {
     });
 
     describe('duplicate', () => {
-        it('should make a POST call to /rest/search/v1/admin/pipelines/:id/duplicate', () => {
+        it('makes a POST call to /rest/search/v1/admin/pipelines/:id/duplicate', () => {
             pipelines.duplicate('🔥');
 
             expect(api.post).toHaveBeenCalledTimes(1);
@@ -76,7 +91,7 @@ describe('Pipelines', () => {
     });
 
     describe('create', () => {
-        it('should make a POST call to /rest/search/v1/admin/pipelines', () => {
+        it('makes a POST call to /rest/search/v1/admin/pipelines', () => {
             const newPipeline: NewPipelineModel = {
                 name: 'fire',
                 description: 'this-is-lit',
@@ -89,15 +104,15 @@ describe('Pipelines', () => {
     });
 
     describe('nested resources', () => {
-        it('should front associations', () => {
+        it('includes associations', () => {
             expect(pipelines.associations).toBeDefined();
         });
 
-        it('should front statements', () => {
+        it('includes statements', () => {
             expect(pipelines.statements).toBeDefined();
         });
 
-        it('should front resultRanking', () => {
+        it('includes resultRanking', () => {
             expect(pipelines.resultRanking).toBeDefined();
         });
     });


### PR DESCRIPTION
### Description

Add the `excludeAbTestTargets` parameters to the `ListPipelinesOptions` interface. 

This property is documented in [Swagger](https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20API#/Pipelines/listQueryPipelinesV1). 📖 

![Screenshot 2024-03-13 at 10 49 20 AM](https://github.com/coveo/platform-client/assets/133259861/ddd628f3-3ad6-4d64-b8d5-c7f3cedabdee)

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
