### PR TITLE
feat: add codeowners for data platform resources [UA-9391]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,3 +8,7 @@
 
 # Prevent PRs that only modify package.json from notifying everyone
 package.json
+
+# Owned by data platform
+src/resources/AnalyticsAdmin/ @coveo/dpf-ui-owners-1
+src/resources/UsageAnalytics/ @coveo/dpf-ui-owners-1


### PR DESCRIPTION
Adds codeowners for resources owned by data platform (specifically the UI subset of owners).

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
