### PR TITLE
docs(caseclassificationconfiguration): add deprecation warnings

### DIFF
--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfiguration.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfiguration.ts
@@ -15,6 +15,9 @@ export default class CaseClassificationConfiguration extends Resource {
     static fieldsUrl = `${CaseClassificationConfiguration.baseUrl}/fields`;
     static previewUrl = `${CaseClassificationConfiguration.baseUrl}/preview`;
 
+    /**
+     * @deprecated create(configModel: CaseClassificationConfigurationModel) is kept for backward compatibility. You should now use MachineLearning `register(registration: RegistrationModel)` instead.
+     */
     create(configModel: New<CaseClassificationConfigurationModel, 'modelId'>) {
         return this.api.post<CaseClassificationConfigurationModel>(
             CaseClassificationConfiguration.modelUrl,
@@ -22,16 +25,25 @@ export default class CaseClassificationConfiguration extends Resource {
         );
     }
 
+    /**
+     * @deprecated delete(modelId: string) is kept for backward compatibility. You should now use Models `delete(modelId: string)` instead.
+     */
     delete(modelId: string) {
         return this.api.delete(`${CaseClassificationConfiguration.modelUrl}/${modelId}`);
     }
 
+    /**
+     * @deprecated get(modelId: string) is kept for backward compatibility. You should now use Models `get(modelId: string)` instead.
+     */
     get(modelId: string) {
         return this.api.get<CaseClassificationConfigurationModel>(
             `${CaseClassificationConfiguration.modelUrl}/${modelId}`,
         );
     }
 
+    /**
+     * @deprecated update(configModel: CaseClassificationConfigurationModel) is kept for backward compatibility. You should now use Models `update(modelId: string, update: RegistrationModel)` instead.
+     */
     update(configModel: CaseClassificationConfigurationModel) {
         return this.api.put<CaseClassificationConfigurationModel>(
             `${CaseClassificationConfiguration.modelUrl}/${configModel.modelId}`,


### PR DESCRIPTION
The following endpoints : Create, Delete, Get, Update
Are no longer to be used through the case classification API. 

A PR has been merged and will be shipped before this one (Opening this PR a bit early so that you guys can review). The PR adds the deprecation warnings on swagger https://github.com/coveo-platform/ml-config-service/pull/2090

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
