### PR TITLE
chore: use merge queue to validate commit message

### DIFF
--- a/.github/actions/merge-commit/action.yml
+++ b/.github/actions/merge-commit/action.yml
@@ -1,0 +1,7 @@
+name: Check merge commit
+description: Ensure that the merge commit message is conventional
+runs:
+  using: composite
+  steps:
+    - run: npx commitlint --last --verbose
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     push:
         branches:
             - 'main'
+    merge_group:
 jobs:
     CI:
         runs-on: ubuntu-latest
@@ -17,6 +18,9 @@ jobs:
               uses: ./.github/actions/setup
             - name: Check lockfiles
               uses: ./.github/actions/lockfiles
+            - name: Check merge commit
+              if: github.event_name == 'merge_group'
+              uses: ./.github/actions/merge-commit
             - name: Tests
               run: npm test
             - name: Build


### PR DESCRIPTION
This PR is a shot in the dark, no idea if it'll actually work, but I think we can leverage some special behavior from the merge queue to actually "see" the merge commit before it reaches master, and validate it.
