### PR TITLE
fix: reason doesnt exist anymore + reason and url are optional

### DIFF
--- a/src/resources/ApiKeys/ApiKeysInterfaces.ts
+++ b/src/resources/ApiKeys/ApiKeysInterfaces.ts
@@ -1,11 +1,11 @@
 import {GranularResource, PrivilegeModel} from '../BaseInterfaces.js';
 import {
+    ApiKeyExposureReportReasonSource,
     ApiKeyExposureReportSeverity,
     ApiKeyPrivacyLevel,
     ApiKeyReportCreationType,
     ApiKeyStatus,
     ApiKeyStatusFilter,
-    ApiKeyExposureReportReasonSource,
 } from '../Enums.js';
 import {UserModel} from '../Users/UserInterfaces.js';
 
@@ -127,11 +127,6 @@ export interface ExposureReport {
      */
     severity: ApiKeyExposureReportSeverity;
     /**
-     * The reason behind the exposure report for a given API key
-     * @deprecated This field is deprecated and will be removed in a future version. Use the reasons field instead.
-     */
-    reason: string;
-    /**
      * The reasons behind the exposure report for a given API key
      */
     reasons: ApiKeyExposureReportReasonModel[];
@@ -158,7 +153,7 @@ export interface ApiKeyExposureReportReasonModel {
     /**
      * The reason behind the exposure report for a given API key
      */
-    reason: string;
+    reason?: string;
     /**
      * The source of which the exposure comes from
      */
@@ -166,7 +161,7 @@ export interface ApiKeyExposureReportReasonModel {
     /**
      * The url where the api key could be found
      */
-    url: string;
+    url?: string;
     /**
      * The date the exposure report was created
      */


### PR DESCRIPTION
* reason and url are optional in new `reasons` field
* reason field of exposure report is now irrelevant

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))
