### PR TITLE
feat(source): add call to get default document config

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -363,6 +363,11 @@ export enum DocumentPermissionState {
     WARNING = 'WARNING',
 }
 
+export enum DocumentConfigurationType {
+    DEFAULT = 'DEFAULT',
+    PUSH = 'PUSH',
+}
+
 export enum SourceExtensionActionOnError {
     REJECT_DOCUMENT = 'REJECT_DOCUMENT',
     SKIP_EXTENSION = 'SKIP_EXTENSION',

--- a/src/resources/Sources/Sources.ts
+++ b/src/resources/Sources/Sources.ts
@@ -9,6 +9,8 @@ import SourcesFields from './SourcesFields/SourcesFields.js';
 import {
     CreateSourceModel,
     CreateSourceOptions,
+    DocumentConfig,
+    GetDefaultDocumentConfigurationParams,
     LightSourceModel,
     ListOperationalStatusSourcesParams,
     ListSourcesParams,
@@ -61,6 +63,12 @@ export default class Sources extends Resource {
 
     createFromRaw(rawSourceConfig: RawSourceConfig, options?: CreateSourceOptions) {
         return this.api.post<{id: string}>(this.buildPath(`${Sources.baseUrl}/raw`, options), rawSourceConfig);
+    }
+
+    getDefaultDocumentConfiguration(params?: GetDefaultDocumentConfigurationParams) {
+        return this.api.get<DocumentConfig>(
+            this.buildPath(`${Sources.baseUrl}/document/configuration/default`, params),
+        );
     }
 
     delete(sourceId: string) {

--- a/src/resources/Sources/Sources.ts
+++ b/src/resources/Sources/Sources.ts
@@ -9,8 +9,8 @@ import SourcesFields from './SourcesFields/SourcesFields.js';
 import {
     CreateSourceModel,
     CreateSourceOptions,
+    DefaultDocumentConfigurationParams,
     DocumentConfig,
-    GetDefaultDocumentConfigurationParams,
     LightSourceModel,
     ListOperationalStatusSourcesParams,
     ListSourcesParams,
@@ -65,7 +65,7 @@ export default class Sources extends Resource {
         return this.api.post<{id: string}>(this.buildPath(`${Sources.baseUrl}/raw`, options), rawSourceConfig);
     }
 
-    getDefaultDocumentConfiguration(params?: GetDefaultDocumentConfigurationParams) {
+    getDefaultDocumentConfiguration(params?: DefaultDocumentConfigurationParams) {
         return this.api.get<DocumentConfig>(
             this.buildPath(`${Sources.baseUrl}/document/configuration/default`, params),
         );

--- a/src/resources/Sources/SourcesInterfaces.ts
+++ b/src/resources/Sources/SourcesInterfaces.ts
@@ -1,5 +1,6 @@
 import {GranularResource, Paginated} from '../BaseInterfaces.js';
 import {
+    DocumentConfigurationType,
     FilterHostType,
     FilterLastOperationResultType,
     FilterLastOperationType,
@@ -29,7 +30,7 @@ export interface ListOperationalStatusSourcesParams extends ListParams {
 }
 
 export interface GetDefaultDocumentConfigurationParams {
-    defaultDocumentConfigurationType?: 'DEFAULT' | 'PUSH';
+    defaultDocumentConfigurationType?: DocumentConfigurationType;
 }
 
 export interface ListSourcesParams extends ListParams {

--- a/src/resources/Sources/SourcesInterfaces.ts
+++ b/src/resources/Sources/SourcesInterfaces.ts
@@ -29,7 +29,7 @@ export interface ListOperationalStatusSourcesParams extends ListParams {
     sourceOperationalStatus: SourceOperationalStatus;
 }
 
-export interface GetDefaultDocumentConfigurationParams {
+export interface DefaultDocumentConfigurationParams {
     defaultDocumentConfigurationType?: DocumentConfigurationType;
 }
 

--- a/src/resources/Sources/SourcesInterfaces.ts
+++ b/src/resources/Sources/SourcesInterfaces.ts
@@ -28,6 +28,10 @@ export interface ListOperationalStatusSourcesParams extends ListParams {
     sourceOperationalStatus: SourceOperationalStatus;
 }
 
+export interface GetDefaultDocumentConfigurationParams {
+    defaultDocumentConfigurationType?: 'DEFAULT' | 'PUSH';
+}
+
 export interface ListSourcesParams extends ListParams {
     filterHostType?: FilterHostType;
     filterLastOperationResultType?: FilterLastOperationResultType;

--- a/src/resources/Sources/tests/Sources.spec.ts
+++ b/src/resources/Sources/tests/Sources.spec.ts
@@ -1,6 +1,6 @@
 import API from '../../../APICore.js';
 import {New} from '../../BaseInterfaces.js';
-import {ActivityOperation} from '../../Enums.js';
+import {ActivityOperation, DocumentConfigurationType} from '../../Enums.js';
 import {ScheduleModel} from '../../SecurityCache/index.js';
 import Sources from '../Sources.js';
 import SourcesDatasets from '../SourcesDatasets/SourcesDatasets.js';
@@ -81,7 +81,7 @@ describe('Sources', () => {
 
         it('should make a GET call to the default document configuration url for a PUSH document', async () => {
             const params: GetDefaultDocumentConfigurationParams = {
-                defaultDocumentConfigurationType: 'PUSH',
+                defaultDocumentConfigurationType: DocumentConfigurationType.PUSH,
             };
 
             await source.getDefaultDocumentConfiguration(params);

--- a/src/resources/Sources/tests/Sources.spec.ts
+++ b/src/resources/Sources/tests/Sources.spec.ts
@@ -8,7 +8,7 @@ import SourcesFeedback from '../SourcesFeedback/SourcesFeedback.js';
 import SourcesFields from '../SourcesFields/SourcesFields.js';
 import {
     CreateSourceModel,
-    GetDefaultDocumentConfigurationParams,
+    DefaultDocumentConfigurationParams,
     ListSourcesParams,
     RawSourceConfig,
 } from '../SourcesInterfaces.js';
@@ -80,7 +80,7 @@ describe('Sources', () => {
         });
 
         it('should make a GET call to the default document configuration url for a PUSH document', async () => {
-            const params: GetDefaultDocumentConfigurationParams = {
+            const params: DefaultDocumentConfigurationParams = {
                 defaultDocumentConfigurationType: DocumentConfigurationType.PUSH,
             };
 

--- a/src/resources/Sources/tests/Sources.spec.ts
+++ b/src/resources/Sources/tests/Sources.spec.ts
@@ -6,7 +6,12 @@ import Sources from '../Sources.js';
 import SourcesDatasets from '../SourcesDatasets/SourcesDatasets.js';
 import SourcesFeedback from '../SourcesFeedback/SourcesFeedback.js';
 import SourcesFields from '../SourcesFields/SourcesFields.js';
-import {CreateSourceModel, ListSourcesParams, RawSourceConfig} from '../SourcesInterfaces.js';
+import {
+    CreateSourceModel,
+    GetDefaultDocumentConfigurationParams,
+    ListSourcesParams,
+    RawSourceConfig,
+} from '../SourcesInterfaces.js';
 import SourcesMappings from '../SourcesMappings/SourcesMappings.js';
 import SourcesMetadata from '../SourcesMetadata/SourcesMetadata.js';
 
@@ -64,6 +69,26 @@ describe('Sources', () => {
             await source.createFromRaw(rawSource);
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(`${Sources.baseUrl}/raw`, rawSource);
+        });
+    });
+
+    describe('getDefaultDocumentConfiguration', () => {
+        it('should make a GET call to the default document configuration url', async () => {
+            await source.getDefaultDocumentConfiguration();
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Sources.baseUrl}/document/configuration/default`);
+        });
+
+        it('should make a GET call to the default document configuration url for a PUSH document', async () => {
+            const params: GetDefaultDocumentConfigurationParams = {
+                defaultDocumentConfigurationType: 'PUSH',
+            };
+
+            await source.getDefaultDocumentConfiguration(params);
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Sources.baseUrl}/document/configuration/default?defaultDocumentConfigurationType=PUSH`,
+            );
         });
     });
 


### PR DESCRIPTION
CTCORE-10773 [Doc Config] Add default document config call to Platform Client

This adds a call to get the default document configuration (`/rest/organizations/{organizationId}/sources/document/configuration/default`)

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
