### PR TITLE
feat(caseclassificationconfiguration): add new endpoints for document…

### DIFF
--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfiguration.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfiguration.ts
@@ -7,12 +7,18 @@ import {
     CaseClassificationContentFieldsParams,
     CaseClassificationDocumentGroupPreview,
     CaseClassificationDocumentGroupPreviewParams,
+    CaseClassificationFieldCountParams,
+    FieldDocumentCount,
+    FieldValueCount,
 } from './CaseClassificationConfigurationInterfaces.js';
 
 export default class CaseClassificationConfiguration extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/caseclassif`;
     static modelUrl = `${CaseClassificationConfiguration.baseUrl}/model`;
     static fieldsUrl = `${CaseClassificationConfiguration.baseUrl}/fields`;
+    static fieldDocumentCountUrl = `${CaseClassificationConfiguration.baseUrl}/fields/{fieldName}/documentCount`;
+    static fieldValueCountUrl = `${CaseClassificationConfiguration.baseUrl}/fields/{fieldName}/valueCount`;
+
     static previewUrl = `${CaseClassificationConfiguration.baseUrl}/preview`;
 
     /**
@@ -60,5 +66,13 @@ export default class CaseClassificationConfiguration extends Resource {
             CaseClassificationConfiguration.previewUrl,
             params,
         );
+    }
+
+    documentCount(params: CaseClassificationFieldCountParams) {
+        return this.api.post<FieldDocumentCount>(CaseClassificationConfiguration.fieldDocumentCountUrl, params);
+    }
+
+    valueCount(params: CaseClassificationFieldCountParams) {
+        return this.api.post<FieldValueCount>(CaseClassificationConfiguration.fieldValueCountUrl, params);
     }
 }

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
@@ -49,7 +49,7 @@ export interface CaseClassificationConfigurationModel {
      */
     modelDisplayName: string;
     /**
-     * The names of the sources containing the cases to use for model building.
+     * The names of the sources that contain the cases that the model will use.
      */
     sources: string[];
     /**
@@ -62,8 +62,7 @@ export interface CaseClassificationConfigurationModel {
      */
     caseIdField: string;
     /**
-     * The time period for which to extract cases for model building.
-     * Must contain an export period or a start time and end time.
+     * The case creation date range for the cases the model will use.
      */
     caseExtractionPeriod?: ExtractionPeriod;
     /**
@@ -77,7 +76,7 @@ export interface CaseClassificationConfigurationModel {
      */
     fieldsToPredict: string[];
     /**
-     * The field value to use as language.
+     * The name of the field that contains the value to use as the language.
      */
     languageField?: string;
 }
@@ -93,11 +92,11 @@ export interface CaseClassificationDocumentGroupPreviewParams {
      */
     caseFilterConditions: FilterConditions[];
     /**
-     * The field value to use as language.
+     * The name of the field that contains the value to use as the language.
      */
     languageField: string;
     /**
-     * The names of the sources containing the cases to use for model building.
+     * The names of the sources that contain the cases that the model will use.
      */
     sources: string[];
 }
@@ -131,8 +130,7 @@ export interface CaseClassificationDocumentGroupPreview {
 
 export interface CaseClassificationContentFieldsParams {
     /**
-     * The time period for which to extract cases for model building.
-     * Must contain an export period or a start time and end time.
+     * The case creation date range for the cases the model will use.
      */
     caseExtractionPeriod: ExtractionPeriod;
     /**
@@ -144,7 +142,7 @@ export interface CaseClassificationContentFieldsParams {
      */
     languageField: string;
     /**
-     * The names of the sources containing the cases to use for model building.
+     * The names of the sources that contain the cases that the model will use.
      */
     sources: string[];
 }
@@ -156,4 +154,72 @@ export interface CaseClassificationContentField {
 export interface CaseClassificationContentFields {
     fields: CaseClassificationContentField[];
     query: string;
+}
+
+interface CaseClassificationFieldCountAdvancedMode {
+    /**
+     * The query to use when building the model.
+     */
+    advancedQuery: string;
+    /**
+     * The names of the sources that contain the cases that the model will use.
+     */
+    sources?: never;
+    /**
+     * An array of filtering conditions.
+     */
+    filterConditions?: never;
+    /**
+     * The name of the field that contains the value to use as the language.
+     */
+    languageField?: never;
+    /**
+     * The case creation date range for the cases the model will use.
+     */
+    caseExtractionPeriod?: never;
+}
+
+interface CaseClassificationFieldCountStandardMode {
+    /**
+     * The names of the sources that contain the cases that the model will use.
+     */
+    sources: string[];
+    /**
+     * An array of filtering conditions.
+     */
+    filterConditions?: FilterConditions[];
+    /**
+     * The name of the field that contains the value to use as the language.
+     */
+    languageField: string;
+    /**
+     * The case creation date range for the cases the model will use.
+     */
+    caseExtractionPeriod: ExtractionPeriod;
+    /**
+     * The query to use when building the model.
+     */
+    advancedQuery?: never;
+}
+
+export type CaseClassificationFieldCountParams =
+    | CaseClassificationFieldCountAdvancedMode
+    | CaseClassificationFieldCountStandardMode;
+
+export interface FieldValueCount {
+    /**
+     * The count of values matching a field.
+     */
+    valueCount: number;
+    /**
+     * Indicates the presence of more values than the one returned in the count.
+     */
+    areMoreValuesAvailable: boolean;
+}
+
+export interface FieldDocumentCount {
+    /**
+     * The count of items matching a field.
+     */
+    documentCount: number;
 }

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
@@ -165,4 +165,68 @@ describe('CaseClassificationConfiguration', () => {
             expect(api.post).toHaveBeenCalledWith(CaseClassificationConfiguration.previewUrl, params);
         });
     });
+
+    describe('documentCount', () => {
+        modelConfigs.forEach(() => {
+            it('should make a POST call to the specific Case Classification Configuration url with an advancedQuery', () => {
+                const params = {advancedQuery: "@source='some source'"};
+
+                ccConfig.documentCount(params);
+
+                expect(api.post).toHaveBeenCalledTimes(1);
+                expect(api.post).toHaveBeenCalledWith(
+                    `${CaseClassificationConfiguration.baseUrl}/fields/{fieldName}/documentCount`,
+                    params,
+                );
+            });
+
+            it('should make a POST call to the specific Case Classification Configuration url with standard params', () => {
+                const params = {
+                    sources: ['some source'],
+                    languageField: 'language',
+                    caseExtractionPeriod: {exportPeriod: 'P6M', dateField: 'date'},
+                };
+
+                ccConfig.documentCount(params);
+
+                expect(api.post).toHaveBeenCalledTimes(1);
+                expect(api.post).toHaveBeenCalledWith(
+                    `${CaseClassificationConfiguration.baseUrl}/fields/{fieldName}/documentCount`,
+                    params,
+                );
+            });
+        });
+    });
+
+    describe('valueCount', () => {
+        modelConfigs.forEach(() => {
+            it('should make a POST call to the specific Case Classification Configuration url with an advancedQuery', () => {
+                const params = {advancedQuery: "@source='some source'"};
+
+                ccConfig.valueCount(params);
+
+                expect(api.post).toHaveBeenCalledTimes(1);
+                expect(api.post).toHaveBeenCalledWith(
+                    `${CaseClassificationConfiguration.baseUrl}/fields/{fieldName}/valueCount`,
+                    params,
+                );
+            });
+
+            it('should make a POST call to the specific Case Classification Configuration url with standard params', () => {
+                const params = {
+                    sources: ['some source'],
+                    languageField: 'language',
+                    caseExtractionPeriod: {exportPeriod: 'P6M', dateField: 'date'},
+                };
+
+                ccConfig.valueCount(params);
+
+                expect(api.post).toHaveBeenCalledTimes(1);
+                expect(api.post).toHaveBeenCalledWith(
+                    `${CaseClassificationConfiguration.baseUrl}/fields/{fieldName}/valueCount`,
+                    params,
+                );
+            });
+        });
+    });
 });


### PR DESCRIPTION
Add new endpoints for `valueCount` and `documentCount`

- Both the new endpoints accept an advancedQuery or the properties set by a 'standard mode configuration'

[MLCONFIG-188] <-- API info in the ticket

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[MLCONFIG-188]: https://coveord.atlassian.net/browse/MLCONFIG-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ