### PR TITLE
feat: adds the Snowflake reader account user reactivation endpoint [U…

### DIFF
--- a/src/resources/UsageAnalytics/Read/Snowflake/Snowflake.ts
+++ b/src/resources/UsageAnalytics/Read/Snowflake/Snowflake.ts
@@ -1,6 +1,7 @@
 import ReadServiceResource from '../ReadServiceResource.js';
 import {
     GetCreditUsageParams,
+    ReactivateUserParams,
     SnowflakeCreditUsageModel,
     SnowflakeNetworkPolicyModel,
     SnowflakeReaderAccountEndpointModel,
@@ -21,6 +22,8 @@ export default class Snowflake extends ReadServiceResource {
 
     /**
      * Create a new user within a Snowflake reader account.
+     *
+     * @param model The user to create.
      */
     createUser(model: SnowflakeUserModel) {
         return this.api.post<SnowflakeUserModel>(this.buildPathWithOrg(`${Snowflake.baseUrl}/users`), model);
@@ -54,6 +57,19 @@ export default class Snowflake extends ReadServiceResource {
     }
 
     /**
+     * Reactivate and set a user's expiration in a Snowflake reader account.
+     *
+     * @param snowflakeUser The login name for the Snowflake user.
+     * @param params The number of days until the user's expiration date.
+     */
+    reactivateUser(snowflakeUser: string, params: ReactivateUserParams) {
+        return this.api.put<void>(
+            this.buildPathWithOrg(`${Snowflake.baseUrl}/users/${snowflakeUser}/expiration`),
+            params,
+        );
+    }
+
+    /**
      * Get the details of the active network policy for a Snowflake reader account.
      */
     getNetworkPolicy() {
@@ -62,6 +78,8 @@ export default class Snowflake extends ReadServiceResource {
 
     /**
      * Set the details of the active network policy for a Snowflake reader account.
+     *
+     * @param model The network policy to create.
      */
     updateNetworkPolicy(model: SnowflakeNetworkPolicyModel) {
         return this.api.put<void>(this.buildPathWithOrg(`${Snowflake.baseUrl}/networkpolicy`), model);
@@ -69,6 +87,8 @@ export default class Snowflake extends ReadServiceResource {
 
     /**
      * Get the amount of compute credits used by a Snowflake reader account within a date range.
+     *
+     * @param params The time range to get the amount of compute credits.
      */
     getCreditUsage(params: GetCreditUsageParams) {
         return this.api.get<SnowflakeCreditUsageModel>(

--- a/src/resources/UsageAnalytics/Read/Snowflake/SnowflakeInterfaces.ts
+++ b/src/resources/UsageAnalytics/Read/Snowflake/SnowflakeInterfaces.ts
@@ -21,6 +21,10 @@ export interface SnowflakeUserModel {
     daysToExpiry?: number;
 }
 
+export interface ReactivateUserParams {
+    daysToExpiry: number;
+}
+
 export interface SnowflakeNetworkPolicyModel {
     allowedIpAddresses: string[];
     blockedIpAddresses: string[];

--- a/src/resources/UsageAnalytics/Read/Snowflake/tests/Snowflake.spec.ts
+++ b/src/resources/UsageAnalytics/Read/Snowflake/tests/Snowflake.spec.ts
@@ -1,6 +1,11 @@
 import API from '../../../../../APICore.js';
 import Snowflake from '../Snowflake.js';
-import {GetCreditUsageParams, SnowflakeNetworkPolicyModel, SnowflakeUserModel} from '../SnowflakeInterfaces.js';
+import {
+    GetCreditUsageParams,
+    ReactivateUserParams,
+    SnowflakeNetworkPolicyModel,
+    SnowflakeUserModel,
+} from '../SnowflakeInterfaces.js';
 
 jest.mock('../../../../../APICore.js');
 
@@ -56,6 +61,19 @@ describe('Snowflake', () => {
 
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(`${Snowflake.baseUrl}/users/${snowflakeUser}`);
+        });
+    });
+
+    describe('reactivateUser', () => {
+        it('makes a PUT call to the specific Snowflake url', () => {
+            const snowflakeUser = 'ross.blais';
+            const params: ReactivateUserParams = {
+                daysToExpiry: 66,
+            };
+            snowflake.reactivateUser(snowflakeUser, params);
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${Snowflake.baseUrl}/users/${snowflakeUser}/expiration`, params);
         });
     });
 


### PR DESCRIPTION
…A-9263]

Adds the endpoint to reactivate a Snowflake reader account user. This endpoint is stable, publicly available in Swagger, and deployed in production.

This PR also adds some missing JSdoc params in the Snowflake resource.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
