### PR TITLE
fix(api-key): fix baseurl

### DIFF
--- a/src/resources/ApiKeyTemplate/ApiKeyTemplate.ts
+++ b/src/resources/ApiKeyTemplate/ApiKeyTemplate.ts
@@ -1,8 +1,9 @@
+import API from '../../APICore.js';
 import Resource from '../Resource.js';
 import {ApiKeyTemplateEligibilityResponseModel, ApiKeyTemplateModel} from './ApiKeyTemplateInterface.js';
 
 export default class ApiKeyTemplate extends Resource {
-    static baseUrl = '/rest/templates/apikeys';
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/templates/apikeys`;
 
     get(apiKeyTemplateId: string) {
         return this.api.get<ApiKeyTemplateModel>(`${ApiKeyTemplate.baseUrl}/${apiKeyTemplateId}`);


### PR DESCRIPTION
Coming from this [PR](https://github.com/coveo/platform-client/pull/889). The first implementation did not correctly set the baseURL. This pr fixes it (by adding `/rest/organizations/:orgId`.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
