### PR TITLE
feat(prapi): add new route for passage retrieval

### DIFF
--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -8,6 +8,8 @@ import {
     RestQueryParams,
     RestQueryResult,
     RestTokenParams,
+    RetrievePassagesParameters,
+    RetrievePassagesResponse,
     SearchListFieldsParams,
     SearchListFieldsResponse,
     SearchResponse,
@@ -17,16 +19,17 @@ import {
 import {ListFieldValuesBodyQueryParams, PostSearchQuerySuggestBodyParams} from './index.js';
 
 export default class Search extends Resource {
-    static baseUrl = `/rest/search/v2`;
+    static baseUrlV2 = `/rest/search/v2`;
+    static baseUrlV3 = `/rest/search/v3`;
 
     createToken(tokenParams: RestTokenParams) {
-        return this.api.post<TokenModel>(`${Search.baseUrl}/token?organizationId=${API.orgPlaceholder}`, tokenParams);
+        return this.api.post<TokenModel>(`${Search.baseUrlV2}/token?organizationId=${API.orgPlaceholder}`, tokenParams);
     }
 
     listFields(params?: SearchListFieldsParams) {
         return this.api.get<SearchListFieldsResponse>(
             this.buildPath(
-                `${Search.baseUrl}/fields`,
+                `${Search.baseUrlV2}/fields`,
                 {
                     ...params,
                     organizationId: params?.organizationId ?? this.api.organizationId,
@@ -38,7 +41,7 @@ export default class Search extends Resource {
 
     getFieldValues(fieldName: string, params?: ListFieldValuesBodyQueryParams) {
         return this.api.get<ListFieldValuesResponse>(
-            this.buildPath(`${Search.baseUrl}/values`, {
+            this.buildPath(`${Search.baseUrlV2}/values`, {
                 field: encodeURI(`${fieldName}`),
                 ...params,
                 organizationId: params?.organizationId ?? this.api.organizationId,
@@ -53,7 +56,7 @@ export default class Search extends Resource {
         const {viewAllContent, ...bodyParameters} = restQueryParameters;
 
         return this.api.post<SearchResponse>(
-            this.buildPath(Search.baseUrl, {
+            this.buildPath(Search.baseUrlV2, {
                 organizationId: this.api.organizationId,
                 viewAllContent: viewAllContent ? 1 : undefined,
             }),
@@ -71,7 +74,7 @@ export default class Search extends Resource {
         const {viewAllContent, ...bodyParameters} = restQueryParameters;
 
         return this.api.post<Blob>(
-            this.buildPath(Search.baseUrl, {
+            this.buildPath(Search.baseUrlV2, {
                 organizationId: this.api.organizationId,
                 viewAllContent: viewAllContent ? 1 : undefined,
             }),
@@ -82,7 +85,7 @@ export default class Search extends Resource {
 
     querySuggestPost(restQuerySuggestParameters: PostSearchQuerySuggestBodyParams) {
         return this.api.post<any>(
-            this.buildPath(`${Search.baseUrl}/querySuggest`, {
+            this.buildPath(`${Search.baseUrlV2}/querySuggest`, {
                 organizationId: this.api.organizationId,
             }),
             restQuerySuggestParameters,
@@ -104,7 +107,7 @@ export default class Search extends Resource {
         ...body
     }: ItemPreviewHtmlParameters) {
         return this.api.post<string>(
-            this.buildPath(`${Search.baseUrl}/html`, {
+            this.buildPath(`${Search.baseUrlV2}/html`, {
                 enableNavigation,
                 findNext,
                 findPrevious,
@@ -125,7 +128,7 @@ export default class Search extends Resource {
     getDocument(params: SingleItemParameters) {
         return this.api.get<RestQueryResult>(
             this.buildPath(
-                `${Search.baseUrl}/document`,
+                `${Search.baseUrlV2}/document`,
                 {
                     ...params,
                     organizationId: params.organizationId ?? this.api.organizationId,
@@ -142,9 +145,23 @@ export default class Search extends Resource {
         const {viewAllContent, organizationId, ...bodyParameters} = params;
 
         return this.api.post<RestFacetSearchResponse>(
-            this.buildPath(`${Search.baseUrl}/facet`, {
+            this.buildPath(`${Search.baseUrlV2}/facet`, {
                 organizationId: organizationId ?? this.api.organizationId,
                 viewAllContent,
+            }),
+            bodyParameters,
+        );
+    }
+
+    /**
+     * Retrieves the passage(s) for a particular query.
+     */
+    retrievePassages(params: RetrievePassagesParameters) {
+        const {organizationId, ...bodyParameters} = params;
+
+        return this.api.post<RetrievePassagesResponse>(
+            this.buildPath(`${Search.baseUrlV3}/passages/retrieve`, {
+                organizationId,
             }),
             bodyParameters,
         );

--- a/src/resources/Search/SearchInterfaces.ts
+++ b/src/resources/Search/SearchInterfaces.ts
@@ -2967,3 +2967,107 @@ export interface RestFacetSearchResponse {
      */
     moreValuesAvailable: boolean;
 }
+
+export interface RetrievePassagesParameters {
+    /**
+     * The unique identifier of the target Coveo Cloud organization.
+     * Specifying a value for this parameter is only necessary when you are authenticating the API call with an OAuth2 token.
+     */
+    organizationId?: string;
+
+    /**
+     * The query for which to retrieve the passage(s).
+     */
+    query: string;
+
+    /**
+     * A filter expression that will be applied during the first stage retrieval.
+     * The expression must comply with the Coveo Query Language (CQL) syntax.
+     */
+    filter?: string;
+
+    /**
+     * The fields to include in the response.
+     * When omitted, only the identifier of the document will be returned.
+     */
+    additionalFields?: string[];
+
+    /**
+     * The maximum number of passage(s) to retrieve.
+     */
+    maxPassages?: number;
+
+    /**
+     * The first level of origin of the request, typically the identifier of the graphical search interface from which the request originates.
+     * Coveo Machine Learning models use this information to provide contextually relevant output.
+     *
+     * Notes:
+     *
+     * - This parameter will be overridden if the search request is authenticated by a search token that enforces a specific pipeline, or a searchHub that routes queries to a specific pipeline via a query pipeline condition.
+     *
+     * - When logging a Search usage analytics event for a query, the originLevel1 field of that event should be set to the value of the searchHub search request parameter.
+     */
+    searchHub?: string;
+
+    /**
+     * Localization parameter.
+     */
+    localization: {
+        /**
+         * The locale of the current user. Must comply with IETF's BCP 47 definition.
+         * Coveo Machine Learning models use this information to provide contextually relevant output. Moreover, this information can be referred to in query expressions and QPL statements by using the $locale object.
+         * Note: When logging a Search usage analytics event, the language field of that event should match the language part of the locale value of the query (e.g., en-US in locale becomes en in language).
+         */
+        locale: string;
+
+        /**
+         * The [tz database identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) of the user's time zone. Used for interpreting dates in query expressions and retrieving passages.
+         */
+        timezone?: string;
+    };
+    context?: Record<string, string | string[]>;
+}
+
+export interface RetrievePassagesResponse {
+    /**
+     * The list of passages retrieved.
+     */
+    items: Passage[];
+
+    /**
+     * A unique identifier for the response. It can be used to track the response in logs or for debugging purposes.
+     */
+    responseId: string;
+}
+
+export interface Passage {
+    /**
+     * The text associated to this passage.
+     */
+    text: string;
+
+    /**
+     * A measure of how relevant a passage is to the query based on semantic similarity, as determined by the CPR model. The higher the value, the higher the relevance.
+     */
+    relevanceScore: number;
+
+    /**
+     * The document that contains this passage. By default, it includes only the title and primary ID of the document. If you specified additional fields in the request payload, they will be included here as well.
+     */
+    document: {
+        /**
+         * The title of the document associated to this passage.
+         */
+        title: string;
+
+        /**
+         * The primary ID of the document associated to this passage.
+         */
+        primaryid: string;
+
+        /**
+         * Fields that were requested in the additionalFields parameter of the request.
+         */
+        [key: string]: any;
+    };
+}

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -1,7 +1,7 @@
 import API from '../../../APICore.js';
 import {RestUserIdType} from '../../Enums.js';
 import Search from '../Search.js';
-import {RestFacetSearchParameters} from '../SearchInterfaces.js';
+import {RestFacetSearchParameters, RetrievePassagesParameters} from '../SearchInterfaces.js';
 
 jest.mock('../../../APICore.js');
 
@@ -55,7 +55,7 @@ describe('Search', () => {
             search.createToken(tokenParams);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(
-                `${Search.baseUrl}/token?organizationId=${API.orgPlaceholder}`,
+                `${Search.baseUrlV2}/token?organizationId=${API.orgPlaceholder}`,
                 tokenParams,
             );
         });
@@ -66,7 +66,7 @@ describe('Search', () => {
             search.listFields({viewAllContent: true, organizationId: 'my-org', pipeline: 'pipeline'});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `${Search.baseUrl}/fields?viewAllContent=true&organizationId=my-org&pipeline=pipeline`,
+                `${Search.baseUrlV2}/fields?viewAllContent=true&organizationId=my-org&pipeline=pipeline`,
             );
         });
 
@@ -74,7 +74,7 @@ describe('Search', () => {
             search.listFields({viewAllContent: true, organizationId: 'my-org', pipeline: ''});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `${Search.baseUrl}/fields?viewAllContent=true&organizationId=my-org&pipeline=`,
+                `${Search.baseUrlV2}/fields?viewAllContent=true&organizationId=my-org&pipeline=`,
             );
         });
 
@@ -86,7 +86,7 @@ describe('Search', () => {
             search.listFields({});
 
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Search.baseUrl}/fields?organizationId=my-org`);
+            expect(api.get).toHaveBeenCalledWith(`${Search.baseUrlV2}/fields?organizationId=my-org`);
 
             // reset organizationId to old value
             Object.defineProperty(api, 'organizationId', {value: tempOrganizationId, writable: true});
@@ -104,7 +104,7 @@ describe('Search', () => {
             search.getFieldValues(fieldName, params);
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                `${Search.baseUrl}/values?field=author&ignoreAccents=false&commerce=%7B%22catalogId%22%3A%22test-id%22%2C%22filter%22%3A%22test-filter%22%2C%22operation%22%3A%22test-operation%22%7D&organizationId=test-org-id`,
+                `${Search.baseUrlV2}/values?field=author&ignoreAccents=false&commerce=%7B%22catalogId%22%3A%22test-id%22%2C%22filter%22%3A%22test-filter%22%2C%22operation%22%3A%22test-operation%22%7D&organizationId=test-org-id`,
             );
         });
     });
@@ -114,42 +114,42 @@ describe('Search', () => {
             const queryParams = {q: ''};
             search.query(queryParams);
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(Search.baseUrl, queryParams);
+            expect(api.post).toHaveBeenCalledWith(Search.baseUrlV2, queryParams);
         });
 
         it('should not add #viewAllContent query string parameter when not specified', () => {
             const queryParams = {q: ''};
             search.query(queryParams);
 
-            expect(api.post).toHaveBeenCalledWith(Search.baseUrl, {q: ''});
+            expect(api.post).toHaveBeenCalledWith(Search.baseUrlV2, {q: ''});
         });
 
         it('should add #viewAllContent=1 to the query string when set to true', () => {
             const queryParams = {q: '', viewAllContent: true};
             search.query(queryParams);
 
-            expect(api.post).toHaveBeenCalledWith(`${Search.baseUrl}?viewAllContent=1`, {q: ''});
+            expect(api.post).toHaveBeenCalledWith(`${Search.baseUrlV2}?viewAllContent=1`, {q: ''});
         });
 
         it('should add #viewAllContent=1 to the query string when set to 1', () => {
             const queryParams = {q: '', viewAllContent: 1};
             search.query(queryParams);
 
-            expect(api.post).toHaveBeenCalledWith(`${Search.baseUrl}?viewAllContent=1`, {q: ''});
+            expect(api.post).toHaveBeenCalledWith(`${Search.baseUrlV2}?viewAllContent=1`, {q: ''});
         });
 
         it('should not add #viewAllContent query string parameter when set to false', () => {
             const queryParams = {q: '', viewAllContent: false};
             search.query(queryParams);
 
-            expect(api.post).toHaveBeenCalledWith(Search.baseUrl, {q: ''});
+            expect(api.post).toHaveBeenCalledWith(Search.baseUrlV2, {q: ''});
         });
 
         it('should not add #viewAllContent query string parameter when set to 0', () => {
             const queryParams = {q: '', viewAllContent: 0};
             search.query(queryParams);
 
-            expect(api.post).toHaveBeenCalledWith(Search.baseUrl, {q: ''});
+            expect(api.post).toHaveBeenCalledWith(Search.baseUrlV2, {q: ''});
         });
     });
 
@@ -159,7 +159,7 @@ describe('Search', () => {
             search.exportQuery(queryParams);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(
-                Search.baseUrl,
+                Search.baseUrlV2,
                 {q: '', format: 'xlsx'},
                 {responseBodyFormat: 'blob'},
             );
@@ -171,7 +171,7 @@ describe('Search', () => {
             const queryParams = {q: ''};
             search.querySuggestPost(queryParams);
             expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(`${Search.baseUrl}/querySuggest`, queryParams);
+            expect(api.post).toHaveBeenCalledWith(`${Search.baseUrlV2}/querySuggest`, queryParams);
         });
     });
 
@@ -237,6 +237,45 @@ describe('Search', () => {
                 `/rest/search/v2/facet?organizationId=my-org`,
                 searchFacetRequest,
             );
+
+            // reset organizationId to old value
+            Object.defineProperty(api, 'organizationId', {value: tempOrganizationId, writable: true});
+        });
+    });
+
+    describe('retrievePassages', () => {
+        const retrievePassageRequest: RetrievePassagesParameters = {
+            query: 'What are the benefits of using solar energy?',
+            filter: '@source=="acme"',
+            additionalFields: ['clickableuri'],
+            maxPassages: 5,
+            searchHub: 'Main',
+            localization: {
+                locale: 'en-CA',
+                timezone: 'America/Montreal',
+            },
+            context: {
+                userAgeRange: '25-35',
+                userRoles: ['PremiumCustomer', 'ProductReviewer'],
+            },
+        };
+        it('makes a post call to the search facet endpoint', () => {
+            search.retrievePassages({...retrievePassageRequest, organizationId: 'specific-org-id'});
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenLastCalledWith(
+                `/rest/search/v3/passages/retrieve?organizationId=specific-org-id`,
+                retrievePassageRequest,
+            );
+        });
+        it('not adds the organizationId query param from the config if missing in the arguments', () => {
+            const tempOrganizationId = api.organizationId;
+            // change the value of organizationId on the mock
+            Object.defineProperty(api, 'organizationId', {value: 'my-org', writable: true});
+
+            search.retrievePassages(retrievePassageRequest);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenLastCalledWith(`/rest/search/v3/passages/retrieve`, retrievePassageRequest);
 
             // reset organizationId to old value
             Object.defineProperty(api, 'organizationId', {value: tempOrganizationId, writable: true});


### PR DESCRIPTION
# Description

- Update the search handler to deal with v2 and v3 routes.
- Add the new interfaces + new handler for the passage retrieval.

To be merged on Jan 31st for the GA.

# Testing

Tested the E2E loop locally:
![image](https://github.com/user-attachments/assets/c2a87ee6-42a2-4158-8ebc-4e041002e1dc)
![image](https://github.com/user-attachments/assets/5e5ab652-ec0f-43ce-babe-fd31b9d39ef7)


<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
