### PR TITLE
feat(extensions): add listVersions and getVersion methods

### DIFF
--- a/src/resources/Extensions/Extensions.ts
+++ b/src/resources/Extensions/Extensions.ts
@@ -1,6 +1,12 @@
 import API from '../../APICore.js';
 import Resource from '../Resource.js';
-import {CreateExtension, ExtensionCompileCode, ExtensionCompileResult, ExtensionModel} from './ExtensionsInterfaces.js';
+import {
+    CreateExtension,
+    ExtensionCompileCode,
+    ExtensionCompileResult,
+    ExtensionContentVersionModel,
+    ExtensionModel,
+} from './ExtensionsInterfaces.js';
 
 export default class Extension extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/extensions`;
@@ -31,6 +37,20 @@ export default class Extension extends Resource {
 
     list() {
         return this.api.get<ExtensionModel[]>(Extension.baseUrl);
+    }
+
+    /**
+     * Lists all versions of an [extension](https://docs.coveo.com/en/206/) in a [Coveo Cloud organization](https://docs.coveo.com/en/185/).
+     */
+    listVersions(extensionId: string) {
+        return this.api.get<ExtensionContentVersionModel[]>(`${Extension.baseUrl}/${extensionId}/versions`);
+    }
+
+    /**
+     * Shows a specific version of an [extension](https://docs.coveo.com/en/206/) in a [Coveo Cloud organization](https://docs.coveo.com/en/185/).
+     */
+    getVersion(extensionId: string, versionId: string) {
+        return this.api.get<ExtensionModel>(`${Extension.baseUrl}/${extensionId}/versions/${versionId}`);
     }
 
     /**

--- a/src/resources/Extensions/ExtensionsInterfaces.ts
+++ b/src/resources/Extensions/ExtensionsInterfaces.ts
@@ -93,3 +93,21 @@ export interface ExtensionCompileError {
      */
     type: string;
 }
+
+/**
+ * An [extension](https://docs.coveo.com/en/206/) version.
+ */
+export interface ExtensionContentVersionModel {
+    /**
+     * The date at which the extension version was created (in number of milliseconds since UNIX epoch), i.e., the date of the modification of the extension when this extension version was created.
+     *
+     * @example 1556308241000
+     */
+    lastModified: number;
+    /**
+     * The unique identifier of the extension target version.
+     *
+     * @example hdJSDb4hTkdnsCynNtF.d657FgLSDydcj
+     */
+    id: string;
+}

--- a/src/resources/Extensions/tests/Extensions.spec.ts
+++ b/src/resources/Extensions/tests/Extensions.spec.ts
@@ -105,4 +105,23 @@ describe('Extension', () => {
             expect(api.post).toHaveBeenCalledWith(`${Extension.baseUrl}/test/compile`, testExtensionCode);
         });
     });
+
+    describe('listVersions', () => {
+        it('makes a GET call to the specific extension versions url', () => {
+            const extensionId = '1';
+            extension.listVersions(extensionId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith('/rest/organizations/{organizationName}/extensions/1/versions');
+        });
+    });
+
+    describe('getVersion', () => {
+        it('make a get call to the extension version url', () => {
+            const extensionId = '1';
+            const versionId = 'a';
+            extension.getVersion(extensionId, versionId);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith('/rest/organizations/{organizationName}/extensions/1/versions/a');
+        });
+    });
 });


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->
Adding methods on the Extension resource for the versions API endpoints:
- listVersions: [`/rest/organizations/{organizationId}/extensions/{extensionId}/versions`](https://platform.cloud.coveo.com/docs/?urls.primaryName=Extension#/Indexing%20Pipeline%20Extensions/rest_organizations_paramId_extensions_paramId_versions_get)
- getVersion: [`/rest/organizations/{organizationId}/extensions/{extensionId}/versions/{versionId}`](https://platform.cloud.coveo.com/docs/?urls.primaryName=Extension#/Indexing%20Pipeline%20Extensions/rest_organizations_paramId_extensions_paramId_versions_paramId_get)

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
