### PR TITLE
fix: correct the call for fields in advanced mode

### DIFF
--- a/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/CaseClassificationConfigurationInterfaces.ts
@@ -128,7 +128,30 @@ export interface CaseClassificationDocumentGroupPreview {
     numberOfValidDocuments: number;
 }
 
-export interface CaseClassificationContentFieldsParams {
+export interface CaseClassificationContentFieldsAdvancedMode {
+    /**
+     * The query to use when building the model.
+     */
+    advancedQuery: string;
+    /**
+     * The case creation date range for the cases the model will use.
+     */
+    caseExtractionPeriod?: never;
+    /**
+     * An array of filtering conditions.
+     */
+    caseFilterConditions?: never;
+    /**
+     * The field value to use as language.
+     */
+    languageField?: never;
+    /**
+     * The names of the sources that contain the cases that the model will use.
+     */
+    sources?: never;
+}
+
+export interface CaseClassificationContentFieldsStandardMode {
     /**
      * The case creation date range for the cases the model will use.
      */
@@ -145,7 +168,15 @@ export interface CaseClassificationContentFieldsParams {
      * The names of the sources that contain the cases that the model will use.
      */
     sources: string[];
+    /**
+     * The query to use when building the model.
+     */
+    advancedQuery?: never;
 }
+
+export type CaseClassificationContentFieldsParams =
+    | CaseClassificationContentFieldsStandardMode
+    | CaseClassificationContentFieldsAdvancedMode;
 
 export interface CaseClassificationContentField {
     name: string;

--- a/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
+++ b/src/resources/MachineLearning/CaseClassificationConfiguration/tests/CaseClassificationConfiguration.spec.ts
@@ -140,6 +140,15 @@ describe('CaseClassificationConfiguration', () => {
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(CaseClassificationConfiguration.fieldsUrl, params);
         });
+
+        it('should make a POST call to retrieve valid content field candidates for the Case Classification model configuration with an advancedQuery', () => {
+            const params = {advancedQuery: "@source='some source'"};
+
+            ccConfig.fields(params);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(CaseClassificationConfiguration.fieldsUrl, params);
+        });
     });
 
     describe('preview', () => {


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->
The [call](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Machine%20Learning%20Configuration#/Case%20Classification%20Configuration/rest_organizations_paramId_machinelearning_configuration_caseclassif_fields_post) to receive the fields can be called in advanced mode with only `advancedQuery` as a parameter


### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
