### PR TITLE
chore: update CODEOWNERS to remove @coveo/dxui

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 # review when someone opens a pull request.
 # see https://help.github.com/articles/about-codeowners/ for more details
 
-* @coveo/frontend-foundation @coveo/dxui
+* @coveo/frontend-foundation
 
 # Prevent PRs that only modify package.json from notifying everyone
 package.json


### PR DESCRIPTION
Removed @coveo/dxui from CODEOWNERS for frontend changes.

Our code review's been rslgtm for a long while now.