### PR TITLE
feat(project): add new endpoint

### DIFF
--- a/src/resources/Projects/Project.ts
+++ b/src/resources/Projects/Project.ts
@@ -8,6 +8,7 @@ import {
     BaseProjectModel,
     ProjectResourceType,
     ListAssociatedProjectsModel,
+    UpdatedProjectResourceAssociationsModel,
 } from './ProjectInterfaces.js';
 
 export default class Project extends Resource {
@@ -107,6 +108,23 @@ export default class Project extends Resource {
         return this.api.post<ListAssociatedProjectsModel[]>(
             this.buildPath(`${Project.baseUrl}/resources/ids`, {resourceType}),
             resourceIds,
+        );
+    }
+
+    /**
+     * Modifies project-resource associations and returns a list of updated projects.
+     *
+     * @param {ProjectResourceType} resourceType
+     * @param {UpdatedProjectResourceAssociationsModel} updatedProjectResourceAssociation
+     * @returns {Promise<ProjectModel[]>} Returns a list of updated projects.
+     */
+    updateProjectResourceAssociation(
+        resourceType: ProjectResourceType,
+        updatedProjectResourceAssociation: UpdatedProjectResourceAssociationsModel,
+    ): Promise<ProjectModel[]> {
+        return this.api.put<ProjectModel[]>(
+            this.buildPath(`${Project.baseUrl}/resources/modify/${resourceType}`),
+            updatedProjectResourceAssociation,
         );
     }
 }

--- a/src/resources/Projects/ProjectInterfaces.ts
+++ b/src/resources/Projects/ProjectInterfaces.ts
@@ -138,3 +138,25 @@ export interface ListAssociatedProjectsModel {
      */
     projectIds: string[];
 }
+
+export interface UpdatedProjectAssociationsModel {
+    /**
+     * IDs of projects that are to be updated
+     */
+    projectIds: string[];
+    /**
+     * IDs of resources whose association with the precised project IDs is to be updated
+     */
+    resourceIds: string[];
+}
+
+export interface UpdatedProjectResourceAssociationsModel {
+    /**
+     * Project-resource associations to be added
+     */
+    additions: UpdatedProjectAssociationsModel[];
+    /**
+     * Project-resource associations to be removed
+     */
+    removals: UpdatedProjectAssociationsModel[];
+}

--- a/src/resources/Projects/tests/Project.spec.ts
+++ b/src/resources/Projects/tests/Project.spec.ts
@@ -1,6 +1,11 @@
 import API from '../../../APICore.js';
 import Project from '../Project.js';
-import {BaseProjectModel, ProjectModel, ProjectType} from '../ProjectInterfaces.js';
+import {
+    BaseProjectModel,
+    ProjectModel,
+    ProjectType,
+    UpdatedProjectResourceAssociationsModel,
+} from '../ProjectInterfaces.js';
 
 jest.mock('../../../APICore.js');
 
@@ -129,6 +134,26 @@ describe('Project', () => {
             expect(api.post).toHaveBeenCalledWith(`${Project.baseUrl}/resources/ids?resourceType=SOURCE`, [
                 randomSourceId,
             ]);
+        });
+    });
+
+    describe('updateProjectResourceAssociation', () => {
+        it('should make a PUT call to the correct Project URL', () => {
+            const randomProjectResourceAssociation: UpdatedProjectResourceAssociationsModel = {
+                additions: [
+                    {
+                        projectIds: ['random-project-id'],
+                        resourceIds: ['random-source-id'],
+                    },
+                ],
+                removals: [],
+            };
+            project.updateProjectResourceAssociation('SOURCE', randomProjectResourceAssociation);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `${Project.baseUrl}/resources/modify/SOURCE`,
+                randomProjectResourceAssociation,
+            );
         });
     });
 });


### PR DESCRIPTION
Added this new [endpoint](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Workspace#/Projects/rest_organizations_paramId_projects_resources_modify_paramId_put)

* This endpoint updates a project's resource associations without having to pass the whole project model;
* It allows us to add /remove specific resources to the precised projects.

**NOTE**: I've also tested this new endpoint with the current feature that I'm implementing.

![image](https://github.com/coveo/platform-client/assets/105073504/c19080d3-7b34-45b4-ae3c-8474ac98af23)


<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
