### PR TITLE
feat(api key): add lifetimeDuration parameter and split interface

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,12 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "enabled": true,
-    "extends": ["github>coveo/renovate-presets", ":semanticPrefixFixDepsChoreOthers", "helpers:pinGitHubActionDigests", "schedule:earlyMondays"],
+    "extends": [
+        "github>coveo/renovate-presets",
+        ":semanticPrefixFixDepsChoreOthers",
+        "helpers:pinGitHubActionDigests",
+        "schedule:earlyMondays"
+    ],
     "packageRules": [
         {
             "matchPackagePatterns": ["*"],

--- a/src/resources/ApiKeys/ApiKeys.ts
+++ b/src/resources/ApiKeys/ApiKeys.ts
@@ -1,7 +1,6 @@
 import API from '../../APICore.js';
-import {New} from '../BaseInterfaces.js';
 import Resource from '../Resource.js';
-import {ApiKeyModel, CreateApiKeyOptions, DuplicateApiKeyOptions} from './ApiKeysInterfaces.js';
+import {ApiKeyModel, CreateApiKeyModel, CreateApiKeyOptions, DuplicateApiKeyOptions} from './ApiKeysInterfaces.js';
 
 export default class ApiKey extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/apikeys`;
@@ -10,7 +9,7 @@ export default class ApiKey extends Resource {
         return this.api.get<ApiKeyModel[]>(ApiKey.baseUrl);
     }
 
-    create(apiKey: New<ApiKeyModel, 'resourceId' | 'id'>, options?: CreateApiKeyOptions) {
+    create(apiKey: CreateApiKeyModel, options?: CreateApiKeyOptions) {
         return this.api.post<ApiKeyModel>(this.buildPath(ApiKey.baseUrl, options), apiKey);
     }
 

--- a/src/resources/ApiKeys/ApiKeysInterfaces.ts
+++ b/src/resources/ApiKeys/ApiKeysInterfaces.ts
@@ -1,14 +1,53 @@
 import {GranularResource, PrivilegeModel} from '../BaseInterfaces.js';
 import {ApiKeyStatus} from '../Enums.js';
-export interface ApiKeyModel extends GranularResource {
+
+export interface ApiKeyBaseModel extends GranularResource {
+    /**
+     * The display name for the API key.
+     * @example PushApiKey
+     */
+    displayName?: string;
+    /**
+     * A brief description of the API key.
+     * @example API key used for managing sources.
+     */
+    description?: string;
+    /**
+     * A set of IP addresses allowed to use the API key.
+     *
+     * Notes:
+     * - IP ranges using CIDR notation are also supported.
+     * - If an IP address is included in both the `allowedIps` and the `deniedIps`, the IP address will be denied.
+     * @example ["192.168.0.0/16", "29.186.225.13"]
+     */
+    allowedIps?: string[];
+    /**
+     * A set of IP addresses that will be denied access when attempting to use the API key.
+     *
+     * Notes:
+     * - IP ranges using CIDR notation are also supported.
+     * - If an IP address is included in both the `allowedIps` as well as the `deniedIps`, the IP address will be denied.
+     * @example [`"192.168.0.0/16"`, `"29.186.225.13"`]
+     */
+    deniedIps?: string[];
+    /**
+     * A set of privileges.
+     */
+    privileges?: PrivilegeModel[];
+    /**
+     * Additional configuration to be included in an API key. [to be revised]
+     */
+    additionalConfiguration?: AdditionalConfigurationModel;
+}
+
+export interface ApiKeyModel extends ApiKeyBaseModel {
     /**
      * The unique identifier of the [organization](https://docs.coveo.com/en/222/) the API key was created for.
      */
     organizationId?: string;
     /**
      * The unique identifier of the API key.
-     *
-     * **Example:** t4hk287bfj5sg6wskg64ckk5a
+     * @example t4hk287bfj5sg6wskg64ckk5a
      */
     id: string;
     /**
@@ -17,22 +56,9 @@ export interface ApiKeyModel extends GranularResource {
     enabled?: boolean;
     /**
      * The value of the API key.
-     *
-     * **Example:** xx65151ec3-7b30-4772-a99a-09b4c0f71343
+     * @example xx65151ec3-7b30-4772-a99a-09b4c0f71343
      */
     value?: string;
-    /**
-     * The display name for the API key.
-     *
-     * **Example:** PushApiKey
-     */
-    displayName?: string;
-    /**
-     * A brief description of the API key.
-     *
-     * **Example:** API key used for managing sources.
-     */
-    description?: string;
     /**
      * The username or the email address that was used to create this API key.
      */
@@ -40,50 +66,19 @@ export interface ApiKeyModel extends GranularResource {
     createdBy?: any;
     /**
      * The API key creation date in Unix timestamp in milliseconds.
-     *
-     * **Example:** 1614969486000
+     * @example 1614969486000
      */
     createdDate?: number;
     /**
      * The approximate API key last used date in Unix timestamp in milliseconds.
-     *
-     * **Example:** 1624575600000
+     * @example 1624575600000
      */
     lastUsedDate?: number;
     /**
-     * A set of IP addresses allowed to use the API key.
-     *
-     * **Notes:**
-     * - IP ranges using CIDR notation are also supported.
-     * - If an IP address is included in both the `allowedIps` as well as the `deniedIps`, the IP address will be denied.
-     *
-     * **Example:** [`"192.168.0.0/16"`, `"29.186.225.13"`]
-     */
-    allowedIps?: string[];
-    /**
-     * A set of IP addresses that will be denied access when attempting to use the API key.
-     *
-     * **Notes:**
-     * - IP ranges using CIDR notation are also supported.
-     * - If an IP address is included in both the `allowedIps` as well as the `deniedIps`, the IP address will be denied.
-     *
-     * **Example:** [`"192.168.0.0/16"`, `"29.186.225.13"`]
-     */
-    deniedIps?: string[];
-    /**
-     * A set of privileges.
-     */
-    privileges?: PrivilegeModel[];
-    /**
      * The unique identifier of the API key.
-     *
-     * **Example:** t4hk287bfj5sg6wskg64ckk5a
+     * @example t4hk287bfj5sg6wskg64ckk5a
      */
     resourceId?: string;
-    /**
-     * Additional configuration to be included in an API key. [to be revised]
-     */
-    additionalConfiguration?: AdditionalConfigurationModel;
     /**
      * The expiration date of the API key.
      */
@@ -104,6 +99,18 @@ export interface ApiKeyModel extends GranularResource {
      * The date the API key has been disabled.
      */
     disabledDate?: number;
+}
+
+export interface CreateApiKeyModel extends ApiKeyBaseModel {
+    /**
+     * The duration of the API key in ISO-8601 format. Once the duration is reached the key expires and cannot be used anymore.
+     * @example
+     * 'P1Y' for 1 year
+     * 'P14D' for 14 days
+     * 'P1M' for 1 month.
+     * 'P1Y3M14D' for 1 year, 3 months, and 14 days.
+     */
+    lifetimeDuration?: string;
 }
 
 export interface CreateApiKeyOptions {

--- a/src/resources/ApiKeys/test/ApiKeys.spec.ts
+++ b/src/resources/ApiKeys/test/ApiKeys.spec.ts
@@ -1,7 +1,6 @@
 import API from '../../../APICore.js';
-import {New} from '../../BaseInterfaces.js';
 import ApiKey from '../ApiKeys.js';
-import {ApiKeyModel} from '../ApiKeysInterfaces.js';
+import {ApiKeyModel, CreateApiKeyModel} from '../ApiKeysInterfaces.js';
 
 jest.mock('../../../APICore.js');
 
@@ -25,9 +24,11 @@ describe('ApiKey', () => {
 
     describe('create', () => {
         it('should make a POST call to the ApiKeys base url', async () => {
-            const apiKeyModel: New<ApiKeyModel> = {
-                organizationId: 'a-smol-org',
-                value: '',
+            const apiKeyModel: CreateApiKeyModel = {
+                displayName: 'Cool key',
+                description: 'My super cool API key',
+                lifetimeDuration: 'P1M',
+                allowedIps: ['192.168.0.0/24'],
             };
 
             await apiKey.create(apiKeyModel);


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

Improved the type of the `ApiKey.create` call, it now only allow the parameters the backend accept
Added the `lifetimeDuration` parameter

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
