### PR TITLE
chore(renovate): use automerge preset and config simplification

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,11 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "enabled": true,
     "extends": [
         "github>coveo/renovate-presets",
         ":semanticPrefixFixDepsChoreOthers",
         "helpers:pinGitHubActionDigests",
-        "schedule:earlyMondays"
+        "schedule:earlyMondays",
+        "github>coveo/renovate-presets//auto-merge.json"
     ],
     "packageRules": [
         {
@@ -24,9 +24,7 @@
             "description": "all our plugins and deps are not compatible with 9.x yet"
         }
     ],
-    "rangeStrategy": "auto",
     "lockFileMaintenance": {
         "enabled": true
-    },
-    "automerge": true
+    }
 }


### PR DESCRIPTION
### Related Issue

[CIA-612](https://coveord.atlassian.net/browse/cia-612)

### Proposed Changes

This PR modifies your Renovate config to use only allowed automerge rules by introducing the auto-merge managed preset. This comes from a move to repatriate all auto-merge rule to a centrally managed preset. More precisely in your case, it removes the top level `automerge: true` and replaces it with the centrally managed preset.

Some bonus changes include removing configurations that were set to their default value or already included in the managed preset. This makes your config leaner.

[CIA-612]: https://coveord.atlassian.net/browse/CIA-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ