### PR TITLE
chore(cd): missing write permission in workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
         branches: [master]
 
 permissions:
-    contents: read # Required to read the repository
+    contents: write # Required to push to the repository
     id-token: write # Required for OIDC
 
 jobs:


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

In my last PR I added permissions on the workflow but I added `contents: read` instead of `contents: write` since we create tags and push to the repo. This PR fixes it
