### PR TITLE
feat(statements): add subFeature parameter to ListStatementParams

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -761,6 +761,11 @@ export enum StatementsFeature {
     QueryParamOverride = 'queryParamOverride',
 }
 
+export enum StatementsSubFeature {
+    QueryParamOverride = 'queryParamOverride',
+    QuerySuggestParamOverride = 'querySuggestParamOverride',
+}
+
 export enum ResultRankingsKind {
     featuredResults = 'featured_result',
     rankingExpression = 'ranking_expression',

--- a/src/resources/Pipelines/Statements/StatementsInterfaces.ts
+++ b/src/resources/Pipelines/Statements/StatementsInterfaces.ts
@@ -1,5 +1,5 @@
 import {Paginated} from '../../BaseInterfaces.js';
-import {ListStatementSortBy, StatementsFeature} from '../../Enums.js';
+import {ListStatementSortBy, StatementsFeature, StatementsSubFeature} from '../../Enums.js';
 import {ConditionModel} from '../Conditions/index.js';
 
 export interface StatementModel {
@@ -128,6 +128,10 @@ export interface ListStatementParams extends Paginated {
      * The query pipeline feature to match.
      */
     feature?: StatementsFeature;
+    /**
+     * The query pipeline sub-feature to match.
+     */
+    subFeature?: StatementsSubFeature;
     /**
      * The unique identifier of the target Coveo Cloud organization.
      */


### PR DESCRIPTION
### Description

Add the `subFeature` query parameter to the `ListStatementParams` interface.

That parameter is properly documented in Swagger [here](https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20API#/Statements%20V2/listQueryPipelineStatementsV2). 📖 


### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
