### PR TITLE
feat(pipelines): add new interface for get single pipeline

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,5 +14,5 @@ jobs:
         with:
             public: true
             distributed: true
-            base-ref: 'main'
-            head-ref: ${{ github.ref_name }}
+            base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
+            head-ref: ${{ github.event.pull_request.head.sha || github.ref_name }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,5 +14,5 @@ jobs:
         with:
             public: true
             distributed: true
-            base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
+            base-ref: ${{ github.event.pull_request.base.sha || 'master' }}
             head-ref: ${{ github.event.pull_request.head.sha || github.ref_name }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,4 +15,4 @@ jobs:
             public: true
             distributed: true
             base-ref: 'main'
-            head-ref: ${{ github.ref }}
+            head-ref: ${{ github.ref_name }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,3 +13,5 @@ jobs:
         with:
             public: true
             distributed: true
+            base-ref: 'main'
+            head-ref: ${{ github.ref }}

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -433,9 +433,9 @@ export interface CatalogFieldStatsOptions {
 
 export interface CatalogObjectType {
     /**
-     * If catalog content exist in source
+     * If catalog source has indexed content
      */
-    hasCatalogContent: boolean;
+    hasIndexedCatalogContent: boolean;
     /**
      * Object type values seen on catalog content
      */

--- a/src/resources/Pipelines/Pipelines.ts
+++ b/src/resources/Pipelines/Pipelines.ts
@@ -8,6 +8,7 @@ import {
     ListPipelinesOptions,
     ListPipelinesReturnVariant,
     NewPipelineModel,
+    PipelineDetailedModel,
     PipelineModel,
     UpdatePipelineModel,
 } from './PipelinesInterfaces.js';
@@ -47,7 +48,7 @@ export default class Pipelines extends Resource {
     }
 
     get(pipelineId: string) {
-        return this.api.get<PipelineModel>(
+        return this.api.get<PipelineDetailedModel>(
             this.buildPath(`${Pipelines.searchUrlVersion1}/${pipelineId}`, {
                 organizationId: this.api.organizationId,
             }),

--- a/src/resources/Pipelines/PipelinesInterfaces.ts
+++ b/src/resources/Pipelines/PipelinesInterfaces.ts
@@ -171,6 +171,17 @@ export interface PipelineModel extends PipelineShared {
     };
 }
 
+export interface PipelineDetailedModel extends PipelineModel {
+    /**
+     * The unique identifier of query pipeline A in the A/B test.
+     *
+     * See also the splitTestName, splitTestRatio, and splitTestEnabled properties
+     *
+     * @example: '22a3860e-fa6f-4e64-a9f1-ef738af0786e'
+     */
+    splitTestOriginalPipeline?: string;
+}
+
 export interface NewPipelineModel extends PipelineShared, GranularResource {}
 export interface UpdatePipelineModel extends PipelineModel, GranularResource {}
 


### PR DESCRIPTION
### Description

Add new interface for response object of the `/rest/search/v1/admin/pipelines/{pipelineId}` endpoint since a new property was added in the response of that endpoint specifically.

See for yourself in [Swagger](https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20API#/Pipelines/getQueryPipelineV1). 📖 

<img width="978" alt="Screenshot 2024-04-26 at 4 31 48 PM" src="https://github.com/coveo/platform-client/assets/133259861/17fd8853-4928-41b6-99f8-8e3c9dfa8f4d"> 

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
