### PR TITLE
feat(usageanalytics): add deleteSnowflakeReaderAccount call to read s…

### DIFF
--- a/src/resources/UsageAnalytics/Read/Snowflake/Snowflake.ts
+++ b/src/resources/UsageAnalytics/Read/Snowflake/Snowflake.ts
@@ -100,4 +100,11 @@ export default class Snowflake extends ReadServiceResource {
     createSnowflakeReaderAccount() {
         return this.api.post<void>(this.buildPathWithOrg(`${Snowflake.baseUrl}/readeraccounts`));
     }
+
+    /**
+     * Delete a reader acocunt.
+     */
+    deleteSnowflakeReaderAccount() {
+        return this.api.delete<void>(this.buildPathWithOrg(`${Snowflake.baseUrl}/readeraccount`));
+    }
 }

--- a/src/resources/UsageAnalytics/Read/Snowflake/tests/Snowflake.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Snowflake/tests/Snowflake.spec.ts
@@ -122,12 +122,21 @@ describe('Snowflake', () => {
         });
     });
 
-    describe('putSnowflakeReaderAccount', () => {
-        it('makes a PUT call to the specific Snowflake url', () => {
+    describe('createSnowflakeReaderAccount', () => {
+        it('makes a POST call to the specific Snowflake url', () => {
             snowflake.createSnowflakeReaderAccount();
 
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${Snowflake.baseUrl}/readeraccounts`);
+        });
+    });
+
+    describe('deleteSnowflakeReaderAccount', () => {
+        it('makes a DELETE call to the specific Snowflake url', () => {
+            snowflake.deleteSnowflakeReaderAccount();
+
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${Snowflake.baseUrl}/readeraccount`);
         });
     });
 });


### PR DESCRIPTION
…ervice

Adds a call to `DELETE /readeraccount` on the Snowflake resource in the usageanalytics read service.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
