### PR TITLE
fix(crawling-modules): add missing ROLLBACK update status category

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -229,6 +229,7 @@ export enum UpdateStatusCategory {
     MINOR = 'MINOR',
     CRITICAL = 'CRITICAL',
     BREAKING = 'BREAKING',
+    ROLLBACK = 'ROLLBACK',
 }
 
 export enum SortingType {


### PR DESCRIPTION
[PSE-940](https://coveord.atlassian.net/browse/PSE-940)

Add missing value in the `UpdateStatusCategory` enum for Crawling Modules. We were missing the `ROLLBACK` value as documented [here](https://platform.cloud.coveo.com/docs/internal?urls.primaryName=Platform#/Crawling%20Module/getUpdateStatus).

<img width="400" height="74" alt="Screenshot 2026-01-29 at 1 25 13 PM" src="https://github.com/user-attachments/assets/31bdad2c-780b-4510-963e-c6ab2734f882" />


### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [X] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))


[PSE-940]: https://coveord.atlassian.net/browse/PSE-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ