### PR TITLE
feat(organization): add missing properties in OrganizationConfigurationModel

### DIFF
--- a/src/resources/Global/OrganizationConfigurations/OrganizationConfigurationInterfaces.ts
+++ b/src/resources/Global/OrganizationConfigurations/OrganizationConfigurationInterfaces.ts
@@ -3,4 +3,8 @@ export interface OrganizationConfigurationModel {
     mainRegions: string[];
     organizationId: string;
     satelliteRegions: string[];
+    primaryMainRegion: string;
+    distributedDns: string;
+    adminDns: string;
+    analyticsDns: string;
 }


### PR DESCRIPTION
### Description

Add missing properties in interface `OrganizationConfigurationModel`.

See it in [Swagger](https://platform.cloud.coveo.com/docs?urls.primaryName=Organization#/Organization%20Global%20Configuration/rest_global_organizations_paramId_get). 📖 

⚠️ **Note:** This schema is not documented in Swagger or in the [official documentation](https://docs.coveo.com/en/3433/api-reference/organization-api#tag/Organization-Global-Configuration/operation/getOrganizationGlobalConfiguration) so no JSDoc was added.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
    - **_See note above_** 
-   [ ] The proposed changes are covered by unit tests
    - _**Not applicable**_ 
-   [ ] Commits containing breaking changes a properly identified as such
    - _**No breaking changes. Only added new properties.**_ 
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
     - **_Not applicable_** 
-   [X] My merge commit message will be conventional (See [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/))
