### PR TITLE
feat(modeldetails): add modelDetails for CPR

### DIFF
--- a/src/resources/MachineLearning/ModelDetailedInfo/details/ModelDetailsBuildingStats.ts
+++ b/src/resources/MachineLearning/ModelDetailedInfo/details/ModelDetailsBuildingStats.ts
@@ -26,6 +26,15 @@ export interface ModelDetailsBuildingStats {
     invalidHtmlDocumentCount?: number;
     documentWithoutIdCount?: number;
     documentWithDuplicatedIdCount?: number;
+    documentsWithChunksCount?: number;
+    documentsWithChunksRatio?: number;
+    chunkCount?: number;
+    meanChunkLength?: number;
+    chunksPerDocument?: {
+        min?: number;
+        max?: number;
+        mean?: number;
+    };
     commerceEventCounts?: ModelDetailsCommerceEvents;
     modelDetailedStatsPerSource?: ModelDetailsStatsPerSource[];
 }

--- a/src/resources/MachineLearning/ModelDetailedInfo/details/ModelDetailsStatsPerSource.ts
+++ b/src/resources/MachineLearning/ModelDetailedInfo/details/ModelDetailsStatsPerSource.ts
@@ -4,4 +4,12 @@ export interface ModelDetailsStatsPerSource {
     invalidHtmlDocumentCount: number;
     documentWithoutIdCount: number;
     documentWithDuplicatedIdCount: number;
+    documentsWithChunksCount?: number;
+    documentsWithChunksRatio?: number;
+    chunkCount?: number;
+    chunksPerDocument?: {
+        min?: number;
+        max?: number;
+        mean?: number;
+    };
 }


### PR DESCRIPTION
New properties with more specific names are now available for consumption by CPR models

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

The list of property changes can be seen here:
![image](https://github.com/user-attachments/assets/5bdcd5f0-381a-407a-a4e4-b0f9a4d870af)

There's an open PR with the changes from the BE but since they're all optional this PR can go first and will unblock working in the adui.

https://github.com/coveo-platform/ml-config-service/pull/2415


### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))

Technically they're already in production on swagger and can be seen on existing models, the addition of it in mlconfig only allows the adui to consume the properties from our own definitions

-   [x] JSDoc annotates each property added in the exported interfaces

Not applicable, we do not document these properties as can be seen with the other properties in this interface.

-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
