### PR TITLE
feat(UA-9179): add properties endpoints to client

### DIFF
--- a/src/resources/AnalyticsAdmin/Properties/Properties.ts
+++ b/src/resources/AnalyticsAdmin/Properties/Properties.ts
@@ -1,0 +1,72 @@
+import Resource from '../../Resource.js';
+import API from '../../../APICore.js';
+import {PageModel, Paginated} from '../../BaseInterfaces.js';
+import {PropertiesResponseMessage, PropertyModel} from './PropertiesInterfaces.js';
+
+export default class Properties extends Resource {
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/analyticsadmin/v1`;
+    /**
+     * Build the request path, handling the optional `org` query parameter.
+     *
+     * @param route The path part of the request.
+     * @param queryParams Optional query parameters object.
+     * If this object contains an `org` property, it will override the value from the configuration.
+     * @returns The request path including formatted query parameters.
+     */
+    protected buildPathWithOrg(route: string, queryParams?: any): string {
+        return super.buildPath(route, {org: this.api.organizationId, ...queryParams});
+    }
+
+    /**
+     * List all properties
+     *
+     * @returns Promise<PageModel<PropertyModel>>
+     */
+    listProperties(pagination?: Paginated): Promise<PageModel<PropertyModel>> {
+        return this.api.get<PageModel<PropertyModel>>(
+            this.buildPathWithOrg(`${Properties.baseUrl}/properties/list`, pagination),
+        );
+    }
+
+    /**
+     * Get a property
+     *
+     * @returns Promise<PropertyModel>
+     */
+    getProperty(trackingId: string): Promise<PropertyModel> {
+        return this.api.get<PropertyModel>(this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`));
+    }
+
+    /**
+     * Create a property
+     *
+     * @returns Promise<PropertiesResponseMessage>
+     */
+    createProperty(trackingId: string, displayName: string): Promise<PropertiesResponseMessage> {
+        return this.api.post<PropertiesResponseMessage>(
+            this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`, {displayName}),
+        );
+    }
+
+    /**
+     * Edit a property
+     *
+     * @returns Promise<PropertiesResponseMessage>
+     */
+    updateProperty(trackingId: string, displayName: string): Promise<PropertiesResponseMessage> {
+        return this.api.put<PropertiesResponseMessage>(
+            this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`, {displayName}),
+        );
+    }
+
+    /**
+     * Delete a property
+     *
+     * @returns Promise<PropertiesResponseMessage>
+     */
+    deleteProperty(trackingId: string): Promise<PropertiesResponseMessage> {
+        return this.api.delete<PropertiesResponseMessage>(
+            this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`),
+        );
+    }
+}

--- a/src/resources/AnalyticsAdmin/Properties/Properties.ts
+++ b/src/resources/AnalyticsAdmin/Properties/Properties.ts
@@ -1,7 +1,7 @@
 import Resource from '../../Resource.js';
 import API from '../../../APICore.js';
-import {PageModel, Paginated} from '../../BaseInterfaces.js';
-import {PropertiesResponseMessage, PropertyModel} from './PropertiesInterfaces.js';
+import {PageModel} from '../../BaseInterfaces.js';
+import {ListPropertiesParams, PropertiesResponseMessage, PropertyModel} from './PropertiesInterfaces.js';
 
 export default class Properties extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/analyticsadmin/v1`;
@@ -22,9 +22,9 @@ export default class Properties extends Resource {
      *
      * @returns Promise<PageModel<PropertyModel>>
      */
-    listProperties(pagination?: Paginated): Promise<PageModel<PropertyModel>> {
+    list(params?: ListPropertiesParams): Promise<PageModel<PropertyModel>> {
         return this.api.get<PageModel<PropertyModel>>(
-            this.buildPathWithOrg(`${Properties.baseUrl}/properties/list`, pagination),
+            this.buildPathWithOrg(`${Properties.baseUrl}/properties/list`, params),
         );
     }
 
@@ -33,7 +33,7 @@ export default class Properties extends Resource {
      *
      * @returns Promise<PropertyModel>
      */
-    getProperty(trackingId: string): Promise<PropertyModel> {
+    get(trackingId: string): Promise<PropertyModel> {
         return this.api.get<PropertyModel>(this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`));
     }
 
@@ -42,7 +42,7 @@ export default class Properties extends Resource {
      *
      * @returns Promise<PropertiesResponseMessage>
      */
-    createProperty(trackingId: string, displayName: string): Promise<PropertiesResponseMessage> {
+    create(trackingId: string, displayName: string): Promise<PropertiesResponseMessage> {
         return this.api.post<PropertiesResponseMessage>(
             this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`, {displayName}),
         );
@@ -53,7 +53,7 @@ export default class Properties extends Resource {
      *
      * @returns Promise<PropertiesResponseMessage>
      */
-    updateProperty(trackingId: string, displayName: string): Promise<PropertiesResponseMessage> {
+    update(trackingId: string, displayName: string): Promise<PropertiesResponseMessage> {
         return this.api.put<PropertiesResponseMessage>(
             this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`, {displayName}),
         );
@@ -64,7 +64,7 @@ export default class Properties extends Resource {
      *
      * @returns Promise<PropertiesResponseMessage>
      */
-    deleteProperty(trackingId: string): Promise<PropertiesResponseMessage> {
+    delete(trackingId: string): Promise<PropertiesResponseMessage> {
         return this.api.delete<PropertiesResponseMessage>(
             this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`),
         );

--- a/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
+++ b/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
@@ -1,3 +1,5 @@
+import {Paginated} from '../..';
+
 export interface PropertyModel {
     trackingId: string;
     displayName: string;
@@ -5,4 +7,8 @@ export interface PropertyModel {
 
 export interface PropertiesResponseMessage {
     message: string;
+}
+
+export interface ListPropertiesParams extends Paginated {
+    filter?: string;
 }

--- a/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
+++ b/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
@@ -1,4 +1,4 @@
-import {Paginated} from '../..';
+import {Paginated} from '../../BaseInterfaces';
 
 export interface PropertyModel {
     trackingId: string;

--- a/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
+++ b/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
@@ -1,0 +1,8 @@
+export interface PropertyModel {
+    trackingId: string;
+    displayName: string;
+}
+
+export interface PropertiesResponseMessage {
+    message: string;
+}

--- a/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
+++ b/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
@@ -1,4 +1,4 @@
-import {Paginated} from '../../BaseInterfaces';
+import {Paginated} from '../../BaseInterfaces.js';
 
 export interface PropertyModel {
     trackingId: string;

--- a/src/resources/AnalyticsAdmin/Properties/index.ts
+++ b/src/resources/AnalyticsAdmin/Properties/index.ts
@@ -1,0 +1,2 @@
+export * from './Properties.js';
+export * from './PropertiesInterfaces.js';

--- a/src/resources/AnalyticsAdmin/index.ts
+++ b/src/resources/AnalyticsAdmin/index.ts
@@ -1,0 +1,1 @@
+export * from './Properties/index.js';

--- a/src/resources/AnalyticsAdmin/tests/Properties.spec.ts
+++ b/src/resources/AnalyticsAdmin/tests/Properties.spec.ts
@@ -1,0 +1,71 @@
+import API from '../../../APICore.js';
+import Properties from '../Properties/Properties.js';
+
+jest.mock('../../../APICore.js');
+
+const APIMock: jest.Mock<API> = API as any;
+
+describe('Properties', () => {
+    let properties: Properties;
+    const api = new APIMock() as jest.Mocked<API>;
+    const serverlessApi = new APIMock() as jest.Mocked<API>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        properties = new Properties(api, serverlessApi);
+    });
+
+    describe('listProperties', () => {
+        it('should make a GET call to the Properties list path', () => {
+            properties.listProperties();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/list`);
+        });
+
+        it('should make a GET call to the Properties list path with pagination', () => {
+            properties.listProperties({page: 1, perPage: 2});
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/list?page=1&perPage=2`);
+        });
+    });
+
+    describe('getProperty', () => {
+        it('should make a GET call to the properties path', () => {
+            properties.getProperty('trackingId');
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/trackingId`);
+        });
+    });
+
+    describe('createProperty', () => {
+        it('should make a POST call to the properties path', () => {
+            properties.createProperty('trackingId', 'displayName');
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(
+                `${Properties.baseUrl}/properties/trackingId?displayName=displayName`,
+            );
+        });
+    });
+
+    describe('updateProperty', () => {
+        it('should make a PUT call to the properties path', () => {
+            properties.updateProperty('trackingId', 'displayName');
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/trackingId?displayName=displayName`);
+        });
+    });
+
+    describe('deleteProperty', () => {
+        it('should make a DELETE call to the properties path', () => {
+            properties.deleteProperty('trackingId');
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/trackingId`);
+        });
+    });
+});

--- a/src/resources/AnalyticsAdmin/tests/Properties.spec.ts
+++ b/src/resources/AnalyticsAdmin/tests/Properties.spec.ts
@@ -16,24 +16,31 @@ describe('Properties', () => {
     });
 
     describe('listProperties', () => {
-        it('should make a GET call to the Properties list path', () => {
-            properties.listProperties();
+        it('should make a GET call to the list path', () => {
+            properties.list();
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/list`);
         });
 
-        it('should make a GET call to the Properties list path with pagination', () => {
-            properties.listProperties({page: 1, perPage: 2});
+        it('should make a GET call to the list path with pagination', () => {
+            properties.list({page: 1, perPage: 2});
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/list?page=1&perPage=2`);
+        });
+
+        it('should make a GET call to the list path with filter', () => {
+            properties.list({filter: 'test'});
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/list?filter=test`);
         });
     });
 
     describe('getProperty', () => {
         it('should make a GET call to the properties path', () => {
-            properties.getProperty('trackingId');
+            properties.get('trackingId');
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/trackingId`);
@@ -42,7 +49,7 @@ describe('Properties', () => {
 
     describe('createProperty', () => {
         it('should make a POST call to the properties path', () => {
-            properties.createProperty('trackingId', 'displayName');
+            properties.create('trackingId', 'displayName');
 
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(
@@ -53,7 +60,7 @@ describe('Properties', () => {
 
     describe('updateProperty', () => {
         it('should make a PUT call to the properties path', () => {
-            properties.updateProperty('trackingId', 'displayName');
+            properties.update('trackingId', 'displayName');
 
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/trackingId?displayName=displayName`);
@@ -62,7 +69,7 @@ describe('Properties', () => {
 
     describe('deleteProperty', () => {
         it('should make a DELETE call to the properties path', () => {
-            properties.deleteProperty('trackingId');
+            properties.delete('trackingId');
 
             expect(api.delete).toHaveBeenCalledTimes(1);
             expect(api.delete).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/trackingId`);

--- a/src/resources/PlatformResources.ts
+++ b/src/resources/PlatformResources.ts
@@ -53,6 +53,7 @@ import SearchAnalysis from './SearchAnalysis/SearchAnalysis.js';
 import Project from './Projects/Project.js';
 import Resources from './Resources/Resources.js';
 import CatalogContent from './Catalogs/CatalogContent.js';
+import Properties from './AnalyticsAdmin/Properties/Properties.js';
 
 const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'activity', resource: Activity},
@@ -91,6 +92,7 @@ const resourcesMap: Array<{key: string; resource: typeof Resource}> = [
     {key: 'productListing', resource: ProductListing},
     {key: 'productListingConfiguration', resource: ProductListingConfiguration},
     {key: 'products', resource: Products},
+    {key: 'properties', resource: Properties},
     {key: 'pushApi', resource: PushApi},
     {key: 'resourceSnapshot', resource: ResourceSnapshots},
     {key: 'saml', resource: Saml},
@@ -151,6 +153,7 @@ class PlatformResources {
     productListing: ProductListing;
     productListingConfiguration: ProductListingConfiguration;
     products: Products;
+    properties: Properties;
     pushApi: PushApi;
     resourceSnapshot: ResourceSnapshots;
     saml: Saml;

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -53,3 +53,4 @@ export * from './Sources/index.js';
 export * from './UsageAnalytics/index.js';
 export * from './Users/index.js';
 export * from './Vaults/index.js';
+export * from './AnalyticsAdmin/index.js';


### PR DESCRIPTION
## [UA-9179](https://coveord.atlassian.net/browse/UA-9179)

Added definitions for list, get, create, update and delete properties

### Acceptance Criteria

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[UA-9179]: https://coveord.atlassian.net/browse/UA-9179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ