### PR TITLE
feat(UA-9879): changed the type of tracking ids to (string | null)

### DIFF
--- a/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
+++ b/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
@@ -1,7 +1,7 @@
 import {Paginated} from '../../BaseInterfaces.js';
 
 export interface PropertyModel {
-    trackingId: string | null;
+    trackingId: string | null ;
     displayName: string;
 }
 

--- a/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
+++ b/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
@@ -1,7 +1,7 @@
 import {Paginated} from '../../BaseInterfaces.js';
 
 export interface PropertyModel {
-    trackingId: string | null ;
+    trackingId: string | null;
     displayName: string;
 }
 

--- a/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
+++ b/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
@@ -1,7 +1,7 @@
 import {Paginated} from '../../BaseInterfaces.js';
 
 export interface PropertyModel {
-    trackingId: string;
+    trackingId: string | null;
     displayName: string;
 }
 


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

# UA-9879 Made tracking ids nullable

We're in the process of making tracking Id nullable, this is just a small PR so that the analytic admin service API interface reflect this change. 

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
