### PR TITLE
feat(UA-9955): added the includeDefault param to the list properties call

### DIFF
--- a/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
+++ b/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
@@ -11,4 +11,5 @@ export interface PropertiesResponseMessage {
 
 export interface ListPropertiesParams extends Paginated {
     filter?: string;
+    includeDefault?: boolean;
 }


### PR DESCRIPTION
feat(UA-9955): added the includeDefault param to the list properties call

Small update to add the new `incluideDefault` param to our properties list call.

The parameter can be seen here in Swagger: https://platform.cloud.coveo.com/docs?urls.primaryName=Analytics%20Admin%20Service

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
