### PR TITLE
fix: add strategy in AssociationItem interface

### DIFF
--- a/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
+++ b/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
@@ -48,5 +48,5 @@ export interface AssociationItem {
     /**
      * The additional parameters to send to Coveo ML.
      */
-    customQueryParameters?: {submodel: string};
+    customQueryParameters?: {submodel?: string, strategy?: string};
 }

--- a/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
+++ b/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
@@ -1,6 +1,18 @@
 import {ConditionModel} from '../../Pipelines/index.js';
 import {MLModelStatusInfo} from '../MachineLearningInterfaces.js';
 
+interface CustomQueryParametersWithSubmodel {
+    submodel: string;
+    strategy?: never;
+}
+
+interface CustomQueryParametersWithStrategy {
+    submodel?: never;
+    strategy: string;
+}
+
+type CustomQueryParameters = CustomQueryParametersWithSubmodel | CustomQueryParametersWithStrategy;
+
 export interface ModelAssociationsListParams {
     /*
      * The 0-based number of the page of results to list. Default: 0
@@ -48,5 +60,5 @@ export interface AssociationItem {
     /**
      * The additional parameters to send to Coveo ML.
      */
-    customQueryParameters?: {submodel?: string; strategy?: string};
+    customQueryParameters?: CustomQueryParameters;
 }

--- a/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
+++ b/src/resources/MachineLearning/ModelAssociations/ModelAssociationsInterfaces.ts
@@ -48,5 +48,5 @@ export interface AssociationItem {
     /**
      * The additional parameters to send to Coveo ML.
      */
-    customQueryParameters?: {submodel?: string, strategy?: string};
+    customQueryParameters?: {submodel?: string; strategy?: string};
 }


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

See https://coveo.slack.com/archives/CQ3A0U5PT/p1770042593441079

Add `strategy` param to the `AssociationItem` interface. Eventually it should replace `submodel`, but in the meantime we should support both.
I've made both optional since it should always be one or the other.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))
