### PR TITLE
feat: add exports with a request body [UA-8951]

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -1066,7 +1066,7 @@ export enum ExportStatus {
     expired = 'EXPIRED',
 }
 
-export enum ExportTablesType {
+export enum ExportTables {
     searches = 'SEARCHES',
     clicks = 'CLICKS',
     customEvents = 'CUSTOM_EVENTS',

--- a/src/resources/UsageAnalytics/Read/Exports/Exports.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/Exports.ts
@@ -28,7 +28,7 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
     /**
      * Generate an export.
      *
-     * @param params Parameters to generate the export with.
+     * @param params The parameters to generate the export with.
      */
     generate(params: GenerateExportParams) {
         return this.api.post<ExportModel>(this.buildPathWithOrg(Exports.baseUrl, params));
@@ -37,7 +37,7 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
     /**
      * Generate an export with the parameters in the request body.
      *
-     * @param params Parameters to generate the export with, passed in the request body.
+     * @param params The parameters to generate the export with, passed in the request body.
      */
     generateExportWithBody(params: GenerateExportWithBodyParams, args?: RequestInit) {
         return this.api.post<ExportModel>(this.buildPathWithOrg(`${Exports.baseUrl}/create`), params, args);
@@ -83,7 +83,7 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
     /**
      * Generate a visit export.
      *
-     * @param params Parameters of the visit export.
+     * @param params The parameters to generate the visit export with.
      */
     generateVisitExport(params: GenerateVisitExportParams) {
         return this.api.post<ExportModel>(this.buildPathWithOrg(`${Exports.baseUrl}/visits`, params));
@@ -92,7 +92,7 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
     /**
      * Generate a visit export with the parameters in the request body.
      *
-     * @param params Parameters of the visit export, passed in the request body.
+     * @param params The parameters to generate the visit export with, passed in the request body.
      */
     generateVisitExportWithBody(params: GenerateVisitExportWithBodyParams, args?: RequestInit) {
         return this.api.post<ExportModel>(this.buildPathWithOrg(`${Exports.baseUrl}/visits/create`), params, args);
@@ -101,7 +101,7 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
     /**
      * Estimate the number of rows in a visit export.
      *
-     * @param params Parameters of the visit export to estimate.
+     * @param params The parameters of the visit export to estimate.
      */
     estimateVisitExportRowsCount(params: EstimateVisitExportParams) {
         return this.api.get<ExportEstimateModel>(this.buildPathWithOrg(`${Exports.baseUrl}/visits/estimate`, params));

--- a/src/resources/UsageAnalytics/Read/Exports/Exports.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/Exports.ts
@@ -9,7 +9,9 @@ import {
     ExportModel,
     ExportScheduleModel,
     GenerateExportParams,
+    GenerateExportWithBodyParams,
     GenerateVisitExportParams,
+    GenerateVisitExportWithBodyParams,
     RowLimitModel,
 } from './ExportsInterfaces.js';
 
@@ -28,6 +30,13 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
      */
     generate(params: GenerateExportParams) {
         return this.api.post<ExportModel>(this.buildPathWithOrg(Exports.baseUrl, params));
+    }
+
+    /**
+     * Generate an export with the parameters in the request body.
+     */
+    generateExportWithBody(params: GenerateExportWithBodyParams, args?: RequestInit) {
+        return this.api.post<ExportModel>(this.buildPathWithOrg(`${Exports.baseUrl}/create`), params, args);
     }
 
     /**
@@ -70,6 +79,13 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
      */
     generateVisitExport(params: GenerateVisitExportParams) {
         return this.api.post<ExportModel>(this.buildPathWithOrg(`${Exports.baseUrl}/visits`, params));
+    }
+
+    /**
+     * Generate a visit export with the parameters in the request body.
+     */
+    generateVisitExportWithBody(params: GenerateVisitExportWithBodyParams, args?: RequestInit) {
+        return this.api.post<ExportModel>(this.buildPathWithOrg(`${Exports.baseUrl}/visits/create`), params, args);
     }
 
     /**

--- a/src/resources/UsageAnalytics/Read/Exports/Exports.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/Exports.ts
@@ -27,6 +27,8 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
 
     /**
      * Generate an export.
+     *
+     * @param params Parameters to generate the export with.
      */
     generate(params: GenerateExportParams) {
         return this.api.post<ExportModel>(this.buildPathWithOrg(Exports.baseUrl, params));
@@ -34,6 +36,8 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
 
     /**
      * Generate an export with the parameters in the request body.
+     *
+     * @param params Parameters to generate the export with, passed in the request body.
      */
     generateExportWithBody(params: GenerateExportWithBodyParams, args?: RequestInit) {
         return this.api.post<ExportModel>(this.buildPathWithOrg(`${Exports.baseUrl}/create`), params, args);
@@ -69,6 +73,8 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
 
     /**
      * Estimate the number of rows in an export.
+     *
+     * @param params The date range and other parameters for the export.
      */
     estimateRowsCount(params: EstimateExportParams) {
         return this.api.get<ExportEstimateModel>(this.buildPathWithOrg(`${Exports.baseUrl}/estimate`, params));
@@ -76,6 +82,8 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
 
     /**
      * Generate a visit export.
+     *
+     * @param params Parameters of the visit export.
      */
     generateVisitExport(params: GenerateVisitExportParams) {
         return this.api.post<ExportModel>(this.buildPathWithOrg(`${Exports.baseUrl}/visits`, params));
@@ -83,6 +91,8 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
 
     /**
      * Generate a visit export with the parameters in the request body.
+     *
+     * @param params Parameters of the visit export, passed in the request body.
      */
     generateVisitExportWithBody(params: GenerateVisitExportWithBodyParams, args?: RequestInit) {
         return this.api.post<ExportModel>(this.buildPathWithOrg(`${Exports.baseUrl}/visits/create`), params, args);
@@ -90,6 +100,8 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
 
     /**
      * Estimate the number of rows in a visit export.
+     *
+     * @param params Parameters of the visit export to estimate.
      */
     estimateVisitExportRowsCount(params: EstimateVisitExportParams) {
         return this.api.get<ExportEstimateModel>(this.buildPathWithOrg(`${Exports.baseUrl}/visits/estimate`, params));
@@ -104,6 +116,8 @@ export default class Exports extends ReadServiceResource implements ReadServiceH
 
     /**
      * Create an export schedule.
+     *
+     * @param model The export schedule to create.
      */
     createSchedule(model: CreateExportScheduleModel) {
         return this.api.post<ExportScheduleModel>(this.buildPathWithOrg(`${Exports.baseUrl}/schedules`), model);

--- a/src/resources/UsageAnalytics/Read/Exports/ExportsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/ExportsInterfaces.ts
@@ -87,34 +87,80 @@ export interface GenerateExportParams extends EstimateExportParams {
     useDisplayNames?: boolean;
 }
 
-type ExportFormat = 'EXCEL' | 'NO_NEWLINE';
-export type ExportTable = 'SEARCHES' | 'CLICKS' | 'CUSTOM_EVENTS' | 'KEYWORDS' | 'GROUPS';
-
-export interface GenerateExportWithBodyParams {
+interface BaseGenerateExportWithBodyParams {
+    /**
+     * The beginning date of the date range. ISO8601 format 'YYYY-MM-DDThh:mm:ss.sssZ'
+     */
     from: string;
+    /**
+     * The end date of the date range. ISO8601 format 'YYYY-MM-DDThh:mm:ss.sssZ'
+     */
     to: string;
-    commonFilters?: string[];
-    searchesFilters?: string[];
-    customEventsFilters?: string[];
+    /**
+     * A file name for the export. Can only contain US-ASCII characters. If none is supplied it will be set to the export's id.
+     */
     filename?: string;
+    /**
+     * Optional description for the export.
+     */
     description?: string;
+    /**
+     * The dimensions that will be exported. If not provided, all dimensions will be exported.
+     */
     dimensions?: string[];
-    tables?: ExportTable[];
-    exportFormat?: ExportFormat;
+    /**
+     * The format of the generated CSV files. If not provided, it will default to Excel.
+     */
+    exportFormat?: CSVFileFormat;
+    /**
+     * Whether to use the display names in the export's header. If false, the api names will be used. If not provided, it defaults to false.
+     */
     useDisplayNames?: boolean;
 }
 
-export interface GenerateVisitExportWithBodyParams {
-    from: string;
-    to: string;
+export interface GenerateExportWithBodyParams extends BaseGenerateExportWithBodyParams {
+    /**
+     * The filter that will be applied to the events common dimensions (shared by all types of events).
+     * Multiple filter parameters are joined with the AND operator.
+     */
+    commonFilters?: string[];
+    /**
+     * The filter that will be applied to the click and search events dimensions.
+     * Multiple filter parameters are joined with the AND operator.
+     */
+    searchesFilters?: string[];
+    /**
+     * The filter that will be applied to the custom events dimensions.
+     * Multiple filter parameters are joined with the AND operator.
+     */
+    customEventsFilters?: string[];
+    /**
+     * The tables that will be exported. If not provided, all tables will be exported.
+     */
+    tables?: ExportTablesType[];
+}
+
+export interface GenerateVisitExportWithBodyParams extends BaseGenerateExportWithBodyParams {
+    /**
+     * The filter that will be applied to the events dimensions.
+     * Multiple filter parameters are joined with the AND operator.
+     */
     inclusionFilters?: string[];
+    /**
+     * Each specified filter is inverted in order to hide events.
+     * Multiple filter parameters are joined with the AND operator.
+     */
     hideEventFilters?: string[];
+    /**
+     * The filter that will be applied to dimensions to exclude events from the results.
+     * Multiple filter parameters are joined with the AND operator.
+     */
     exclusionFilters?: string[];
-    filename?: string;
-    description?: string;
-    dimensions?: string[];
-    exportFormat?: ExportFormat;
-    useDisplayNames?: boolean;
+    /**
+     * Whether to order the rows by datetime in the export.
+     * If the number of rows exported is to great, this parameter will be ignored and data will be unsorted.
+     * If not provided, it defaults to true.
+     */
     ordered?: boolean;
 }
 
@@ -122,6 +168,7 @@ export interface GenerateVisitExportParams extends GenerateExportParams {
     /**
      * Whether to order the rows by datetime in the export.
      * If the number of rows exported is too large, this parameter will be ignored and data will be unsorted.
+     * If not provided, it defaults to true.
      */
     ordered?: boolean;
 }

--- a/src/resources/UsageAnalytics/Read/Exports/ExportsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/ExportsInterfaces.ts
@@ -1,4 +1,4 @@
-import {CSVFileFormat, DayOfWeek, ExportScheduleFrequency, ExportStatus, ExportTablesType} from '../../../Enums.js';
+import {CSVFileFormat, DayOfWeek, ExportScheduleFrequency, ExportStatus, ExportTables} from '../../../Enums.js';
 import {
     EventDimensionsExcludeFilterParamParts,
     EventDimensionsFilterParamParts,
@@ -45,7 +45,7 @@ export interface EstimateExportParams extends TimeRangeParamParts, EventDimensio
      * The tables that will be included.
      * If not provided, all tables will be included.
      */
-    tables?: ExportTablesType[];
+    tables?: ExportTables[];
     /**
      * The filter that will be applied to the click and search events dimensions.
      * Multiple filter parameters are joined with the AND operator.
@@ -89,55 +89,55 @@ export interface GenerateExportParams extends EstimateExportParams {
 
 interface BaseGenerateExportWithBodyParams {
     /**
-     * The beginning date of the date range. ISO8601 format 'YYYY-MM-DDThh:mm:ss.sssZ'
+     * The beginning of the date range, in ISO8601 format (`YYYY-MM-DDThh:mm:ss.sssZ`).
      */
     from: string;
     /**
-     * The end date of the date range. ISO8601 format 'YYYY-MM-DDThh:mm:ss.sssZ'
+     * The end of the date range, in ISO8601 format (`YYYY-MM-DDThh:mm:ss.sssZ`).
      */
     to: string;
     /**
-     * A file name for the export. Can only contain US-ASCII characters. If none is supplied it will be set to the export's id.
+     * The file name to use for the export. Can only contain US-ASCII characters. By default, the export ID is used.
      */
     filename?: string;
     /**
-     * Optional description for the export.
+     * An optional description for the export.
      */
     description?: string;
     /**
-     * The dimensions that will be exported. If not provided, all dimensions will be exported.
+     * The dimensions to export. By default, all dimensions are exported.
      */
     dimensions?: string[];
     /**
-     * The format of the generated CSV files. If not provided, it will default to Excel.
+     * The format of the generated CSV files. Defaults to `Excel`.
      */
     exportFormat?: CSVFileFormat;
     /**
-     * Whether to use the display names in the export's header. If false, the api names will be used. If not provided, it defaults to false.
+     * Whether to use the display names in the export's header. Defaults to `false`, meaning that the API names are used by default.
      */
     useDisplayNames?: boolean;
 }
 
 export interface GenerateExportWithBodyParams extends BaseGenerateExportWithBodyParams {
     /**
-     * The filter that will be applied to the events common dimensions (shared by all types of events).
+     * The filters to apply to dimensions shared by all types of events.
      * Multiple filter parameters are joined with the AND operator.
      */
     commonFilters?: string[];
     /**
-     * The filter that will be applied to the click and search events dimensions.
+     * The filters to apply to the dimensions of click and search events only.
      * Multiple filter parameters are joined with the AND operator.
      */
     searchesFilters?: string[];
     /**
-     * The filter that will be applied to the custom events dimensions.
+     * The filters to apply to the dimensions of custom events only.
      * Multiple filter parameters are joined with the AND operator.
      */
     customEventsFilters?: string[];
     /**
-     * The tables that will be exported. If not provided, all tables will be exported.
+     * The tables to export. By default, all tables are exported.
      */
-    tables?: ExportTablesType[];
+    tables?: ExportTables[];
 }
 
 export interface GenerateVisitExportWithBodyParams extends BaseGenerateExportWithBodyParams {
@@ -154,12 +154,13 @@ export interface GenerateVisitExportWithBodyParams extends BaseGenerateExportWit
     /**
      * The filter that will be applied to dimensions to exclude events from the results.
      * Multiple filter parameters are joined with the AND operator.
+     * The exclusion filter has precedence over the inclusion filter.
      */
     exclusionFilters?: string[];
     /**
      * Whether to order the rows by datetime in the export.
-     * If the number of rows exported is to great, this parameter will be ignored and data will be unsorted.
-     * If not provided, it defaults to true.
+     * If there are a large number of rows to export, this parameter will be ignored and the data will be unsorted.
+     * Defaults to `true`.
      */
     ordered?: boolean;
 }
@@ -167,8 +168,8 @@ export interface GenerateVisitExportWithBodyParams extends BaseGenerateExportWit
 export interface GenerateVisitExportParams extends GenerateExportParams {
     /**
      * Whether to order the rows by datetime in the export.
-     * If the number of rows exported is too large, this parameter will be ignored and data will be unsorted.
-     * If not provided, it defaults to true.
+     * If there are a large number of rows to export, this parameter will be ignored and the data will be unsorted.
+     * Defaults to `true`.
      */
     ordered?: boolean;
 }
@@ -196,7 +197,7 @@ export interface CreateExportScheduleModel extends ExportScheduleModelCommonProp
     searchesFilters?: string[];
     customEventsFilters?: string[];
     description?: string;
-    tables?: ExportTablesType[];
+    tables?: ExportTables[];
     exportFormat?: CSVFileFormat;
 }
 

--- a/src/resources/UsageAnalytics/Read/Exports/ExportsInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/ExportsInterfaces.ts
@@ -87,6 +87,37 @@ export interface GenerateExportParams extends EstimateExportParams {
     useDisplayNames?: boolean;
 }
 
+type ExportFormat = 'EXCEL' | 'NO_NEWLINE';
+export type ExportTable = 'SEARCHES' | 'CLICKS' | 'CUSTOM_EVENTS' | 'KEYWORDS' | 'GROUPS';
+
+export interface GenerateExportWithBodyParams {
+    from: string;
+    to: string;
+    commonFilters?: string[];
+    searchesFilters?: string[];
+    customEventsFilters?: string[];
+    filename?: string;
+    description?: string;
+    dimensions?: string[];
+    tables?: ExportTable[];
+    exportFormat?: ExportFormat;
+    useDisplayNames?: boolean;
+}
+
+export interface GenerateVisitExportWithBodyParams {
+    from: string;
+    to: string;
+    inclusionFilters?: string[];
+    hideEventFilters?: string[];
+    exclusionFilters?: string[];
+    filename?: string;
+    description?: string;
+    dimensions?: string[];
+    exportFormat?: ExportFormat;
+    useDisplayNames?: boolean;
+    ordered?: boolean;
+}
+
 export interface GenerateVisitExportParams extends GenerateExportParams {
     /**
      * Whether to order the rows by datetime in the export.

--- a/src/resources/UsageAnalytics/Read/Exports/tests/Exports.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/tests/Exports.spec.ts
@@ -26,8 +26,8 @@ describe('Exports', () => {
     });
 
     describe('list', () => {
-        it('makes a GET call to the Exports base url', () => {
-            exports.list();
+        it('makes a GET call to the Exports base url', async () => {
+            await exports.list();
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(Exports.baseUrl);
@@ -35,12 +35,12 @@ describe('Exports', () => {
     });
 
     describe('generate', () => {
-        it('makes a POST call to the Exports base url', () => {
+        it('makes a POST call to the Exports base url', async () => {
             const params: GenerateExportParams = {
                 from: '123',
                 to: '456',
             };
-            exports.generate(params);
+            await exports.generate(params);
 
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${Exports.baseUrl}?from=123&to=456`);
@@ -48,12 +48,12 @@ describe('Exports', () => {
     });
 
     describe('generateExportWithBody', () => {
-        it('makes a POST call to the Exports base url with a request body', () => {
+        it('makes a POST call to the Exports base url with a request body', async () => {
             const params: GenerateExportWithBodyParams = {
                 from: '123',
                 to: '456',
             };
-            exports.generateExportWithBody(params);
+            await exports.generateExportWithBody(params);
 
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${Exports.baseUrl}/create`, params, undefined);
@@ -61,9 +61,9 @@ describe('Exports', () => {
     });
 
     describe('get', () => {
-        it('makes a GET call to the specific Exports url', () => {
+        it('makes a GET call to the specific Exports url', async () => {
             const exportId = '🌞';
-            exports.get(exportId);
+            await exports.get(exportId);
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/${exportId}?redirect=false`);
@@ -71,18 +71,18 @@ describe('Exports', () => {
     });
 
     describe('getExportDownloadLink', () => {
-        it('makes a GET call to the specific Exports url', () => {
+        it('makes a GET call to the specific Exports url', async () => {
             const exportId = 'Soubame';
-            exports.getExportDownloadLink(exportId);
+            await exports.getExportDownloadLink(exportId);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/${exportId}/downloadlink`);
         });
     });
 
     describe('delete', () => {
-        it('makes a DELETE call to the specific Exports url', () => {
+        it('makes a DELETE call to the specific Exports url', async () => {
             const exportId = '🌞';
-            exports.delete(exportId);
+            await exports.delete(exportId);
 
             expect(api.delete).toHaveBeenCalledTimes(1);
             expect(api.delete).toHaveBeenCalledWith(`${Exports.baseUrl}/${exportId}`);
@@ -90,12 +90,12 @@ describe('Exports', () => {
     });
 
     describe('estimateRowsCount', () => {
-        it('makes a GET call to the specific Exports url', () => {
+        it('makes a GET call to the specific Exports url', async () => {
             const params: EstimateExportParams = {
                 from: '246',
                 to: '135',
             };
-            exports.estimateRowsCount(params);
+            await exports.estimateRowsCount(params);
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/estimate?from=246&to=135`);
@@ -103,12 +103,12 @@ describe('Exports', () => {
     });
 
     describe('generateVisitExport', () => {
-        it('makes a POST call to the specific Exports url', () => {
+        it('makes a POST call to the specific Exports url', async () => {
             const params: GenerateVisitExportParams = {
                 from: '987',
                 to: '654',
             };
-            exports.generateVisitExport(params);
+            await exports.generateVisitExport(params);
 
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${Exports.baseUrl}/visits?from=987&to=654`);
@@ -116,12 +116,12 @@ describe('Exports', () => {
     });
 
     describe('generateVisitExportWithBody', () => {
-        it('makes a POST call to the specific Exports url with a request body', () => {
+        it('makes a POST call to the specific Exports url with a request body', async () => {
             const params: GenerateVisitExportWithBodyParams = {
                 from: '987',
                 to: '654',
             };
-            exports.generateVisitExportWithBody(params);
+            await exports.generateVisitExportWithBody(params);
 
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${Exports.baseUrl}/visits/create`, params, undefined);
@@ -129,12 +129,12 @@ describe('Exports', () => {
     });
 
     describe('estimateVisitExportRowsCount', () => {
-        it('makes a GET call to the specific Exports url', () => {
+        it('makes a GET call to the specific Exports url', async () => {
             const params: EstimateVisitExportParams = {
                 from: '741',
                 to: '369',
             };
-            exports.estimateVisitExportRowsCount(params);
+            await exports.estimateVisitExportRowsCount(params);
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/visits/estimate?from=741&to=369`);
@@ -142,8 +142,8 @@ describe('Exports', () => {
     });
 
     describe('listSchedules', () => {
-        it('makes a GET call to the specific Exports url', () => {
-            exports.listSchedules();
+        it('makes a GET call to the specific Exports url', async () => {
+            await exports.listSchedules();
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/schedules`);
@@ -151,12 +151,12 @@ describe('Exports', () => {
     });
 
     describe('createSchedule', () => {
-        it('makes a POST call to the specific Exports url', () => {
+        it('makes a POST call to the specific Exports url', async () => {
             const model: CreateExportScheduleModel = {
                 frequency: ExportScheduleFrequency.monthly,
                 timezone: 'Area51',
             };
-            exports.createSchedule(model);
+            await exports.createSchedule(model);
 
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${Exports.baseUrl}/schedules`, model);
@@ -164,9 +164,9 @@ describe('Exports', () => {
     });
 
     describe('getSchedule', () => {
-        it('makes a GET call to the specific Exports url', () => {
+        it('makes a GET call to the specific Exports url', async () => {
             const exportScheduleId = '🌞';
-            exports.getSchedule(exportScheduleId);
+            await exports.getSchedule(exportScheduleId);
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/schedules/${exportScheduleId}`);
@@ -174,13 +174,13 @@ describe('Exports', () => {
     });
 
     describe('updateSchedule', () => {
-        it('makes a PUT call to the specific Exports url', () => {
+        it('makes a PUT call to the specific Exports url', async () => {
             const exportScheduleId = '🌞';
             const model: CreateExportScheduleModel = {
                 frequency: ExportScheduleFrequency.monthly,
                 timezone: 'Area51',
             };
-            exports.updateSchedule(exportScheduleId, model);
+            await exports.updateSchedule(exportScheduleId, model);
 
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(`${Exports.baseUrl}/schedules/${exportScheduleId}`, model);
@@ -188,9 +188,9 @@ describe('Exports', () => {
     });
 
     describe('deleteSchedule', () => {
-        it('makes a DELETE call to the specific Exports url', () => {
+        it('makes a DELETE call to the specific Exports url', async () => {
             const exportScheduleId = '🌞';
-            exports.deleteSchedule(exportScheduleId);
+            await exports.deleteSchedule(exportScheduleId);
 
             expect(api.delete).toHaveBeenCalledTimes(1);
             expect(api.delete).toHaveBeenCalledWith(`${Exports.baseUrl}/schedules/${exportScheduleId}`);
@@ -198,8 +198,8 @@ describe('Exports', () => {
     });
 
     describe('getRowLimit', () => {
-        it('makes a GET call to the specific Exports url', () => {
-            exports.getRowLimit();
+        it('makes a GET call to the specific Exports url', async () => {
+            await exports.getRowLimit();
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/rowLimit`);
@@ -207,8 +207,8 @@ describe('Exports', () => {
     });
 
     describe('checkHealth', () => {
-        it('makes a GET call to the specific Exports url', () => {
-            exports.checkHealth();
+        it('makes a GET call to the specific Exports url', async () => {
+            await exports.checkHealth();
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/monitoring/health`);
@@ -216,8 +216,8 @@ describe('Exports', () => {
     });
 
     describe('checkStatus', () => {
-        it('makes a GET call to the specific Exports url', () => {
-            exports.checkStatus();
+        it('makes a GET call to the specific Exports url', async () => {
+            await exports.checkStatus();
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Exports.baseUrl}/status`);

--- a/src/resources/UsageAnalytics/Read/Exports/tests/Exports.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Exports/tests/Exports.spec.ts
@@ -6,7 +6,9 @@ import {
     EstimateExportParams,
     EstimateVisitExportParams,
     GenerateExportParams,
+    GenerateExportWithBodyParams,
     GenerateVisitExportParams,
+    GenerateVisitExportWithBodyParams,
 } from '../ExportsInterfaces.js';
 
 jest.mock('../../../../../APICore.js');
@@ -42,6 +44,19 @@ describe('Exports', () => {
 
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${Exports.baseUrl}?from=123&to=456`);
+        });
+    });
+
+    describe('generateExportWithBody', () => {
+        it('makes a POST call to the Exports base url with a request body', () => {
+            const params: GenerateExportWithBodyParams = {
+                from: '123',
+                to: '456',
+            };
+            exports.generateExportWithBody(params);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Exports.baseUrl}/create`, params, undefined);
         });
     });
 
@@ -97,6 +112,19 @@ describe('Exports', () => {
 
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${Exports.baseUrl}/visits?from=987&to=654`);
+        });
+    });
+
+    describe('generateVisitExportWithBody', () => {
+        it('makes a POST call to the specific Exports url with a request body', () => {
+            const params: GenerateVisitExportWithBodyParams = {
+                from: '987',
+                to: '654',
+            };
+            exports.generateVisitExportWithBody(params);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${Exports.baseUrl}/visits/create`, params, undefined);
         });
     });
 


### PR DESCRIPTION
Adds the exports with body endpoints from the experimental client in the admin UI here- https://github.com/coveo-platform/admin-ui/blob/135ef77c0705b5c1925ae4df511bae2fc8637571/core/api/src/resources/UAExportsResource.ts

These endpoints are stable, publicly available and on Swagger, and documented.

### Acceptance Criteria
<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
