### PR TITLE
fix(project): modify endpoint return type

### DIFF
--- a/src/resources/Projects/Project.ts
+++ b/src/resources/Projects/Project.ts
@@ -98,13 +98,13 @@ export default class Project extends Resource {
      *
      * @param {ProjectResourceType} resourceType
      * @param {string[]} resourceIds
-     * @returns {Promise<ListAssociatedProjectsModel>} List of project IDs associated to the provided resource IDs.
+     * @returns {Promise<ListAssociatedProjectsModel[]>} List of project IDs associated to the provided resource IDs.
      */
     listAssociatedProjects(
         resourceType: ProjectResourceType,
         resourceIds: string[],
-    ): Promise<ListAssociatedProjectsModel> {
-        return this.api.post<ListAssociatedProjectsModel>(
+    ): Promise<ListAssociatedProjectsModel[]> {
+        return this.api.post<ListAssociatedProjectsModel[]>(
             this.buildPath(`${Project.baseUrl}/resources/ids`, {resourceType}),
             resourceIds,
         );


### PR DESCRIPTION
* Made a mistake with the endpoint's return type when merging the original [PR](https://github.com/coveo/platform-client/pull/824);
* To avoid forgetting anything, I've tested this endpoint with the feature that I'm currently developing.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
