### PR TITLE
feat(api-keys): adding should show in consumption dashboard to entitlement model

### DIFF
--- a/src/resources/License/LicenseInterfaces.ts
+++ b/src/resources/License/LicenseInterfaces.ts
@@ -100,21 +100,70 @@ export interface LicenseModel {
 }
 
 export interface EntitlementModel {
+    /**
+     * Limit of items
+     */
     itemLimit: number;
+    /**
+     * Limit of Queries Per Month for product listing
+     */
     lrpmLimit: number;
+    /**
+     * The unique identifier of the entitlement
+     */
     id: string;
+    /**
+     * The unique identifier of the product on Salesforce
+     */
     productId: string;
+    /**
+     * Name of the product on Salesforce
+     */
     productName: string;
+    /**
+     * Unit on which the price is based on
+     */
     pricingUnit: string;
+    /**
+     * Name of the product on Coveo
+     */
     displayName: string;
+    /**
+     * Queries per month limit
+     */
     qpmLimit: number;
+    /**
+     * Reommendation Limit
+     */
     recommendationLimit: number;
+    /**
+     * Status of the entitlement
+     */
     status: string;
+    /**
+     * Flag that informs if entitlement allow unlimited Queries Per Month
+     */
     unlimitedQPM: boolean;
+    /**
+     * Flag that informs if entitlement allow unlimited recommendations
+     */
     unlimitedRecommendations: boolean;
+    /**
+     * Flag that informs if entitlement allow unlimited users
+     */
     unlimitedUsers: boolean;
-    useCase: string;
+    /**
+     * Use case of the entitlement
+     */
+    useCase: string;    
+    /**
+     * Limit of users for the entitlement
+     */
     userLimit: number;
+    /**
+     * Flag to control if the entitlement should be shown in the consumption dashboard
+     */
+    shouldShowInConsumptionDashboard: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

https://coveord.atlassian.net/browse/ORG-775

Adding shouldShowInConsumptionDashboard to EntitlementModel

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
