### PR TITLE
Add new GetObjectTypes call to Platform Client

### DIFF
--- a/src/resources/Catalogs/CatalogContent.ts
+++ b/src/resources/Catalogs/CatalogContent.ts
@@ -1,13 +1,23 @@
 import API from '../../APICore.js';
 import Resource from '../Resource.js';
-import {CatalogMetadata, CatalogMetadataName} from './CatalogInterfaces.js';
+import {CatalogMetadata, CatalogMetadataName, CatalogObjectType} from './CatalogInterfaces.js';
 
 export type ObjectType = {
     objectType: string;
 };
 
+export type Version = {
+    version: number;
+};
+
 export default class CatalogContent extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/catalogcontent/source`;
+
+    getObjectTypeV2(sourceId: string, version: Version) {
+        return this.api.get<CatalogObjectType>(
+            this.buildPath(`${CatalogContent.baseUrl}/${sourceId}/objecttypes`, version),
+        );
+    }
 
     getObjectTypes(sourceId: string) {
         return this.api.get<string[]>(`${CatalogContent.baseUrl}/${sourceId}/objecttypes`);

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -431,6 +431,17 @@ export interface CatalogFieldStatsOptions {
     forceRefresh?: boolean;
 }
 
+export interface CatalogObjectType {
+    /**
+     * If catalog content exist in source
+     */
+    hasCatalogContent: boolean;
+    /**
+     * Object type values seen on catalog content
+     */
+    objectTypeValues: string[];
+}
+
 export interface CatalogMetadata {
     /**
      * Metadata seen on catalog documents with a sample of values.

--- a/src/resources/Catalogs/tests/CatalogContent.spec.ts
+++ b/src/resources/Catalogs/tests/CatalogContent.spec.ts
@@ -18,6 +18,20 @@ describe('CatalogContent', () => {
         metadata = new CatalogContent(api, serverlessApi);
     });
 
+    describe('getObjectTypeV2', () => {
+        it('should make a GET call to the specific CatalogContent url', () => {
+            const defaultOptions: queryString.StringifyOptions = {skipEmptyString: true, skipNull: true, sort: false};
+            const sourceId = 'McDonald';
+            const version = {version: 2};
+
+            metadata.getObjectTypeV2(sourceId, version);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${baseUrl}/${sourceId}/objecttypes?${queryString.stringify(version, {...defaultOptions})}`,
+            );
+        });
+    });
+
     describe('getObjectTypes', () => {
         it('should make a GET call to the specific CatalogContent url', () => {
             const sourceId = 'McDonald';


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

Goal: Inform users that “ObjectType” is needed, and not found, on a catalog that’s been indexed at least once through Tailgate.

The new GetObjectTypes call, added to the Catalog Content API in https://github.com/coveo-platform/tailgateservice/pull/315, should be added to the platform client so that the called used in the Admin UI is replaced.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
