### PR TITLE
feat(statement-groups): add conditionDetailed property

### DIFF
--- a/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
+++ b/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
@@ -47,8 +47,7 @@ interface StatementGroupModelBase {
     /**
      * A structured representation of the condition
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    conditionDetailed?: any;
+    conditionDetailed?: unknown;
     /**
      * Date of creation
      * Format: ISO-8601

--- a/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
+++ b/src/resources/Pipelines/StatementGroups/StatementGroupsInterfaces.ts
@@ -44,7 +44,11 @@ interface StatementGroupModelBase {
      * The definition of the condition that must be satisfied for a request to be processed by the statement group.
      */
     conditionDefinition?: string;
-
+    /**
+     * A structured representation of the condition
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    conditionDetailed?: any;
     /**
      * Date of creation
      * Format: ISO-8601


### PR DESCRIPTION
### Description

[SEARCHAPI-11324](https://coveord.atlassian.net/jira/software/c/projects/SEARCHAPI/boards/1092?quickFilter=3461&selectedIssue=SEARCHAPI-11324)
 
Add new `conditionDetailed` property in the `StatementGroup` model.

<img width="1050" alt="Screenshot 2024-12-06 at 2 13 47 PM" src="https://github.com/user-attachments/assets/f99997c1-3dde-40dc-bf2d-204bb744115f">

It was added in the backend as you can see in [Swagger](https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20API#/Statement%20groups/listStatementGroups).

**Note:** it is currently typed as `any` as the other places where the "detailed" condition object is returned. The API doesn't provide a definitive type yet but it is currently being worked on. Once the API defines the schema, I'll update `platform-client` to add the proper interfaces.

### Acceptance Criteria

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))


[SEARCHAPI-11324]: https://coveord.atlassian.net/browse/SEARCHAPI-11324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ