### PR TITLE
feat: update the SecurityProviderType enum in platform-client

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -310,11 +310,17 @@ export enum ActivityOperation {
 }
 
 export enum SecurityProviderType {
+    /**
+     * @deprecated
+     */
     ACTIVE_DIRECTORY = 'ACTIVE_DIRECTORY',
     ACTIVE_DIRECTORY2 = 'ACTIVE_DIRECTORY2',
     BOX = 'BOX',
     CLAIMS = 'CLAIMS',
     CLAIMS_TO_EMAIL = 'CLAIMS_TO_EMAIL',
+    /**
+     * @deprecated
+     */
     CONFLUENCE = 'CONFLUENCE',
     CONFLUENCE2 = 'CONFLUENCE2',
     CUSTOM = 'CUSTOM',
@@ -325,8 +331,10 @@ export enum SecurityProviderType {
     FILE = 'file',
     GOOGLE_DRIVE_DOMAIN_WIDE = 'GOOGLE_DRIVE_DOMAIN_WIDE',
     GENERIC_REST = 'GENERIC_REST',
+    GRAPHQL = 'GRAPHQL',
     JIRA2 = 'JIRA2',
     JIVE = 'JIVE',
+    KHOROS_COMMUNITY = 'KHOROS_COMMUNITY',
     MICROSOFT_DYNAMICS = 'MICROSOFT_DYNAMICS',
     OFFICE365 = 'OFFICE365',
     SALESFORCE = 'SALESFORCE',
@@ -334,6 +342,7 @@ export enum SecurityProviderType {
     SHAREPOINT = 'SHAREPOINT',
     SHAREPOINT_ONLINE = 'SHAREPOINT_ONLINE',
     SITECORE = 'SITECORE',
+    SLACK = 'SLACK',
     ZENDESK = 'ZENDESK',
 }
 
@@ -1181,7 +1190,6 @@ export enum ApiKeyStatus {
 
 /**
  * Represents the different statuses an API key can be filtered by.
- * @enum {string}
  */
 export enum ApiKeyStatusFilter {
     /** Keys that are currently active and usable */


### PR DESCRIPTION
Update the `SecurityProviderType` enum to match the values of the [SecurityProviderType](https://github.com/coveo-platform/security-cache-service/blob/main/coveo-cloud-services-securitycache-api/src/main/java/com/coveo/cloud/securityprovider/model/SecurityProviderType.java) in the security-cache-service 
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
