### PR TITLE
feat(mlx): update platform-client to add activemodelbuilddate in modelstatusinfo

### DIFF
--- a/src/resources/MachineLearning/MachineLearningInterfaces.ts
+++ b/src/resources/MachineLearning/MachineLearningInterfaces.ts
@@ -118,12 +118,12 @@ export enum MLModelStatus {
 export interface MLModelStatusInfo {
     /**
      * The status of the model.
-     * @Example `ACTIVE`
+     * @example `ACTIVE`
      */
     modelStatus: MLModelStatus;
     /**
      * The remaining days until the model is archived.
-     * @Example `4`
+     * @example `4`
      */
     daysUntilArchival?: number;
     /**

--- a/src/resources/MachineLearning/MachineLearningInterfaces.ts
+++ b/src/resources/MachineLearning/MachineLearningInterfaces.ts
@@ -114,3 +114,21 @@ export enum MLModelStatus {
     ACTIVE = 'ACTIVE',
     INACTIVE = 'INACTIVE',
 }
+
+export interface MLModelStatusInfo {
+    /**
+     * The status of the model.
+     * @Example `ACTIVE`
+     */
+    modelStatus: MLModelStatus;
+    /**
+     * The remaining days until the model is archived.
+     * @Example `4`
+     */
+    daysUntilArchival?: number;
+    /**
+     * The epoch timestamp, in milliseconds, of when the active model was built.
+     * @example 1741726807000
+     */
+    activeModelBuildDate?: number;
+}

--- a/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
+++ b/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
@@ -1,5 +1,5 @@
 import {ConditionModel} from '../../Pipelines/index.js';
-import {MLModelStatus} from '../MachineLearningInterfaces.js';
+import {MLModelStatusInfo} from '../MachineLearningInterfaces.js';
 
 export interface ModelAssociationsListParams {
     /*
@@ -32,17 +32,7 @@ export interface AssociationItem {
      * The current status of the model.
      * @example { modelStatus: "BUILDING", daysUntilArchival : 3 }
      */
-    modelStatusInfo?: {
-        /**
-         * The status of the model.
-         * @example "ACTIVE"
-         */
-        modelStatus: MLModelStatus;
-        /**
-         * The remaining days until the model is archived.
-         */
-        daysUntilArchival?: number;
-    };
+    modelStatusInfo?: MLModelStatusInfo;
     /**
      * The condition that must be met to trigger the model association.
      */

--- a/src/resources/MachineLearning/ModelDetailedInfo/ModelDetailedInfoInterfaces.ts
+++ b/src/resources/MachineLearning/ModelDetailedInfo/ModelDetailedInfoInterfaces.ts
@@ -1,4 +1,4 @@
-import {MLModelStatus} from '../MachineLearningInterfaces.js';
+import {MLModelStatusInfo} from '../MachineLearningInterfaces.js';
 import {ModelDetails} from './details/ModelDetails.js';
 
 export interface ModelAssociation {
@@ -35,12 +35,7 @@ export interface ModelIssues {
     troubleshoot: string;
 }
 
-export interface ModelStatusInfo {
-    /**
-     * The status of the model.
-     * @example ACTIVE
-     */
-    modelStatus: MLModelStatus;
+export interface ModelStatusInfo extends Omit<MLModelStatusInfo, 'daysUntilArchival'> {
     /**
      * The remaining days until the model is archived.
      * @example 2

--- a/src/resources/MachineLearning/ModelDetailedInfo/ModelDetailedInfoInterfaces.ts
+++ b/src/resources/MachineLearning/ModelDetailedInfo/ModelDetailedInfoInterfaces.ts
@@ -35,7 +35,7 @@ export interface ModelIssues {
     troubleshoot: string;
 }
 
-export type ModelStatusInfo = MLModelStatusInfo & Required<Pick<MLModelStatusInfo, 'activeModelBuildDate'>>;
+export type ModelStatusInfo = MLModelStatusInfo & Required<Pick<MLModelStatusInfo, 'daysUntilArchival'>>;
 
 export interface ModelWithDetails {
     /**

--- a/src/resources/MachineLearning/ModelDetailedInfo/ModelDetailedInfoInterfaces.ts
+++ b/src/resources/MachineLearning/ModelDetailedInfo/ModelDetailedInfoInterfaces.ts
@@ -35,8 +35,7 @@ export interface ModelIssues {
     troubleshoot: string;
 }
 
-export type ModelStatusInfo = Required<Pick<MLModelStatusInfo, 'modelStatus' | 'daysUntilArchival'>> &
-    MLModelStatusInfo;
+export type ModelStatusInfo = MLModelStatusInfo & Required<Pick<MLModelStatusInfo, 'activeModelBuildDate'>>;
 
 export interface ModelWithDetails {
     /**

--- a/src/resources/MachineLearning/ModelDetailedInfo/ModelDetailedInfoInterfaces.ts
+++ b/src/resources/MachineLearning/ModelDetailedInfo/ModelDetailedInfoInterfaces.ts
@@ -35,13 +35,8 @@ export interface ModelIssues {
     troubleshoot: string;
 }
 
-export interface ModelStatusInfo extends Omit<MLModelStatusInfo, 'daysUntilArchival'> {
-    /**
-     * The remaining days until the model is archived.
-     * @example 2
-     */
-    daysUntilArchival: number;
-}
+export type ModelStatusInfo = Required<Pick<MLModelStatusInfo, 'modelStatus' | 'daysUntilArchival'>> &
+    MLModelStatusInfo;
 
 export interface ModelWithDetails {
     /**

--- a/src/resources/MachineLearning/ModelListing/ModelListingInterfaces.ts
+++ b/src/resources/MachineLearning/ModelListing/ModelListingInterfaces.ts
@@ -1,4 +1,4 @@
-import {MLModelStatus} from '../MachineLearningInterfaces.js';
+import {MLModelStatusInfo} from '../MachineLearningInterfaces.js';
 
 export interface MLListingModel {
     /**
@@ -50,19 +50,6 @@ export interface MLListingModel {
      * Specifies whether the model must be associated with a query pipeline to be effective.
      */
     requiresAssociation: boolean;
-}
-
-export interface MLModelStatusInfo {
-    /**
-     * The status of the model.
-     * @Example `ACTIVE`
-     */
-    modelStatus: MLModelStatus;
-    /**
-     * The remaining days until the model is archived.
-     * @Example `4`
-     */
-    daysUntilArchival?: number;
 }
 
 export interface MLModelAssociation {


### PR DESCRIPTION
Update to add `activeModelBuildDate` in `MLModelStatusInfo`, added in 3 interfaces listing, detailed, and modelassociation 
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
