### PR TITLE
feat(statements): add bulkDelete endpoint for pipeline statements

### DIFF
--- a/src/resources/Pipelines/Statements/Statements.ts
+++ b/src/resources/Pipelines/Statements/Statements.ts
@@ -15,12 +15,26 @@ export default class Statements extends Resource {
     static getStatementUrl = (pipelineId: string, statementId: string) =>
         `${Statements.getBaseUrl(pipelineId)}/${statementId}`;
 
-    list(pipelineId: string, options?: ListStatementParams) {
+    /**
+     * Gets a sorted page of query pipeline statements matching certain criteria from a specific query pipeline.
+     *
+     * @param {string} pipelineId The unique identifier of the target query pipeline.
+     * @param {ListStatementParams} options Listing options.
+     * @returns {Promise<PageModel<StatementModel, "statements">>} The matching statements in the current page of results
+     */
+    list(pipelineId: string, options?: ListStatementParams): Promise<PageModel<StatementModel, 'statements'>> {
         return this.api.get<PageModel<StatementModel, 'statements'>>(
             this.buildPath(Statements.getBaseUrl(pipelineId), {organizationId: this.api.organizationId, ...options}),
         );
     }
 
+    /**
+     * Exports the definition, condition, and description of statements from a specific query pipeline to a CSV file.
+     *
+     * @param {string} pipelineId The unique identifier of the target query pipeline.
+     * @param {ExportStatementParams} options Export options
+     * @returns {Promise<Blob>} The file containing the exported data.
+     */
     exportCSV(pipelineId: string, options?: ExportStatementParams): Promise<Blob> {
         return this.api.get(
             this.buildPath(`${Statements.getBaseUrl(pipelineId)}/export`, {
@@ -31,6 +45,13 @@ export default class Statements extends Resource {
         );
     }
 
+    /**
+     * Import the definition, condition, and description of statements from a CSV file to a specific query pipeline.
+     *
+     * @param {string} pipelineId The unique identifier of the target query pipeline.
+     * @param {File | string} csvFile The file containing the statements to import.
+     * @param {ExportStatementParams} options Import options
+     */
     importCSV(pipelineId: string, csvFile: File | string, options?: ExportStatementParams) {
         const formData = new FormData();
         if (typeof csvFile === 'string') {
@@ -49,14 +70,29 @@ export default class Statements extends Resource {
         );
     }
 
-    create(pipelineId: string, model: CreateStatementModel) {
+    /**
+     * Creates a new query pipeline statement in a specific query pipeline.
+     *
+     * @param {string} pipelineId The unique identifier of the target query pipeline.
+     * @param {CreateStatementModel} model The query pipeline statement information.
+     * @returns {Promise<StatementModel>} The created statement.
+     */
+    create(pipelineId: string, model: CreateStatementModel): Promise<StatementModel> {
         return this.api.post<StatementModel>(
             this.buildPath(Statements.getBaseUrl(pipelineId), {organizationId: this.api.organizationId}),
             model,
         );
     }
 
-    update(pipelineId: string, statementId: string, model: CreateStatementModel) {
+    /**
+     * Updates a single query pipeline statement in a specific query pipeline.
+     *
+     * @param {string} pipelineId The unique identifier of the target query pipeline.
+     * @param {string} statementId The unique identifier of the target statement.
+     * @param {CreateStatementModel} model The updated query pipeline statement information.
+     * @returns {Promise<StatementModel>} The updated statement.
+     */
+    update(pipelineId: string, statementId: string, model: CreateStatementModel): Promise<StatementModel> {
         return this.api.put<StatementModel>(
             this.buildPath(Statements.getStatementUrl(pipelineId, statementId), {
                 organizationId: this.api.organizationId,
@@ -65,6 +101,13 @@ export default class Statements extends Resource {
         );
     }
 
+    /**
+     * Copies specific statements from an origin to a target query pipeline. Using the same pipeline as origin and target will duplicate the specified statements in that pipeline.
+     *
+     * @param {string} pipelineId The unique identifier of the target query pipeline.
+     * @param {CopyStatementModel} model The copy operation to perform.
+     * @returns {Promise<PageModel<StatementModel, "statements">>} The matching statements in the current page of results.
+     */
     copy(pipelineId: string, model: CopyStatementModel) {
         return this.api.post<PageModel<StatementModel, 'statements'>>(
             this.buildPath(`${Statements.getBaseUrl(pipelineId)}/copy`, {organizationId: this.api.organizationId}),
@@ -72,7 +115,14 @@ export default class Statements extends Resource {
         );
     }
 
-    get(pipelineId: string, statementId: string) {
+    /**
+     * Gets a single query pipeline statement from a specific query pipeline.
+     *
+     * @param {string} pipelineId The unique identifier of the target query pipeline.
+     * @param {string} statementId The unique identifier of the target statement.
+     * @returns {Promise<StatementModel>} The statement
+     */
+    get(pipelineId: string, statementId: string): Promise<StatementModel> {
         return this.api.get<StatementModel>(
             this.buildPath(Statements.getStatementUrl(pipelineId, statementId), {
                 organizationId: this.api.organizationId,
@@ -80,7 +130,19 @@ export default class Statements extends Resource {
         );
     }
 
-    move(pipelineId: string, statementId: string, model: MoveStatementModel) {
+    /**
+     * Sets the position of a query pipeline statement in a specific query pipeline and updates other statement positions as appropriate.
+     *
+     * @param {string} pipelineId The unique identifier of the target query pipeline.
+     * @param {string} statementId The unique identifier of the target statement.
+     * @param {MoveStatementModel} model The move operation to perform.
+     * @returns {Promise<PageModel<StatementModel, 'statements'>>} The matching statements in the current page of results.
+     */
+    move(
+        pipelineId: string,
+        statementId: string,
+        model: MoveStatementModel,
+    ): Promise<PageModel<StatementModel, 'statements'>> {
         return this.api.put<PageModel<StatementModel, 'statements'>>(
             this.buildPath(`${Statements.getStatementUrl(pipelineId, statementId)}/move`, {
                 organizationId: this.api.organizationId,
@@ -89,6 +151,12 @@ export default class Statements extends Resource {
         );
     }
 
+    /**
+     * Deletes a single query pipeline statement from a specific query pipeline.
+     *
+     * @param {string} pipelineId The unique identifier of the target query pipeline.
+     * @param {string} statementId The unique identifier of the target statement.
+     */
     delete(pipelineId: string, statementId: string) {
         return this.api.delete(
             this.buildPath(Statements.getStatementUrl(pipelineId, statementId), {
@@ -97,11 +165,36 @@ export default class Statements extends Resource {
         );
     }
 
-    bulkGet(pipelineId: string, {ids, ...allQueryStringOptions}: BulkGetStatementsParams) {
+    /**
+     * Gets a sorted page of query pipeline statements matching certain criteria from a specific query pipeline.
+     *
+     * @param {string} pipelineId The unique identifier of the target query pipeline.
+     * @param {BulkGetStatementsParams} params A set of parameters to customize the results.
+     * @returns {Promise<PageModel<StatementModel, 'statements'>>} The matching statements in the current page of results.
+     */
+    bulkGet(
+        pipelineId: string,
+        {ids, ...allQueryStringOptions}: BulkGetStatementsParams,
+    ): Promise<PageModel<StatementModel, 'statements'>> {
         return this.api.post<PageModel<StatementModel, 'statements'>>(
             this.buildPath(`${Statements.getBaseUrl(pipelineId)}/bulkGet`, {
                 organizationId: this.api.organizationId,
                 ...allQueryStringOptions,
+            }),
+            {ids},
+        );
+    }
+
+    /**
+     * Delete multiple statements at once for a specific pipeline.
+     *
+     * @param {string} pipelineId The unique identifier of the target query pipeline.
+     * @param {string[]} ids A list of resource identifiers to delete. A maximum of 100 can be sent.
+     */
+    bulkDelete(pipelineId: string, ids: string[]) {
+        return this.api.post(
+            this.buildPath(`${Statements.getBaseUrl(pipelineId)}/bulkDelete`, {
+                organizationId: this.api.organizationId,
             }),
             {ids},
         );

--- a/src/resources/Pipelines/Statements/tests/Statements.spec.ts
+++ b/src/resources/Pipelines/Statements/tests/Statements.spec.ts
@@ -180,4 +180,14 @@ describe('Statements', () => {
             expect(api.post).toHaveBeenCalledWith(`${Statements.getBaseUrl(pipelineId)}/bulkGet`, {ids});
         });
     });
+
+    describe('bulkDelete', () => {
+        it('sends a POST call to /bulkDelete with the provided ids', () => {
+            statements.bulkDelete('🆔', ['rule-one', 'rule-two']);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith('/rest/search/v2/admin/pipelines/🆔/statements/bulkDelete', {
+                ids: ['rule-one', 'rule-two'],
+            });
+        });
+    });
 });


### PR DESCRIPTION
### Related ticket

https://coveord.atlassian.net/browse/SEARCHAPI-9775

### Description

Add the `statements/bulkDelete` endpoint. It allows to delete multiple statements from a query pipelines at once.

It's documented in Swagger [here](https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20API#/Statements%20V2/bulkDeleteStatements). 📖 

I also took the liberty to add the missing jsDoc to the other endpoints in that resource. 
Documentation for those endpoints is at the same place as the new endpoint above (under `Statements V2`) [here](https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20API#/). 📖  

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
