### PR TITLE
feat(security-cache): move the enum SecurityProviderStatusType in platform-client

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -346,6 +346,13 @@ export enum SecurityProviderType {
     ZENDESK = 'ZENDESK',
 }
 
+export enum SecurityProviderStatusType {
+    PENDING_REFRESH = 'PENDING_REFRESH',
+    REFRESHING = 'REFRESHING',
+    IDLE = 'IDLE',
+    ERROR = 'ERROR',
+}
+
 export enum RestUserIdType {
     User = 'User',
     Group = 'Group',

--- a/src/resources/SecurityCache/SecurityCacheInterfaces.ts
+++ b/src/resources/SecurityCache/SecurityCacheInterfaces.ts
@@ -6,6 +6,7 @@ import {
     SecurityCacheFilteringMode,
     SecurityCacheStateOptions,
     SecurityProviderReferenceType,
+    SecurityProviderStatusType,
     SecurityProviderType,
 } from '../Enums.js';
 import {DataFile, ParameterModel, UserIdentityModel} from '../Sources/index.js';
@@ -120,7 +121,7 @@ export interface CurrentStatusModel {
     numberOfEntitiesProcessed?: number;
     refreshType?: string;
     totalNumberOfEntities?: number;
-    type?: string;
+    type?: SecurityProviderStatusType;
 }
 
 export interface SecurityProviderStatisticsModel {


### PR DESCRIPTION
Move the enum SecurityProviderStatusType in platform-client to delete the[ enum in admin-ui](https://github.com/coveo-platform/admin-ui/blob/master/pages/security-cache/src/constants/SecurityCacheConstants.ts)
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))
