### PR TITLE
fix(modeldetails): renamed the property to the expected value

### DIFF
--- a/src/resources/MachineLearning/ModelDetailedInfo/details/ModelDetails.ts
+++ b/src/resources/MachineLearning/ModelDetailedInfo/details/ModelDetails.ts
@@ -13,7 +13,7 @@ export interface ModelDetails {
     languages?: Map<string, ModelDetailsLanguages>;
     candidateExamples?: Map<string, string[]>;
     candidatesPerLanguages?: Map<string, number>;
-    minClickCountPerLang?: Map<string, number>;
+    minClickCountByLang?: Map<string, number>;
     subModels?: {[key: string]: ModelDetailsSubModels};
     candidates?: number;
     modelDetailedBuildingStats?: ModelDetailsBuildingStats;


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

Property was wrongly baptised, expected property name is 
![image](https://github.com/user-attachments/assets/e437639d-0d28-41cd-aef5-a72406b24f1c)

Technically it's not a breaking change since the property mapped to nothing before, and so changing the name doesn't break the change since nothing points to nothing
 

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
