### PR TITLE
feat(analytics-admin): add api additions and align naming

### DIFF
--- a/src/resources/AnalyticsAdmin/Properties/Properties.ts
+++ b/src/resources/AnalyticsAdmin/Properties/Properties.ts
@@ -1,7 +1,7 @@
 import Resource from '../../Resource.js';
 import API from '../../../APICore.js';
 import {PageModel} from '../../BaseInterfaces.js';
-import {ListPropertiesParams, PropertiesResponseMessage, PropertyModel} from './PropertiesInterfaces.js';
+import {ListPropertiesRequest, PropertyActionResponse, PropertyModel} from './PropertiesInterfaces.js';
 
 export default class Properties extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/analyticsadmin/v1`;
@@ -17,18 +17,35 @@ export default class Properties extends Resource {
     }
 
     /**
-     * List all properties
-     * @param params
+     * List all properties, optionally using filters.
+     * Note that `list` and `query` are equivalent, with the only difference being that `list` uses GET and `query` uses POST.
+     *
+     * @param params Optional parameters to filter the listing by.
      * @returns Promise<PageModel<PropertyModel>>
      */
-    list(params?: ListPropertiesParams): Promise<PageModel<PropertyModel>> {
+    list(params?: ListPropertiesRequest): Promise<PageModel<PropertyModel>> {
         return this.api.get<PageModel<PropertyModel>>(
-            this.buildPathWithOrg(`${Properties.baseUrl}/properties/list`, params),
+            this.buildPathWithOrg(`${Properties.baseUrl}/properties`, params),
         );
     }
 
     /**
-     * Get a property
+     * Query all properties, optionally using filters.
+     * Note that `list` and `query` are equivalent, with the only difference being that `list` uses GET and `query` uses POST.
+     *
+     * @param params Optional parameters to filter the listing by.
+     * @returns Promise<PageModel<PropertyModel>>
+     */
+    query(params?: ListPropertiesRequest): Promise<PageModel<PropertyModel>> {
+        return this.api.post<PageModel<PropertyModel>>(
+            this.buildPathWithOrg(`${Properties.baseUrl}/properties`),
+            params,
+        );
+    }
+
+    /**
+     * Get a property.
+     *
      * @param trackingId
      * @returns Promise<PropertyModel>
      */
@@ -37,36 +54,38 @@ export default class Properties extends Resource {
     }
 
     /**
-     * Create a property
+     * Create a property.
+     *
      * @param trackingId
      * @param displayName
-     * @returns Promise<PropertiesResponseMessage>
+     * @returns Promise<PropertyActionResponse>
      */
-    create(trackingId: string, displayName: string): Promise<PropertiesResponseMessage> {
-        return this.api.post<PropertiesResponseMessage>(
+    create(trackingId: string, displayName: string): Promise<PropertyActionResponse> {
+        return this.api.post<PropertyActionResponse>(
             this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`, {displayName}),
         );
     }
 
     /**
-     * Edit a property
+     * Edit a property.
+     *
      * @param trackingId
      * @param displayName
-     * @returns Promise<PropertiesResponseMessage>
+     * @returns Promise<PropertyActionResponse>
      */
-    update(trackingId: string, displayName: string): Promise<PropertiesResponseMessage> {
-        return this.api.put<PropertiesResponseMessage>(
+    update(trackingId: string, displayName: string): Promise<PropertyActionResponse> {
+        return this.api.put<PropertyActionResponse>(
             this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`, {displayName}),
         );
     }
 
     /**
-     * Delete a property
+     * Delete a property.
      * @param trackingId
-     * @returns Promise<PropertiesResponseMessage>
+     * @returns Promise<PropertyActionResponse>
      */
-    delete(trackingId: string): Promise<PropertiesResponseMessage> {
-        return this.api.delete<PropertiesResponseMessage>(
+    delete(trackingId: string): Promise<PropertyActionResponse> {
+        return this.api.delete<PropertyActionResponse>(
             this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`),
         );
     }

--- a/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
+++ b/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
@@ -1,15 +1,61 @@
 import {Paginated} from '../../BaseInterfaces.js';
 
 export interface PropertyModel {
-    trackingId: string | null;
+    /**
+     * The Organization ID that owns the property.
+     */
+    organizationId: string;
+    /**
+     * The string used to represent the tracking ID when sending a event request.
+     */
+    trackingId: string;
+    /**
+     * The name used for the property in the UI.
+     */
     displayName: string;
+    /**
+     * Optional list of project identifiers the property is mapped to.
+     * Project IDs are only included on request.
+     */
+    projectIds?: string[] | null;
 }
 
-export interface PropertiesResponseMessage {
+export interface PropertyActionResponse {
+    /**
+     * A message detailing the result of the requested operation.
+     */
     message: string;
 }
 
-export interface ListPropertiesParams extends Paginated {
-    filter?: string;
+export interface ListPropertiesRequest extends Paginated {
+    /**
+     * Whether the default property should be included.
+     */
     includeDefault?: boolean;
+    /**
+     * Optional filter on tracking id or display name.
+     */
+    filter?: string;
+    /**
+     * Optional filter on project id, requiring the view projects privilege.
+     */
+    projectId?: string;
+    /**
+     * Whether the projectIds of properties should be included.
+     * The default value is based on whether a `projectId` is specified:
+     * this property defaults to `false`, unless a `projectId` is specified.
+     */
+    includeProjectIds?: boolean;
+    /**
+     * Optional filter on a list of tracking IDs (exact case-sensitive match).
+     * When specified, it is recommended to use the `query` (POST) method over the `list` (GET) method,
+     * especially if the list of tracking IDs may have many entries.
+     * Note that if this is an empty array, the result will always be empty.
+     */
+    trackingIds?: string[];
 }
+
+/** @deprecated Deprecated alias for `ListPropertiesRequest`. */
+export type ListPropertiesParams = ListPropertiesRequest;
+/** @deprecated Deprecated alias for `PropertyActionResponse`. */
+export type PropertiesResponseMessage = PropertyActionResponse;

--- a/src/resources/AnalyticsAdmin/tests/Properties.spec.ts
+++ b/src/resources/AnalyticsAdmin/tests/Properties.spec.ts
@@ -1,5 +1,6 @@
 import API from '../../../APICore.js';
 import Properties from '../Properties/Properties.js';
+import {ListPropertiesRequest} from '../Properties/PropertiesInterfaces.js';
 
 jest.mock('../../../APICore.js');
 
@@ -13,26 +14,69 @@ describe('Properties', () => {
         properties = new Properties(api, serverlessApi);
     });
 
-    describe('listProperties', () => {
+    describe('list', () => {
         it('should make a GET call to the list path', async () => {
             await properties.list();
 
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/list`);
+            expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties`);
         });
 
         it('should make a GET call to the list path with pagination', async () => {
             await properties.list({page: 1, perPage: 2});
 
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/list?page=1&perPage=2`);
+            expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties?page=1&perPage=2`);
         });
 
-        it('should make a GET call to the list path with filter', async () => {
-            await properties.list({filter: 'test'});
+        it('should make a GET call to the list path with filter and includeDefault', async () => {
+            await properties.list({filter: 'test', includeDefault: false});
 
             expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/list?filter=test`);
+            expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties?filter=test&includeDefault=false`);
+        });
+
+        it('should make a GET call to the list path with projectId and includeProjectIds', async () => {
+            await properties.list({includeProjectIds: false, projectId: 'my-project'});
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(
+                `${Properties.baseUrl}/properties?includeProjectIds=false&projectId=my-project`,
+            );
+        });
+
+        it('should make a GET call to the list path with trackingIds', async () => {
+            await properties.list({trackingIds: ['id-1', 'id-2']});
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${Properties.baseUrl}/properties?trackingIds=id-1&trackingIds=id-2`);
+        });
+    });
+
+    describe('query', () => {
+        it('should make a POST call to the list path without body', async () => {
+            await properties.query();
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith<[string, ListPropertiesRequest?]>(
+                `${Properties.baseUrl}/properties`,
+                undefined,
+            );
+        });
+
+        it('should make a POST call to the list path with body', async () => {
+            const params: ListPropertiesRequest = {
+                includeDefault: false,
+                includeProjectIds: true,
+                trackingIds: ['id-1', 'id-2'],
+            };
+            await properties.query(params);
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith<[string, ListPropertiesRequest?]>(
+                `${Properties.baseUrl}/properties`,
+                params,
+            );
         });
     });
 


### PR DESCRIPTION
UA-10349

In request of the Workspace team, support for projects was added to the Analytics Admin Service. Properties (effectively tracking IDs) are resources that can be linked to projects, and the service has been updated to work with this. In short, the "list properties" endpoint has these optional filter properties added: `projectId`, `includeProjectIds` & `trackingIds`.

The use case for filtering the list result with `trackingIds` is somewhat obscure, Workspace wants to use this to validate the properties they have mapped still exist. It's not expected other clients will have use for this, but there is also no need to hide this feature from end users. Since the number of tracking IDs may get large, the service now also supports a POST equivalent of `list`, named `query`. (Yes, this would have been a [QUERY method](https://httpwg.org/http-extensions/draft-ietf-httpbis-safe-method-w-body.html), if the web finally adopted and implemented that standard 🙄).

✅ I tested the changes using the local-link setup.

### Not-so-breaking changes

In short, **before** the projects API updates, there was:
  - `…/properties` (GET) **unpaginated** call without any parameters (no filter, default property was always included).
    This method returned a `List<PropertyModel>` a.k.a. `PropertyModel[]`. Veteran API designers know it's best to ensure your response is always an object, not directly a list/array, so you can always add response values without breaking the API, but alas.
    Note that this method was **not** modeled by platform-client, but was (and is) visible on [Swagger](https://platform.cloud.coveo.com/docs/?urls.primaryName=Analytics+Admin+Service#/Property%20API).
  - `…/properties/list` (GET) paginated call with `filter` and `includeDefault` options.
    Note that there where (and will be) no guards against customers creating a property with trackingId `list`, and anybody doing so probably opens up a world of fun.

After the projects API updates, there will be:
  - `…/properties` (GET | POST) paginated call with `filter`, `includeDefault`, `projectId`, `includeProjectIds` & `trackingIds` options.
  - `…/properties/list` (GET) deprecated alias for `…/properties`.

While the changes to `GET …/properties` are very much breaking, this method was not modeled by platform-client, and thus to platform-client this is actually mostly only an additive breaking change. This PR does switch platform-client over to the new `GET …/properties` endpoint for `list`, so that the deprecated alias can hopefully soon be removed.

### This is your backstory
I will not include the full history here, but when Analytics Admin was developed, our team missed the mark on the API design on some fronts. The first thing was that some "model" (Pojo) classes had weird names. The person defining the previous version of this API in platform-client actually used different names from the Java service, likely in an attempt to make the API a bit more sensible. This PR also aligns the names with the names of the Java code, putting in deprecated aliases for what things were named before (which did not align with the previous Java API version).

The biggest mess was the "list properties" saga, partially explained above. For reasons unknown to the author of this PR, the unpaginated call was kept and the sibling `…/properties/list` call was added. This was done while the feature was still in development, and it would have been better to just take the pain of the breaking change then (even if via a temporary alias to not break the beta UI). Most of the API follows REST CRUD standard, except the listing method that has the `/list` suffix.

Checks to production logs showed only 2 non-Coveo-employee calls across all prod regions over the last month to the unpaginated listing end-point, so they were probably one-offs through Swagger. Since we had to do quite some changes to the API for adding projects support, I decided to just take the pain of fixing the API now. To do so, I'm following these steps:
 1. Break the `GET …/properties` call to be paginated and support the filters, and make `GET …/properties/list` a deprecated alias for it.
    (In other words, "move" `GET …/properties/list` to become `GET …/properties`, and "alias" it as `GET …/properties/list`).
 2. Adjust platform-client to use the now paginated `GET …/properties` endpoint.
    "You are here".
 3. After some time, remove the deprecated `GET …/properties/list` alias, to remove the collision with accessing a property that has tracking ID `"list"`.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces.
-   [X] The proposed changes are covered by unit tests.
-   [X] Commits containing breaking changes a properly identified as such.
-   [X] ~[README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)~ _Not applicable._
-   [X] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)).
