### PR TITLE
Revert "feat(TSP-414): add listByProject endpoint to platform client"

### DIFF
--- a/src/resources/InProductExperiences/InProductExperiences.ts
+++ b/src/resources/InProductExperiences/InProductExperiences.ts
@@ -7,7 +7,6 @@ import {
     UpdateInProductExperienceModel,
     InProductExperienceLoader,
     CreateInProductExperienceResponse,
-    InProductExperienceProjectsModel,
 } from './InProductExperiencesInterfaces.js';
 
 /**
@@ -43,12 +42,6 @@ export default class InProductExperiences extends Resource {
 
     list(name?: string) {
         return this.api.get<InProductExperienceModel[]>(this.buildPath(`${InProductExperiences.ipxBaseUrl}s`, {name}));
-    }
-
-    listByProject(projectId?: string) {
-        return this.api.get<InProductExperienceProjectsModel[]>(
-            this.buildPath(`${InProductExperiences.ipxBaseUrl}s/projectid`, {projectid: projectId}),
-        );
     }
 
     getLoader(ipxId: string, access_token?: string) {

--- a/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
+++ b/src/resources/InProductExperiences/InProductExperiencesInterfaces.ts
@@ -1,4 +1,3 @@
-import {ProjectResourceModel} from '../Projects/ProjectInterfaces.js';
 import {RestTokenParams} from '../Search/index.js';
 import {CSSResourceModel, JavaScriptResourceModel} from '../SearchPages/index.js';
 
@@ -84,8 +83,6 @@ export interface InProductExperienceModel extends SharedInProductExperienceModel
 
     token: RestTokenParams;
 }
-
-export interface InProductExperienceProjectsModel extends InProductExperienceModel, ProjectResourceModel {}
 
 export interface CreateUpdateInProductExperienceModel extends SharedInProductExperienceModel {
     /**

--- a/src/resources/InProductExperiences/tests/InProductExperiences.spec.ts
+++ b/src/resources/InProductExperiences/tests/InProductExperiences.spec.ts
@@ -25,14 +25,6 @@ describe('InProductExperiences', () => {
         });
     });
 
-    describe('listByProject', () => {
-        it('should make a GET call to the specific Project In-Product Experiences url', async () => {
-            await ipxService.listByProject();
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${InProductExperiences.ipxBaseUrl}s/projectid`);
-        });
-    });
-
     describe('create', () => {
         it('should make a POST call to the In-Product Experiences base url', () => {
             const ipxModel: CreateInProductExperienceModel = {

--- a/src/resources/Projects/ProjectInterfaces.ts
+++ b/src/resources/Projects/ProjectInterfaces.ts
@@ -160,17 +160,3 @@ export interface UpdatedProjectResourceAssociationsModel {
      */
     removals: UpdatedProjectAssociationsModel;
 }
-
-export interface ListResourceByProjectParams {
-    /**
-     * Project identifier for which resources are to be fetched
-     */
-    projectId: string;
-}
-
-export interface ProjectResourceModel {
-    /**
-     * Ids of projects associated to this resource
-     */
-    projectIds: string[];
-}


### PR DESCRIPTION
[TSP-414](https://coveord.atlassian.net/browse/TSP-414)
Reverts coveo/platform-client#858

After some discussions, it was decided that these calls should be private and not exposed to clients

[TSP-414]: https://coveord.atlassian.net/browse/TSP-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ