### PR TITLE
feat(api-keys): +listing apikey eligibility call endpoint

### DIFF
--- a/src/resources/ApiKeyTemplate/ApiKeyTemplate.ts
+++ b/src/resources/ApiKeyTemplate/ApiKeyTemplate.ts
@@ -1,10 +1,16 @@
 import Resource from '../Resource.js';
-import {ApiKeyTemplateModel} from './ApiKeyTemplateInterface.js';
+import {ApiKeyTemplateEligibilityResponseModel, ApiKeyTemplateModel} from './ApiKeyTemplateInterface.js';
 
 export default class ApiKeyTemplate extends Resource {
     static baseUrl = '/rest/templates/apikeys';
 
     get(apiKeyTemplateId: string) {
         return this.api.get<ApiKeyTemplateModel>(`${ApiKeyTemplate.baseUrl}/${apiKeyTemplateId}`);
+    }
+
+    listAPIKeysEligibility() {
+        return this.api.get<ApiKeyTemplateEligibilityResponseModel[]>(
+            `${ApiKeyTemplate.baseUrl}/privileges/eligibility`,
+        );
     }
 }

--- a/src/resources/ApiKeyTemplate/ApiKeyTemplateInterface.ts
+++ b/src/resources/ApiKeyTemplate/ApiKeyTemplateInterface.ts
@@ -26,3 +26,18 @@ export interface ApiKeyTemplateModel {
      */
     privileges?: PrivilegeModel[];
 }
+
+export interface ApiKeyTemplateEligibilityResponseModel {
+    /**
+     * The id of the template
+     */
+    id: string;
+    /**
+     * The list of privileges missing to access the template
+     */
+    missingPrivileges: PrivilegeModel[];
+    /**
+     * If the user can generate an API key from this template
+     */
+    canGenerate: boolean;
+}

--- a/src/resources/ApiKeyTemplate/test/ApiKeyTemplate.spec.ts
+++ b/src/resources/ApiKeyTemplate/test/ApiKeyTemplate.spec.ts
@@ -22,4 +22,12 @@ describe('ApiKeyTemplateModel', () => {
             expect(api.get).toHaveBeenCalledWith(`${ApiKeyTemplate.baseUrl}/${apiKeyTemplateToGetId}`);
         });
     });
+
+    describe('listAPIKeysEligibility', () => {
+        it('should make a GET call to the listAPIKeysEligibility endpoint', async () => {
+            await apiKeyTemplate.listAPIKeysEligibility();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${ApiKeyTemplate.baseUrl}/privileges/eligibility`);
+        });
+    });
 });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/ADUI-10325

This PR adds the newly made call to fetch the list of missing privileges when a user is creating (from scratch or from existing) an api key from a template.

As of right now, the user has access to go through all the steps to create a template api key (or create from existing) only to get denied at the very end for missing privileges of what that template key provides. This call will make it possible to prevent even starting the process for keys that require privileges that the user does not have

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
