### PR TITLE
feat(api-keys): add endpoints for bulk operations

### DIFF
--- a/src/resources/ApiKeys/ApiKeys.ts
+++ b/src/resources/ApiKeys/ApiKeys.ts
@@ -27,8 +27,11 @@ export default class ApiKey extends Resource {
         return this.api.put(path, apiKey);
     }
 
-    delete(apiKeyId: string) {
-        return this.api.delete(`${ApiKey.baseUrl}/${apiKeyId}`);
+    delete(apiKeyIds: string | string[]) {
+        if (Array.isArray(apiKeyIds) && apiKeyIds.length > 1) {
+            return this.api.post<void>(`${ApiKey.baseUrl}/delete/bulk`, apiKeyIds);
+        }
+        return this.api.delete<void>(`${ApiKey.baseUrl}/${Array.isArray(apiKeyIds) ? apiKeyIds[0] : apiKeyIds}`);
     }
 
     extend(apiKeyId: string) {
@@ -37,5 +40,19 @@ export default class ApiKey extends Resource {
 
     duplicate(apiKeyId: string, options: DuplicateApiKeyOptions) {
         return this.api.put<ApiKeyModel>(this.buildPath(`${ApiKey.baseUrl}/${apiKeyId}/duplicate`), options);
+    }
+
+    activate(apiKeyIds: string | string[]) {
+        if (Array.isArray(apiKeyIds) && apiKeyIds.length > 1) {
+            return this.api.put<void>(`${ApiKey.baseUrl}/activate/bulk`, apiKeyIds);
+        }
+        return this.api.put<void>(`${ApiKey.baseUrl}/${Array.isArray(apiKeyIds) ? apiKeyIds[0] : apiKeyIds}/activate`);
+    }
+
+    disable(apiKeyIds: string | string[]) {
+        if (Array.isArray(apiKeyIds) && apiKeyIds.length > 1) {
+            return this.api.put<void>(`${ApiKey.baseUrl}/disable/bulk`, apiKeyIds);
+        }
+        return this.api.put<void>(`${ApiKey.baseUrl}/${Array.isArray(apiKeyIds) ? apiKeyIds[0] : apiKeyIds}/disable`);
     }
 }

--- a/src/resources/ApiKeys/test/ApiKeys.spec.ts
+++ b/src/resources/ApiKeys/test/ApiKeys.spec.ts
@@ -62,12 +62,26 @@ describe('ApiKey', () => {
     });
 
     describe('delete', () => {
-        it('should make a DELETE call to the specific ApiKey url', async () => {
+        it('makes a DELETE call to DELETE call to /rest/organizations/:orgId/apikeys/:id when only one id is specified', async () => {
             const apiKeyToDeleteId = 'ApiKey-to-be-deleted';
 
             await apiKey.delete(apiKeyToDeleteId);
             expect(api.delete).toHaveBeenCalledTimes(1);
             expect(api.delete).toHaveBeenCalledWith(`${ApiKey.baseUrl}/${apiKeyToDeleteId}`);
+        });
+
+        it('makes a DELETE call to /rest/organizations/:orgId/apikeys/:id when an array of one id is provided', async () => {
+            const apiKeyToDeleteId = 'ApiKey-to-be-deleted';
+            await apiKey.delete([apiKeyToDeleteId]);
+            expect(api.delete).toHaveBeenCalledTimes(1);
+            expect(api.delete).toHaveBeenCalledWith(`${ApiKey.baseUrl}/${apiKeyToDeleteId}`);
+        });
+
+        it('makes a POST call to /rest/organizations/:orgId/apikeys/delete/bulk when multiple ids are provided', async () => {
+            const apiKeysToDelete = ['api-key-id-one', 'api-key-id-two'];
+            await apiKey.delete(apiKeysToDelete);
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(`${ApiKey.baseUrl}/delete/bulk`, apiKeysToDelete);
         });
     });
 
@@ -118,6 +132,52 @@ describe('ApiKey', () => {
             await apiKey.extend(apiKeyModel.id);
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(`${ApiKey.baseUrl}/${apiKeyModel.id}/activation/extend`);
+        });
+    });
+
+    describe('activate', () => {
+        it('makes a PUT call to /rest/organizations/:orgId/apikeys/:id/activate when only one id is provided', async () => {
+            await apiKey.activate('api-key-id');
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${ApiKey.baseUrl}/api-key-id/activate`);
+        });
+
+        it('makes a PUT call to /rest/organizations/:orgId/apikeys/:id/activate when an array of one id is provided', async () => {
+            await apiKey.activate(['api-key-id']);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${ApiKey.baseUrl}/api-key-id/activate`);
+        });
+
+        it('makes a PUT call to /rest/organizations/:orgId/apikeys/activate/bulk when multiple ids are provided', async () => {
+            await apiKey.activate(['api-key-id-one', 'api-key-id-two']);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${ApiKey.baseUrl}/activate/bulk`, [
+                'api-key-id-one',
+                'api-key-id-two',
+            ]);
+        });
+    });
+
+    describe('disable', () => {
+        it('makes a PUT call to /rest/organizations/:orgId/apikeys/:id/disable when only one id is provided', async () => {
+            await apiKey.disable('api-key-id');
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${ApiKey.baseUrl}/api-key-id/disable`);
+        });
+
+        it('makes a PUT call to /rest/organizations/:orgId/apikeys/:id/disable when an array of one id is provided', async () => {
+            await apiKey.disable(['api-key-id']);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${ApiKey.baseUrl}/api-key-id/disable`);
+        });
+
+        it('makes a PUT call to /rest/organizations/:orgId/apikeys/disable/bulk when multiple ids are provided', async () => {
+            await apiKey.disable(['api-key-id-one', 'api-key-id-two']);
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(`${ApiKey.baseUrl}/disable/bulk`, [
+                'api-key-id-one',
+                'api-key-id-two',
+            ]);
         });
     });
 });


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

Add endpoints for bulk delete, bulk activate, and bulk disable on API keys resource.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
