### PR TITLE
fix(success response handler): parse unsafe integers as strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.0-development",
             "license": "Apache-2.0",
             "dependencies": {
+                "core-js": "^3.37.1",
                 "exponential-backoff": "^3.1.0",
                 "query-string-cjs": "npm:query-string@^7.0.0",
                 "query-string-esm": "npm:query-string@^9.0.0"
@@ -4932,6 +4933,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/core-js": {
+            "version": "3.37.1",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+            "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+            "hasInstallScript": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
             }
         },
         "node_modules/core-util-is": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         }
     },
     "dependencies": {
+        "core-js": "^3.37.1",
         "exponential-backoff": "^3.1.0",
         "query-string-cjs": "npm:query-string@^7.0.0",
         "query-string-esm": "npm:query-string@^9.0.0"

--- a/src/handlers/response/ResponseHandlers.ts
+++ b/src/handlers/response/ResponseHandlers.ts
@@ -1,4 +1,4 @@
-// TODO: remove this polyfill when we bump the minimal supported Node.js version to 22
+// TODO CDX-1574: remove this polyfill when we bump the minimal supported Node.js version to 22
 import 'core-js/actual/json/parse.js';
 import {Predicate} from '../../utils/types.js';
 import {ResponseBodyFormat, ResponseHandler} from './ResponseHandlerInterfaces.js';

--- a/src/handlers/response/ResponseHandlers.ts
+++ b/src/handlers/response/ResponseHandlers.ts
@@ -1,3 +1,5 @@
+// TODO: remove this polyfill when we bump the minimal supported Node.js version to 22
+import 'core-js/actual/json/parse.js';
 import {Predicate} from '../../utils/types.js';
 import {ResponseBodyFormat, ResponseHandler} from './ResponseHandlerInterfaces.js';
 
@@ -14,7 +16,23 @@ const noContent: ResponseHandler = {
 
 const success: ResponseHandler = {
     canProcess: isAnyOkStatus,
-    process: async (response, responseBodyFormat = 'json') => response[responseBodyFormat](),
+    process: async (response, responseBodyFormat = 'json') => {
+        if (responseBodyFormat !== 'json') {
+            return response[responseBodyFormat]();
+        }
+        const content = await response.text();
+        return (
+            JSON.parse as (
+                text: string,
+                reviver?: (key: string, value: any, context: {source: any}) => any | undefined,
+            ) => any
+        )(content, (_key, value, context) => {
+            if (typeof value === 'number' && !Number.isSafeInteger(Math.floor(value))) {
+                return context.source;
+            }
+            return value;
+        });
+    },
 };
 
 /**

--- a/src/handlers/response/tests/ResponseHandlers.spec.ts
+++ b/src/handlers/response/tests/ResponseHandlers.spec.ts
@@ -10,11 +10,41 @@ describe('ResponseHandlers', () => {
     });
 
     describe.each([200, 299])('when the response status code is between 200 and 299 (success)', (status) => {
-        it(`${status} returns a promise resolved with the response body in JSON format`, async () => {
-            const data = {someData: 'thank you!'};
-            const okResponse = new Response(JSON.stringify(data), {status});
-            const result = await handleResponse(okResponse);
-            expect(result).toEqual(data);
+        describe('if responseBodyFormat = "json", or by default', () => {
+            it(`${status} returns a promise resolved with the response body in JSON format`, async () => {
+                const data = {someData: 'thank you!'};
+                const okResponse = new Response(JSON.stringify(data), {status});
+                const result = await handleResponse(okResponse);
+                expect(result).toEqual(data);
+            });
+
+            it(`${status} parses unsafe integer as a string`, async () => {
+                const data = '{"unsafeInteger": 9999999999999999}';
+                const okResponse = new Response(data, {status});
+                const result = await handleResponse(okResponse);
+                expect(result).toEqual({unsafeInteger: '9999999999999999'});
+            });
+
+            it(`${status} parses safe integer as an integer`, async () => {
+                const data = '{"safeInteger": 999999999999999}';
+                const okResponse = new Response(data, {status});
+                const result = await handleResponse(okResponse);
+                expect(result).toEqual({safeInteger: 999999999999999});
+            });
+
+            it(`${status} parses float whose integer part is unsafe as a string`, async () => {
+                const data = '{"float": 9999999999999999.9}';
+                const okResponse = new Response(data, {status});
+                const result = await handleResponse(okResponse);
+                expect(result).toEqual({float: '9999999999999999.9'});
+            });
+
+            it(`${status} parses float whose integer part is safe as a number`, async () => {
+                const data = '{"float": 999999999999999.9}';
+                const okResponse = new Response(data, {status});
+                const result = await handleResponse(okResponse);
+                expect(result).toEqual({float: 999999999999999.9});
+            });
         });
 
         it(`${status} returns a promise resolved with the response body in text format if responseBodyFormat = "text"`, async () => {


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

JavaScript will automatically round integers that are outside of its "safe" bounds, i.e., from -(2^53 - 1) to 2^53 - 1, inclusive (±9,007,199,254,740,991). This means we'll lose precision if we convert values beyond those boundaries to integers.

The suggested fix is to return out of bound integers as strings, such that no precision will be lost.

Technically, this means that any number in a successful response body will be typed as a number (if it's safe) or as as string (if it's unsafe).

I decided not to adjust the response body interfaces, because this should happen only in a few exceptional cases (e.g., `rowid` / `sysrowid`, which are returned as very large integers).

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
