### PR TITLE
feat(source): added new attributes for the SourceStatus interface - CTCORE-10153

### DIFF
--- a/src/resources/Sources/SourcesSubInterfaces/Information.ts
+++ b/src/resources/Sources/SourcesSubInterfaces/Information.ts
@@ -32,7 +32,15 @@ export interface NextOperation {
 }
 
 export interface SourceStatus {
+    /**
+     * The unique identifier of the current activity of the source.
+     */
+    activityId?: string;
     allowedOperations?: ActivityOperation[];
+    /**
+     * The date when the activity was created.
+     */
+    createdDate?: number;
     /**
      * The status type including transition statuses.
      */


### PR DESCRIPTION
[The source service](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Source#/Sources/rest_organizations_paramId_sources_get) adds 2 new attributes (activityId & createdDate) to the `sourceStatus` attribute to be aware of current activity.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
