### PR TITLE
feat(properties)!: add default timezone and currency fields [comhub3-609]

### DIFF
--- a/src/resources/AnalyticsAdmin/Properties/Properties.ts
+++ b/src/resources/AnalyticsAdmin/Properties/Properties.ts
@@ -1,7 +1,12 @@
 import Resource from '../../Resource.js';
 import API from '../../../APICore.js';
 import {PageModel} from '../../BaseInterfaces.js';
-import {ListPropertiesRequest, PropertyActionResponse, PropertyModel} from './PropertiesInterfaces.js';
+import {
+    ListPropertiesRequest,
+    MutatePropertyModel,
+    PropertyActionResponse,
+    PropertyModel,
+} from './PropertiesInterfaces.js';
 
 export default class Properties extends Resource {
     static baseUrl = `/rest/organizations/${API.orgPlaceholder}/analyticsadmin/v1`;
@@ -57,12 +62,12 @@ export default class Properties extends Resource {
      * Create a property.
      *
      * @param trackingId
-     * @param displayName
+     * @param params
      * @returns Promise<PropertyActionResponse>
      */
-    create(trackingId: string, displayName: string): Promise<PropertyActionResponse> {
+    create(trackingId: string, params: MutatePropertyModel): Promise<PropertyActionResponse> {
         return this.api.post<PropertyActionResponse>(
-            this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`, {displayName}),
+            this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`, params),
         );
     }
 
@@ -70,12 +75,12 @@ export default class Properties extends Resource {
      * Edit a property.
      *
      * @param trackingId
-     * @param displayName
+     * @param params
      * @returns Promise<PropertyActionResponse>
      */
-    update(trackingId: string, displayName: string): Promise<PropertyActionResponse> {
+    update(trackingId: string, params: MutatePropertyModel): Promise<PropertyActionResponse> {
         return this.api.put<PropertyActionResponse>(
-            this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`, {displayName}),
+            this.buildPathWithOrg(`${Properties.baseUrl}/properties/${trackingId}`, params),
         );
     }
 

--- a/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
+++ b/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
@@ -18,6 +18,33 @@ export interface PropertyModel {
      * Project IDs are only included on request.
      */
     projectIds?: string[] | null;
+    /**
+     * Optional: The default time zone associated with the property.
+     * Leaving this empty will set the value to 'null'.
+     */
+    defaultTimeZone?: string;
+    /**
+     * Optional: The default currency associated with the property.
+     * Leaving this empty will set the value to 'null'.
+     */
+    defaultCurrency?: string;
+}
+
+export interface MutatePropertyModel {
+    /**
+     * The name used for the property in the UI.
+     */
+    displayName: string;
+    /**
+     * Optional: The default time zone associated with the property.
+     * Leaving this empty will set the value to 'null'.
+     */
+    defaultTimeZone?: string;
+    /**
+     * Optional: The default currency associated with the property.
+     * Leaving this empty will set the value to 'null'.
+     */
+    defaultCurrency?: string;
 }
 
 export interface PropertyActionResponse {

--- a/src/resources/AnalyticsAdmin/tests/Properties.spec.ts
+++ b/src/resources/AnalyticsAdmin/tests/Properties.spec.ts
@@ -91,7 +91,22 @@ describe('Properties', () => {
 
     describe('createProperty', () => {
         it('should make a POST call to the properties path', async () => {
-            await properties.create('trackingId', 'displayName');
+            await properties.create('trackingId', {
+                displayName: 'displayName',
+                defaultTimeZone: 'America/New_York',
+                defaultCurrency: 'USD',
+            });
+
+            expect(api.post).toHaveBeenCalledTimes(1);
+            expect(api.post).toHaveBeenCalledWith(
+                `${Properties.baseUrl}/properties/trackingId?displayName=displayName&defaultTimeZone=America%2FNew_York&defaultCurrency=USD`,
+            );
+        });
+
+        it('should allow passing undefined for optional fields', async () => {
+            await properties.create('trackingId', {
+                displayName: 'displayName',
+            });
 
             expect(api.post).toHaveBeenCalledTimes(1);
             expect(api.post).toHaveBeenCalledWith(
@@ -102,13 +117,27 @@ describe('Properties', () => {
 
     describe('updateProperty', () => {
         it('should make a PUT call to the properties path', async () => {
-            await properties.update('trackingId', 'displayName');
+            await properties.update('trackingId', {
+                displayName: 'displayName',
+                defaultTimeZone: 'America/New_York',
+                defaultCurrency: 'USD',
+            });
+
+            expect(api.put).toHaveBeenCalledTimes(1);
+            expect(api.put).toHaveBeenCalledWith(
+                `${Properties.baseUrl}/properties/trackingId?displayName=displayName&defaultTimeZone=America%2FNew_York&defaultCurrency=USD`,
+            );
+        });
+
+        it('should allow passing undefined for optional fields', async () => {
+            await properties.update('trackingId', {
+                displayName: 'displayName',
+            });
 
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(`${Properties.baseUrl}/properties/trackingId?displayName=displayName`);
         });
     });
-
     describe('deleteProperty', () => {
         it('should make a DELETE call to the properties path', async () => {
             await properties.delete('trackingId');


### PR DESCRIPTION
### Description

Add defaultCurrency and defaultTimeZone fields to property model.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))
