### PR TITLE
feat(properties): add jsdoc to property models

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ In case your changes don't fall within the scope **yet**, but you still want to 
 
 ## Commit messages
 
-**Every commit message must comply with the [Angular Commit Message Conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format) specification. We use the commit messages to automatically bump the package version according to the semantic versioning notation. Moreover, we generate changelogs for each version using those commit messages.**
+**Every commit message must comply with the [Angular Commit Message Conventions](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md#commit-message-footer) specification. We use the commit messages to automatically bump the package version according to the semantic versioning notation. Moreover, we generate changelogs for each version using those commit messages.**
 
 -   You can either manually write a commit message that follows the convention using your favorite method.
 -   Or you can run `npm run commit-cli`. It will prompt you some questions about the nature of your changes, then it will commit your staged changes along with a generated message that follows our convention.

--- a/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
+++ b/src/resources/AnalyticsAdmin/Properties/PropertiesInterfaces.ts
@@ -20,6 +20,7 @@ export interface PropertyModel {
     projectIds?: string[] | null;
     /**
      * Optional: The default time zone associated with the property.
+     * Only valid IANA time zones are accepted (UTC, America/Montreal, ...).
      * Leaving this empty will set the value to 'null'.
      */
     defaultTimeZone?: string;
@@ -37,6 +38,7 @@ export interface MutatePropertyModel {
     displayName: string;
     /**
      * Optional: The default time zone associated with the property.
+     * Only valid IANA time zones are accepted (UTC, America/Montreal, ...).
      * Leaving this empty will set the value to 'null'.
      */
     defaultTimeZone?: string;


### PR DESCRIPTION
- Add some JSDoc to clarify the default timezone field on property models.
- Update contributing.md link to angular breaking commit convention

This commit will be marked as breaking to fix a previous commit that was wrongfully marked as a patch : https://github.com/coveo/platform-client/commit/8f26c6320113330f8c768d40077c9cf53320fa71

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))
