### PR TITLE
fix(project): modify endpoint body type

### DIFF
--- a/src/resources/Projects/ProjectInterfaces.ts
+++ b/src/resources/Projects/ProjectInterfaces.ts
@@ -154,9 +154,9 @@ export interface UpdatedProjectResourceAssociationsModel {
     /**
      * Project-resource associations to be added
      */
-    additions: UpdatedProjectAssociationsModel[];
+    additions: UpdatedProjectAssociationsModel;
     /**
      * Project-resource associations to be removed
      */
-    removals: UpdatedProjectAssociationsModel[];
+    removals: UpdatedProjectAssociationsModel;
 }

--- a/src/resources/Projects/tests/Project.spec.ts
+++ b/src/resources/Projects/tests/Project.spec.ts
@@ -4,6 +4,7 @@ import {
     BaseProjectModel,
     ProjectModel,
     ProjectType,
+    UpdatedProjectAssociationsModel,
     UpdatedProjectResourceAssociationsModel,
 } from '../ProjectInterfaces.js';
 
@@ -140,13 +141,11 @@ describe('Project', () => {
     describe('updateProjectResourceAssociation', () => {
         it('should make a PUT call to the correct Project URL', () => {
             const randomProjectResourceAssociation: UpdatedProjectResourceAssociationsModel = {
-                additions: [
-                    {
-                        projectIds: ['random-project-id'],
-                        resourceIds: ['random-source-id'],
-                    },
-                ],
-                removals: [],
+                additions: {
+                    projectIds: ['random-project-id'],
+                    resourceIds: ['random-source-id'],
+                },
+                removals: {} as UpdatedProjectAssociationsModel,
             };
             project.updateProjectResourceAssociation('SOURCE', randomProjectResourceAssociation);
             expect(api.put).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
* Modified the body's attributes to accept an object rather than a list of objects.

See [Swagger](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Workspace#/Projects/rest_organizations_paramId_projects_resources_modify_paramId_put) for more details.

<img width="423" alt="image" src="https://github.com/coveo/platform-client/assets/105073504/58914127-5148-45bb-8570-39e63637eff2">

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
