### PR TITLE
fix(SRC-5281): drop call that was removed

### DIFF
--- a/src/resources/Projects/Project.ts
+++ b/src/resources/Projects/Project.ts
@@ -8,7 +8,6 @@ import {
     BaseProjectModel,
     ProjectResourceType,
     ListAssociatedProjectsModel,
-    UpdatedProjectResourceAssociationsModel,
 } from './ProjectInterfaces.js';
 
 export default class Project extends Resource {
@@ -108,23 +107,6 @@ export default class Project extends Resource {
         return this.api.post<ListAssociatedProjectsModel[]>(
             this.buildPath(`${Project.baseUrl}/resources/ids`, {resourceType}),
             resourceIds,
-        );
-    }
-
-    /**
-     * Modifies project-resource associations and returns a list of updated projects.
-     *
-     * @param {ProjectResourceType} resourceType
-     * @param {UpdatedProjectResourceAssociationsModel} updatedProjectResourceAssociation
-     * @returns {Promise<ProjectModel[]>} Returns a list of updated projects.
-     */
-    updateProjectResourceAssociation(
-        resourceType: ProjectResourceType,
-        updatedProjectResourceAssociation: UpdatedProjectResourceAssociationsModel,
-    ): Promise<ProjectModel[]> {
-        return this.api.put<ProjectModel[]>(
-            this.buildPath(`${Project.baseUrl}/resources/modify/${resourceType}`),
-            updatedProjectResourceAssociation,
         );
     }
 }

--- a/src/resources/Projects/tests/Project.spec.ts
+++ b/src/resources/Projects/tests/Project.spec.ts
@@ -1,12 +1,6 @@
 import API from '../../../APICore.js';
 import Project from '../Project.js';
-import {
-    BaseProjectModel,
-    ProjectModel,
-    ProjectType,
-    UpdatedProjectAssociationsModel,
-    UpdatedProjectResourceAssociationsModel,
-} from '../ProjectInterfaces.js';
+import {BaseProjectModel, ProjectModel, ProjectType} from '../ProjectInterfaces.js';
 
 jest.mock('../../../APICore.js');
 
@@ -135,24 +129,6 @@ describe('Project', () => {
             expect(api.post).toHaveBeenCalledWith(`${Project.baseUrl}/resources/ids?resourceType=SOURCE`, [
                 randomSourceId,
             ]);
-        });
-    });
-
-    describe('updateProjectResourceAssociation', () => {
-        it('should make a PUT call to the correct Project URL', () => {
-            const randomProjectResourceAssociation: UpdatedProjectResourceAssociationsModel = {
-                additions: {
-                    projectIds: ['random-project-id'],
-                    resourceIds: ['random-source-id'],
-                },
-                removals: {} as UpdatedProjectAssociationsModel,
-            };
-            project.updateProjectResourceAssociation('SOURCE', randomProjectResourceAssociation);
-            expect(api.put).toHaveBeenCalledTimes(1);
-            expect(api.put).toHaveBeenCalledWith(
-                `${Project.baseUrl}/resources/modify/SOURCE`,
-                randomProjectResourceAssociation,
-            );
         });
     });
 });


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->
A scan on github was done to check if this call is used and only SearchApi is using it. Outside of coveo, this call is not used. It was already dropped in the backend.

**Note** This is a breaking change, but the call is not used in PROD/HIPAA
### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
