### PR TITLE
fix(project): fix object stringifying

### DIFF
--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -1,4 +1,6 @@
 import API from '../APICore.js';
+import {stringifyNestedObjects} from '../utils/stringifyNestedObjects.js';
+
 import queryString from '#query-string';
 
 const defaultOptions: queryString.StringifyOptions = {skipEmptyString: true, skipNull: true, sort: false};
@@ -19,6 +21,9 @@ class Resource {
         if (!parameters) {
             return '';
         } else {
+            if (typeof parameters === 'object' && !Array.isArray(parameters)) {
+                parameters = stringifyNestedObjects(parameters);
+            }
             const requestURL = queryString.stringify(parameters, {...defaultOptions, ...userOptions});
             return requestURL.length ? `?${requestURL}` : '';
         }

--- a/src/resources/Search/SearchInterfaces.ts
+++ b/src/resources/Search/SearchInterfaces.ts
@@ -204,9 +204,9 @@ export interface RestUserId {
 }
 
 export interface RestCommerceParameters {
-    catalogId: string;
-    filter: string;
-    operation: string;
+    catalogId?: string;
+    filter?: string;
+    operation?: string;
 }
 
 export interface TokenModel {

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -95,11 +95,17 @@ describe('Search', () => {
 
     describe('getFieldValue', () => {
         it('should make a get call to searchAPI correct url with its params to fetch the values of a field', () => {
-            const params = {ignoreAccents: false};
+            const params = {
+                ignoreAccents: false,
+                commerce: {catalogId: 'test-id', filter: 'test-filter', operation: 'test-operation'},
+                organizationId: 'test-org-id',
+            };
             const fieldName = 'author';
             search.getFieldValues(fieldName, params);
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Search.baseUrl}/values?field=author&ignoreAccents=false`);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Search.baseUrl}/values?field=author&ignoreAccents=false&commerce=%7B%22catalogId%22%3A%22test-id%22%2C%22filter%22%3A%22test-filter%22%2C%22operation%22%3A%22test-operation%22%7D&organizationId=test-org-id`,
+            );
         });
     });
 

--- a/src/utils/stringifyNestedObjects.ts
+++ b/src/utils/stringifyNestedObjects.ts
@@ -1,0 +1,9 @@
+export const stringifyNestedObjects = (obj: object): object => {
+    Object.keys(obj).forEach((key) => {
+        const value = obj[key];
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            obj[key] = JSON.stringify(value, null, 0);
+        }
+    });
+    return obj;
+};

--- a/src/utils/tests/stringifyNestedObjects.spec.ts
+++ b/src/utils/tests/stringifyNestedObjects.spec.ts
@@ -1,0 +1,19 @@
+import {stringifyNestedObjects} from '../stringifyNestedObjects.js';
+
+describe('stringifyNestedObjects', () => {
+    it('should stringify a nested object', () => {
+        expect(stringifyNestedObjects({commerce: {catalogId: 'test'}})).toEqual({commerce: '{"catalogId":"test"}'});
+    });
+    it('should not stringify booleans', () => {
+        expect(stringifyNestedObjects({commerce: {catalogId: 'test'}, bool: true})).toEqual({
+            bool: true,
+            commerce: '{"catalogId":"test"}',
+        });
+    });
+    it('should not stringify arrays', () => {
+        expect(stringifyNestedObjects({commerce: {catalogId: 'test'}, arr: ['1', '2']})).toEqual({
+            arr: ['1', '2'],
+            commerce: '{"catalogId":"test"}',
+        });
+    });
+});


### PR DESCRIPTION
- fix handling of parameters objects that include an object - currently those are not being handled - e.g.

`getFieldValues('ec_name', { commerce: { catalogId: 'id' })` get's serialized as:

`/rest/search/v2/values?field=author&commerce=%5Bobject%20Object%5D`

we want to actually pass those nested params.

This falls in line with how the APIs are expecting the params to get serialized.

<img width="839" alt="Screenshot 2024-06-12 at 12 19 42" src="https://github.com/coveo/platform-client/assets/10165959/28e5d7a8-db6b-455c-9e4d-e2f19ba608b2">
