### PR TITLE
feat(mlx): add the modelassociations call

### DIFF
--- a/src/resources/MachineLearning/MachineLearning.ts
+++ b/src/resources/MachineLearning/MachineLearning.ts
@@ -4,6 +4,7 @@ import CaseClassificationConfiguration from './CaseClassificationConfiguration/C
 import DNEConfiguration from './DNEConfiguration/DNEConfiguration.js';
 import IAPRConfiguration from './IAPRConfiguration/IAPRConfiguration.js';
 import {MLModelCreated, RegistrationModel} from './MachineLearningInterfaces.js';
+import ModelAssociations from './ModelAssociations/ModelAssociations.js';
 import ModelDetailedInfo from './ModelDetailedInfo/ModelDetailedInfo.js';
 import ModelListing from './ModelListing/ModelListing.js';
 import Models from './Models/Models.js';
@@ -27,6 +28,7 @@ export default class MachineLearning extends Resource {
     relevanceGenerativeAnsweringConfig: RelevanceGenerativeAnsweringConfiguration;
     semanticEncoderConfig: SemanticEncoderConfiguration;
     modelDetailedInfo: ModelDetailedInfo;
+    modelAssociations: ModelAssociations;
 
     constructor(
         protected api: API,
@@ -45,6 +47,7 @@ export default class MachineLearning extends Resource {
         this.relevanceGenerativeAnsweringConfig = new RelevanceGenerativeAnsweringConfiguration(api, serverlessApi);
         this.semanticEncoderConfig = new SemanticEncoderConfiguration(api, serverlessApi);
         this.modelDetailedInfo = new ModelDetailedInfo(api, serverlessApi);
+        this.modelAssociations = new ModelAssociations(api, serverlessApi);
     }
 
     register(registration: RegistrationModel) {

--- a/src/resources/MachineLearning/ModelAssociations/ModelAssociations.ts
+++ b/src/resources/MachineLearning/ModelAssociations/ModelAssociations.ts
@@ -1,0 +1,18 @@
+import API from '../../../APICore.js';
+import {PageModel} from '../../BaseInterfaces.js';
+import Resource from '../../Resource.js';
+import {AssociationItem, ModelAssociationsListParams} from './ModelAssociationsInterfaces.js';
+
+export default class ModelAssociations extends Resource {
+    static baseUrl = `/rest/organizations/${API.orgPlaceholder}/machinelearning/configuration/querypipelines`;
+
+    /**
+     * Lists the organization associations corresponding to the specified pipelineId.
+     * @param pipelineId The unique identifier of the query pipeline.
+     * @param params The pagination parameters.
+     * @returns A list of associated models
+     */
+    list(pipelineId: string, params: ModelAssociationsListParams): Promise<PageModel<AssociationItem>> {
+        return this.api.get(this.buildPath(`${ModelAssociations.baseUrl}/${pipelineId}/associations`, params));
+    }
+}

--- a/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
+++ b/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
@@ -12,15 +12,51 @@ export interface ModelAssociationsListParams {
     pageSize: number;
 }
 export interface AssociationItem {
+    /**
+     * The unique identifier of the model association.
+     */
     associationId: string;
+    /**
+     * The unique identifier of the target machine learning model.
+     */
     modelId: string;
+    /**
+     * The id of the engine.
+     */
     engineId?: string;
+    /**
+     * The name of the model configuration.
+     */
     modelDisplayName?: string;
+    /**
+     * The current status of the model.
+     * @example { modelStatus: "BUILDING", daysUntilArchival : 3 }
+     */
     modelStatusInfo?: {
+        /**
+         * The status of the model.
+         * @example "ACTIVE"
+         */
         modelStatus: MLModelStatus;
+        /**
+         * The remaining days until the model is archived.
+         */
+        daysUntilArchival?: number;
     };
+    /**
+     * The condition that must be met to trigger the model association.
+     */
     condition?: ConditionModel;
+    /**
+     * The position at which this model association is evaluated in the query pipeline, relative to other model associations.
+     */
     position: number;
+    /**
+     * Whether the Coveo Administration Console should show the advanced configuration for this association.
+     */
     useAdvancedConfiguration?: boolean;
+    /**
+     * The additional parameters to send to Coveo ML.
+     */
     customQueryParameters?: {submodel: string};
 }

--- a/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
+++ b/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
@@ -1,0 +1,26 @@
+import {ConditionModel} from '../../Pipelines/index.js';
+import {MLModelStatus} from '../MachineLearningInterfaces.js';
+
+export interface ModelAssociationsListParams {
+    /*
+     * The 0-based number of the page of results to list. Default: 0
+     */
+    page: number;
+    /*
+     * The maximum number of results to include per page.. Default: 100
+     */
+    pageSize: number;
+}
+export interface AssociationItem {
+    associationId: string;
+    modelId: string;
+    engineId?: string;
+    modelDisplayName?: string;
+    modelStatusInfo?: {
+        modelStatus: MLModelStatus;
+    };
+    condition?: ConditionModel;
+    position: number;
+    useAdvancedConfiguration?: boolean;
+    customQueryParameters?: {submodel: string};
+}

--- a/src/resources/MachineLearning/ModelAssociations/index.ts
+++ b/src/resources/MachineLearning/ModelAssociations/index.ts
@@ -1,0 +1,2 @@
+export * from './ModelAssociations.js';
+export * from './ModelAssociationsInterfaces.js';

--- a/src/resources/MachineLearning/ModelAssociations/tests/ModelAssociations.spec.ts
+++ b/src/resources/MachineLearning/ModelAssociations/tests/ModelAssociations.spec.ts
@@ -1,0 +1,26 @@
+import API from '../../../../APICore.js';
+import ModelAssociations from '../ModelAssociations.js';
+
+jest.mock('../../../../APICore');
+
+describe('ModelAssociations', () => {
+    let modelAssociations: ModelAssociations;
+    const api = new API({accessToken: 'some-token'});
+    const serverlessApi = new API({accessToken: 'some-token'});
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        modelAssociations = new ModelAssociations(api, serverlessApi);
+    });
+
+    describe('createPQSModel', () => {
+        it('should make a GET call to the specific IAPRConfiguration url', async () => {
+            const pipelineId = '123';
+            await modelAssociations.list(pipelineId, {page: 1, pageSize: 25});
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${ModelAssociations.baseUrl}/${pipelineId}/associations?page=1&pageSize=25`,
+            );
+        });
+    });
+});

--- a/src/resources/MachineLearning/index.ts
+++ b/src/resources/MachineLearning/index.ts
@@ -5,6 +5,7 @@ export * from './FilterConditions.js';
 export * from './IAPRConfiguration/index.js';
 export * from './MachineLearning.js';
 export * from './MachineLearningInterfaces.js';
+export * from './ModelAssociations/index.js';
 export * from './ModelDetailedInfo/index.js';
 export * from './ModelInformation/index.js';
 export * from './ModelListing/index.js';

--- a/src/resources/MachineLearning/tests/MachineLearning.spec.ts
+++ b/src/resources/MachineLearning/tests/MachineLearning.spec.ts
@@ -4,6 +4,7 @@ import DNEConfiguration from '../DNEConfiguration/DNEConfiguration.js';
 import IAPRConfiguration from '../IAPRConfiguration/IAPRConfiguration.js';
 import MachineLearning from '../MachineLearning.js';
 import {RegistrationModel} from '../MachineLearningInterfaces.js';
+import ModelAssociations from '../ModelAssociations/ModelAssociations.js';
 import ModelDetailedInfo from '../ModelDetailedInfo/ModelDetailedInfo.js';
 import Models from '../Models/Models.js';
 import PQSConfiguration from '../PQSConfiguration/PQSConfiguration.js';
@@ -71,5 +72,10 @@ describe('MachineLearning', () => {
     it('should register the modelDetailedInfo resource', () => {
         expect(ml.modelDetailedInfo).toBeDefined();
         expect(ml.modelDetailedInfo).toBeInstanceOf(ModelDetailedInfo);
+    });
+
+    it('should register the modelAssociations resource', () => {
+        expect(ml.modelAssociations).toBeDefined();
+        expect(ml.modelAssociations).toBeInstanceOf(ModelAssociations);
     });
 });


### PR DESCRIPTION
Add the model associations call
https://platform.cloud.coveo.com/docs?urls.primaryName=Machine%20Learning%20Configuration#/Model%20Associations/rest_organizations_paramId_machinelearning_configuration_querypipelines_paramId_associations_get
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
