### PR TITLE
chore: remove aem source type

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -133,10 +133,6 @@ export enum SourceStatusTypeWithTransition {
 }
 
 export enum SourceType {
-    /**
-     * @deprecated
-     */
-    ADOBE_EXPERIENCE_MANAGER = 'ADOBE_EXPERIENCE_MANAGER',
     AMAZONS3 = 'AMAZONS3',
     BOX_ENTERPRISE2 = 'BOX_ENTERPRISE2',
     CATALOG = 'CATALOG',
@@ -1003,7 +999,6 @@ export enum SearchHubLicenseMetrics {
     coveoForSelfService = 'coveoForSelfService',
     coveoForZendeskPortals = 'coveoForZendeskPortals',
     coveoForSalesforceServiceCloud = 'coveoForSalesforceServiceCloud',
-    coveoForAdobe = 'coveoForAdobe',
     coveoForSitecore = 'coveoForSitecore',
     coveoForSitecoreStandard = 'coveoForSitecoreStandard',
     coveoForWebsites = 'coveoForWebsites',


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

- Remove ADOBE_EXPERIENCE_EDITOR from sourceType.
This value has been deprecated for quite some time, and we are now proceeding to remove all remaining Adobe Experience Manager (AEM) components.

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
  - Yes, I will bunp the version in the admin-ui and remove all usage of this value. 
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))
