### PR TITLE
refactor(organization): leverage organization property for servingExperimentsAllowed

### DIFF
--- a/src/resources/Organizations/Organization.ts
+++ b/src/resources/Organizations/Organization.ts
@@ -87,18 +87,9 @@ export default class Organization extends Resource {
         return this.api.get<any>(`${Organization.baseUrl}/${organizationId}/additionalinformation`);
     }
 
-    getExperimentalStatus(organizationId: string = API.orgPlaceholder) {
-        return this.api.get<boolean>(
-            `${Organization.baseUrl}/${organizationId}/machinelearning/orgconfiguration/servingExperimentAllowed`,
-        );
-    }
-
-    updateExperimentalStatus(isAllowed: boolean = false) {
+    updateExperimentalStatus(allowed: boolean = true) {
         return this.api.put<boolean>(
-            this.buildPath(
-                `${Organization.baseUrl}/${API.orgPlaceholder}/machinelearning/orgconfiguration/servingExperimentAllowed`,
-                {isAllowed},
-            ),
+            `${Organization.baseUrl}/${API.orgPlaceholder}/configuration/servingExperiment?allowed=${allowed}`,
         );
     }
 

--- a/src/resources/Organizations/OrganizationInterfaces.ts
+++ b/src/resources/Organizations/OrganizationInterfaces.ts
@@ -115,6 +115,9 @@ export interface OrganizationModel {
     readOnly: boolean;
     license?: LicenseModel;
     organizationStatusModel?: OrganizationsStatusModel;
+    configuration: {
+        servingExperimentAllowed: boolean;
+    };
 }
 
 export type AdditionalOrganizationField = 'status' | 'license' | string;

--- a/src/resources/Organizations/tests/Organizations.spec.ts
+++ b/src/resources/Organizations/tests/Organizations.spec.ts
@@ -251,31 +251,22 @@ describe('Organization', () => {
     });
 
     describe('experimental status', () => {
-        it('should make a GET call to the specific Organization url', () => {
-            const organizationToGetId = 'Organization-to-be-fetched';
-            organization.getExperimentalStatus(organizationToGetId);
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(
-                `${Organization.baseUrl}/${organizationToGetId}/machinelearning/orgconfiguration/servingExperimentAllowed`,
-            );
-        });
-
-        it('should make a PUT call to update experimental status with default false', () => {
+        it('should make a PUT call to update experimental status with default true', () => {
             organization.updateExperimentalStatus();
 
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(
-                `${Organization.baseUrl}/{organizationName}/machinelearning/orgconfiguration/servingExperimentAllowed?isAllowed=${false}`,
+                `${Organization.baseUrl}/{organizationName}/configuration/servingExperiment?allowed=true`,
             );
         });
 
         it('should make a PUT call to update experimental status with passed value', () => {
-            const isAllowed = true;
+            const isAllowed = false;
             organization.updateExperimentalStatus(isAllowed);
 
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(
-                `${Organization.baseUrl}/{organizationName}/machinelearning/orgconfiguration/servingExperimentAllowed?isAllowed=${true}`,
+                `${Organization.baseUrl}/{organizationName}/configuration/servingExperiment?allowed=false`,
             );
         });
     });


### PR DESCRIPTION
The organization has a new property (non-optional) called configuration which contains the boolean property `servingExperiementsAllowed`

The goal is to start leveraging the new property from the org and the new endpoint that was created to update that property.

- Added the property to the organization definition
- (breaking change) Removed the old entrypoint for `getExperimentalStatus`
- Switched over the existing update call to leverage the new endpoint
- Change the default from false to true since we don't promote false.


<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
