### PR TITLE
fix(security-cache): update the interface of listSecurityProviderIdentities endpoint

### DIFF
--- a/src/resources/SecurityCache/SecurityCache.ts
+++ b/src/resources/SecurityCache/SecurityCache.ts
@@ -55,7 +55,7 @@ export default class SecurityCache extends Ressource {
             identityTypes: rest.identityTypes,
             providerIds: [providerId],
         };
-        return this.api.post<PageModel<SecurityCacheIdentityModel>>(
+        return this.api.post<PageModel<DetailedSecurityCacheMemberModel>>(
             this.buildPath(`${SecurityCache.cacheUrl}/entities/list`, {page, perPage}),
             filterModel,
         );

--- a/src/resources/SecurityCache/SecurityCacheInterfaces.ts
+++ b/src/resources/SecurityCache/SecurityCacheInterfaces.ts
@@ -8,6 +8,8 @@ import {
     SecurityProviderReferenceType,
     SecurityProviderStatusType,
     SecurityProviderType,
+    SinglePermissionResult,
+    SinglePermissionState,
 } from '../Enums.js';
 import {DataFile, ParameterModel, UserIdentityModel} from '../Sources/index.js';
 
@@ -188,8 +190,8 @@ export interface SecurityCacheMemberModel {
 export interface DetailedSecurityCacheMemberModel extends SecurityCacheMemberModel {
     lastUpdateDate?: number;
     lastUpdateErrorDetail?: string;
-    lastUpdateResult?: string;
-    state?: string;
+    lastUpdateResult?: SinglePermissionResult;
+    state?: SinglePermissionState;
 }
 
 export interface SecurityCacheMemberInfoModel {


### PR DESCRIPTION
The interface of the [entities/list](https://platformdev.cloud.coveo.com/docs?urls.primaryName=SecurityCache#/Security%20Cache/rest_organizations_paramId_securitycache_entities_list_post) was not the good one, and I update the `DetailedSecurityCacheMemberModel` interface to use the enum for `lastUpdateResult` and `state`

![Capture d’écran, le 2025-05-14 à 15 15 40](https://github.com/user-attachments/assets/ddd46d83-8cde-4d95-a1f4-5ff2237a0c14)


<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))
