### PR TITLE
chore(ci): workaround for CodeQL in merge queues

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -136,6 +136,7 @@ jobs:
                   ')
                   conclusion=$(echo $response | jq -r '.data.repository.pullRequest.commits.nodes[0].commit.checkSuites.nodes[0].checkRuns.nodes[0].conclusion')
                     if [ "$conclusion" != "SUCCESS" ]; then
+                      echo "$conclusion"
                       echo "CodeQL check failed"
                       exit 1
                     fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,85 +9,133 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
-  merge_group:
-  schedule:
-    - cron: '21 1 * * 6'
+    push:
+        branches: ['master']
+    pull_request:
+        branches: ['master']
+    merge_group:
+    schedule:
+        - cron: '21 1 * * 6'
 
 jobs:
-  analyze:
-    name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
-    permissions:
-      # required for all workflows
-      security-events: write
+    analyze:
+        name: Analyze (${{ matrix.language }})
+        # Runner size impacts CodeQL analysis time. To learn more, please see:
+        #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+        #   - https://gh.io/supported-runners-and-hardware-resources
+        #   - https://gh.io/using-larger-runners (GitHub.com only)
+        # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+        runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+        timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+        permissions:
+            # required for all workflows
+            security-events: write
 
-      # required to fetch internal or private CodeQL packs
-      packages: read
+            # required to fetch internal or private CodeQL packs
+            packages: read
 
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
+            # only required for workflows in private repositories
+            actions: read
+            contents: read
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - language: javascript-typescript
-          build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - language: javascript-typescript
+                      build-mode: none
+                # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+                # Use `c-cpp` to analyze code written in C, C++ or both
+                # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+                # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+                # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+                # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+                # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+                # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+            # Initializes the CodeQL tools for scanning.
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                  languages: ${{ matrix.language }}
+                  build-mode: ${{ matrix.build-mode }}
+                  # If you wish to specify custom queries, you can do so here or in a config file.
+                  # By default, queries listed here will override any specified in a config file.
+                  # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+                  # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+                  # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+            # If the analyze step fails for one of the languages you are analyzing with
+            # "We were unable to automatically build your code", modify the matrix above
+            # to set the build mode to "manual" for that language. Then modify this step
+            # to build your code.
+            # ℹ️ Command-line programs to run using the OS shell.
+            # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+            - if: matrix.build-mode == 'manual'
+              run: |
+                  echo 'If you are using a "manual" build mode for one or more of the' \
+                    'languages you are analyzing, replace this with the commands to build' \
+                    'your code, for example:'
+                  echo '  make bootstrap'
+                  echo '  make release'
+                  exit 1
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v3
+              with:
+                  category: '/language:${{matrix.language}}'
+
+    # The CodeQL action status is not reported in merge queues. See https://github.com/github/codeql-action/issues/1537.
+    # This is a workaround to check the status of the CodeQL analysis in the PR but not in the merge queue. See https://github.com/orgs/community/discussions/46757#discussioncomment-7768838
+    check_codeql_status:
+        name: Check CodeQL Status
+        needs: analyze
+        permissions:
+            contents: read
+            checks: read
+            pull-requests: read
+        runs-on: ubuntu-latest
+        if: ${{ github.event_name == 'pull_request' }}
+        steps:
+            - name: Authenticate gh CLI
+              run: |
+                  gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+            - name: Check CodeQL Status
+              run: |
+                  response=$(gh api graphql -f query='
+                    {
+                      repository(owner: "${{ github.event.repository.owner.login }}", name: "${{ github.event.repository.name }}") {
+                        pullRequest(number: ${{ github.event.pull_request.number }}) {
+                          commits(last: 1) {
+                            nodes {
+                              commit {
+                                checkSuites(first: 1, filterBy: {checkName: "CodeQL"}) {
+                                  nodes {
+                                    checkRuns(first: 1) {
+                                      nodes {
+                                        name
+                                        status
+                                        conclusion
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ')
+                  conclusion=$(echo $response | jq -r '.data.repository.pullRequest.commits.nodes[0].commit.checkSuites.nodes[0].checkRuns.nodes[0].conclusion')
+                    if [ "$conclusion" != "SUCCESS" ]; then
+                      echo "CodeQL check failed"
+                      exit 1
+                    fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -136,7 +136,7 @@ jobs:
                   ')
                   conclusion=$(echo $response | jq -r '.data.repository.pullRequest.commits.nodes[0].commit.checkSuites.nodes[0].checkRuns.nodes[0].conclusion')
                     if [ "$conclusion" != "SUCCESS" ]; then
-                      echo "$conclusion"
+                      echo "$response"
                       echo "CodeQL check failed"
                       exit 1
                     fi


### PR DESCRIPTION
The CodeQL action doesn't seem to support merge queues yet. See this issue: https://github.com/github/codeql-action/issues/1537

See this discussion for the workaround: https://github.com/orgs/community/discussions/46757#discussioncomment-7768838

Basically we make sure the CodeQL status check is run the PR only.
