### PR TITLE
feat: remove version number in get objecttype call

### DIFF
--- a/src/resources/Catalogs/CatalogContent.ts
+++ b/src/resources/Catalogs/CatalogContent.ts
@@ -6,21 +6,11 @@ export type ObjectType = {
     objectType: string;
 };
 
-export type Version = {
-    version: number;
-};
-
 export default class CatalogContent extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/catalogcontent/source`;
 
-    getObjectTypeV2(sourceId: string, version: Version) {
-        return this.api.get<CatalogObjectType>(
-            this.buildPath(`${CatalogContent.baseUrl}/${sourceId}/objecttypes`, version),
-        );
-    }
-
-    getObjectTypes(sourceId: string) {
-        return this.api.get<string[]>(`${CatalogContent.baseUrl}/${sourceId}/objecttypes`);
+    getObjectTypeV2(sourceId: string) {
+        return this.api.get<CatalogObjectType>(this.buildPath(`${CatalogContent.baseUrl}/${sourceId}/objecttypes`));
     }
 
     getMetadataValues(sourceId: string, objectType: ObjectType) {

--- a/src/resources/Catalogs/CatalogContent.ts
+++ b/src/resources/Catalogs/CatalogContent.ts
@@ -9,8 +9,8 @@ export type ObjectType = {
 export default class CatalogContent extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/catalogcontent/source`;
 
-    getObjectTypeV2(sourceId: string) {
-        return this.api.get<CatalogObjectType>(this.buildPath(`${CatalogContent.baseUrl}/${sourceId}/objecttypes`));
+    getObjectTypes(sourceId: string) {
+        return this.api.get<CatalogObjectType>(`${CatalogContent.baseUrl}/${sourceId}/objecttypes`);
     }
 
     getMetadataValues(sourceId: string, objectType: ObjectType) {

--- a/src/resources/Catalogs/tests/CatalogContent.spec.ts
+++ b/src/resources/Catalogs/tests/CatalogContent.spec.ts
@@ -20,23 +20,9 @@ describe('CatalogContent', () => {
 
     describe('getObjectTypeV2', () => {
         it('should make a GET call to the specific CatalogContent url', () => {
-            const defaultOptions: queryString.StringifyOptions = {skipEmptyString: true, skipNull: true, sort: false};
-            const sourceId = 'McDonald';
-            const version = {version: 2};
-
-            metadata.getObjectTypeV2(sourceId, version);
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(
-                `${baseUrl}/${sourceId}/objecttypes?${queryString.stringify(version, {...defaultOptions})}`,
-            );
-        });
-    });
-
-    describe('getObjectTypes', () => {
-        it('should make a GET call to the specific CatalogContent url', () => {
             const sourceId = 'McDonald';
 
-            metadata.getObjectTypes(sourceId);
+            metadata.getObjectTypeV2(sourceId);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${baseUrl}/${sourceId}/objecttypes`);
         });

--- a/src/resources/Catalogs/tests/CatalogContent.spec.ts
+++ b/src/resources/Catalogs/tests/CatalogContent.spec.ts
@@ -18,11 +18,11 @@ describe('CatalogContent', () => {
         metadata = new CatalogContent(api, serverlessApi);
     });
 
-    describe('getObjectTypeV2', () => {
+    describe('getObjectTypes', () => {
         it('should make a GET call to the specific CatalogContent url', () => {
             const sourceId = 'McDonald';
 
-            metadata.getObjectTypeV2(sourceId);
+            metadata.getObjectTypes(sourceId);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${baseUrl}/${sourceId}/objecttypes`);
         });


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

removed version number in catalog content api call
since the old call is deprecated, and the new call is already being used in prod, we longer need a version number to make the difference

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
