### PR TITLE
feat: add new paged metadataNames call

### DIFF
--- a/src/resources/Catalogs/CatalogContent.ts
+++ b/src/resources/Catalogs/CatalogContent.ts
@@ -1,6 +1,12 @@
 import API from '../../APICore.js';
 import Resource from '../Resource.js';
-import {CatalogMetadata, CatalogMetadataName, CatalogObjectType} from './CatalogInterfaces.js';
+import {MetadataPageModel} from '../Sources/index.js';
+import {
+    CatalogMetadata,
+    CatalogMetadataName,
+    CatalogMetadataNameParams,
+    CatalogObjectType,
+} from './CatalogInterfaces.js';
 
 export type ObjectType = {
     objectType: string;
@@ -22,6 +28,12 @@ export default class CatalogContent extends Resource {
     getMetadata(sourceId: string, objectType: ObjectType) {
         return this.api.get<CatalogMetadataName>(
             this.buildPath(`${CatalogContent.baseUrl}/${sourceId}/metadata`, objectType),
+        );
+    }
+
+    getMetadataV2(sourceId: string, params?: CatalogMetadataNameParams) {
+        return this.api.get<MetadataPageModel>(
+            this.buildPath(`${CatalogContent.baseUrl}/${sourceId}/metadata`, params),
         );
     }
 }

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -462,7 +462,7 @@ export interface CatalogMetadataName {
 
 export interface CatalogMetadataNameParams extends Paginated {
     /**
-     * Metadata's object type.
+     * Object type parameter.
      */
     objectType: string;
     /**

--- a/src/resources/Catalogs/CatalogInterfaces.ts
+++ b/src/resources/Catalogs/CatalogInterfaces.ts
@@ -1,3 +1,5 @@
+import {Paginated} from '../BaseInterfaces.js';
+
 export interface CatalogsListOptions {
     /**
      * Filter that will be matched against the catalog name, description and its configuration name.
@@ -456,4 +458,20 @@ export interface CatalogMetadataName {
      * Metadata name seen on catalog documents.
      */
     metadataNames: string[];
+}
+
+export interface CatalogMetadataNameParams extends Paginated {
+    /**
+     * Metadata's object type.
+     */
+    objectType: string;
+    /**
+     * Filters applied to the returned metadata. Only applies to metadata names, not values or origins.
+     */
+    filter?: string;
+
+    /**
+     * Indicate the version of MetadataName call
+     */
+    version?: number;
 }

--- a/src/resources/Catalogs/tests/CatalogContent.spec.ts
+++ b/src/resources/Catalogs/tests/CatalogContent.spec.ts
@@ -55,4 +55,20 @@ describe('CatalogContent', () => {
             );
         });
     });
+
+    describe('getMetadataV2', () => {
+        it('should make a GET call to the specific metadataName url', () => {
+            const defaultOptions: queryString.StringifyOptions = {skipEmptyString: true, skipNull: true, sort: false};
+            const sourceId = 'KFC';
+
+            metadata.getMetadataV2(sourceId, {objectType: 'provigo', filter: 'a', version: 2, page: 0, perPage: 100});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${baseUrl}/${sourceId}/metadata?${queryString.stringify(
+                    {objectType: 'provigo', filter: 'a', version: 2, page: 0, perPage: 100},
+                    {...defaultOptions},
+                )}`,
+            );
+        });
+    });
 });

--- a/src/resources/Catalogs/tests/CatalogContent.spec.ts
+++ b/src/resources/Catalogs/tests/CatalogContent.spec.ts
@@ -1,5 +1,6 @@
 import API from '../../../APICore.js';
 import CatalogContent, {ObjectType} from '../CatalogContent.js';
+import {CatalogMetadataNameParams} from '../CatalogInterfaces.js';
 import queryString from '#query-string';
 
 jest.mock('../../../APICore.js');
@@ -61,13 +62,18 @@ describe('CatalogContent', () => {
             const defaultOptions: queryString.StringifyOptions = {skipEmptyString: true, skipNull: true, sort: false};
             const sourceId = 'KFC';
 
-            metadata.getMetadataV2(sourceId, {objectType: 'provigo', filter: 'a', version: 2, page: 0, perPage: 100});
+            const params: CatalogMetadataNameParams = {
+                objectType: 'provigo',
+                filter: 'a',
+                version: 2,
+                page: 0,
+                perPage: 100,
+            };
+
+            metadata.getMetadataV2(sourceId, params);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `${baseUrl}/${sourceId}/metadata?${queryString.stringify(
-                    {objectType: 'provigo', filter: 'a', version: 2, page: 0, perPage: 100},
-                    {...defaultOptions},
-                )}`,
+                `${baseUrl}/${sourceId}/metadata?${queryString.stringify(params, {...defaultOptions})}`,
             );
         });
     });


### PR DESCRIPTION
Added new MetadataNames paged call (catalog content)

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
