### PR TITLE
feat: add new param to bypass field enrichements on list catalogs

### DIFF
--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -19,6 +19,10 @@ export interface CatalogsListOptions {
      * List of the unique identifiers of the sources.
      */
     sourceIds?: string[];
+    /**
+     * If true, catalog will be enriched with field suggestions. This requires a call to SearchAPI
+     */
+    enrichWithFields?: boolean;
 }
 
 export type CatalogConfigurationsListOptions = Omit<CatalogsListOptions, 'filter'>;


### PR DESCRIPTION
[CIUG-771](https://coveord.atlassian.net/jira/software/c/projects/CIUG/boards/1054?selectedIssue=CIUG-771)

Add a param `enrichWithFields` 

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[CIUG-771]: https://coveord.atlassian.net/browse/CIUG-771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ