### PR TITLE
feat(mlx): add deprecation warning for RecommendationsPerLanguage in platform-client

### DIFF
--- a/src/resources/MachineLearning/ModelDetailedInfo/details/ModelDetails.ts
+++ b/src/resources/MachineLearning/ModelDetailedInfo/details/ModelDetails.ts
@@ -1,12 +1,15 @@
 import {ModelDetailsBuildingStats} from './ModelDetailsBuildingStats.js';
 import {ModelDetailsLanguages} from './ModelDetailsLanguages.js';
-import {ModelDetailsSubModels} from './ModelDetailsSubModels.js';
 import {ModelDetailsPreparationDetails} from './ModelDetailsPreparationDetails.js';
+import {ModelDetailsSubModels} from './ModelDetailsSubModels.js';
 import {ModelDetailsTrainingDetails} from './ModelDetailsTrainingDetails.js';
 
 export interface ModelDetails {
     possibleRecommendations?: number;
     totalQueries?: number;
+    /**
+     * @deprecated Recommendations language support is disabled
+     */
     recommendationsPerLanguage?: Record<string, number>;
     userContextFields?: string[];
     contentIDKeys?: string[];


### PR DESCRIPTION
[Disable Content Recs language by default](https://coveord.atlassian.net/browse/COREAI-941)

There is a PR in admin-ui to remove the use of this value : https://github.com/coveo-platform/admin-ui/pull/13906
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
