### PR TITLE
fix(conditions): add missing pipeline statement type

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -1255,8 +1255,18 @@ export enum ConditionAssociationType {
     pipelines = 'pipelines',
     pipelineStatements = 'pipelineStatements',
     pipelineStatementGroups = 'pipelineStatementGroups',
-    featuredResults = 'featuredResults',
-    unmanagedMlStatements = 'unmanagedMlStatements',
+}
+
+export enum ConditionPipelineStatementType {
+    filter = 'filter',
+    queryParamOverride = 'queryParamOverride',
+    rankingWeight = 'rankingweight',
+    stopWord = 'stopWord',
+    thesaurus = 'thesaurus',
+    trigger = 'trigger',
+    featuredResult = 'featuredResult',
+    rankingExpression = 'rankingExpression',
+    unmanagedMlStatement = 'unmanagedMlStatement',
 }
 
 export enum ConditionAssociationSortByType {

--- a/src/resources/Pipelines/Conditions/ConditionInterfaces.ts
+++ b/src/resources/Pipelines/Conditions/ConditionInterfaces.ts
@@ -2,9 +2,9 @@ import {PageModel, Paginated} from '../../BaseInterfaces.js';
 import {
     ConditionAssociationSortByType,
     ConditionAssociationType,
+    ConditionPipelineStatementType,
     ListStatementAssocationFilter,
     ListStatementSortBy,
-    StatementsFeature,
 } from '../../Enums.js';
 
 interface ConditionAssociations {
@@ -150,6 +150,12 @@ export interface ListAssociationsOptions extends Paginated {
     associationTypes?: ConditionAssociationType[];
 
     /**
+     * Optional filter to include only associations whose associationType is pipelineStatements and whose pipelineStatementType matches the specified value.
+     * Must be used in conjunction with associationTypes=["pipelineStatements"].
+     */
+    pipelineStatementType?: ConditionPipelineStatementType;
+
+    /**
      * Optional filter to match the pipeline name of the object associated with this condition.
      */
     pipelineName?: string;
@@ -170,6 +176,10 @@ export interface ConditionPipelineAssociation {
      * The type of the association.
      */
     associationType: ConditionAssociationType;
+    /**
+     * Pipeline statement type of the association.
+     */
+    pipelineStatementType?: ConditionPipelineStatementType;
     /**
      * Primary key of the associated entity.
      */
@@ -202,10 +212,9 @@ export interface ConditionPipelineStatementAssociation {
      */
     pipelineName: string;
     /**
-     * QPL feature (only present for pipelineStatements).
-     *
+     * Pipeline statement type of the association (only present for pipelineStatements).
      */
-    feature: StatementsFeature;
+    pipelineStatementType?: ConditionPipelineStatementType;
 }
 
 export type ConditionAssociationItemUnion = ConditionPipelineAssociation | ConditionPipelineStatementAssociation;

--- a/src/resources/Pipelines/Conditions/tests/Condition.spec.ts
+++ b/src/resources/Pipelines/Conditions/tests/Condition.spec.ts
@@ -2,6 +2,7 @@ import API from '../../../../APICore.js';
 import {
     ConditionAssociationSortByType,
     ConditionAssociationType,
+    ConditionPipelineStatementType,
     ListStatementAssocationFilter,
     ListStatementSortBy,
 } from '../../../Enums.js';
@@ -148,11 +149,12 @@ describe('Condition', () => {
                 pipelineName: 'testName',
                 isOrderAscending: true,
                 sortBy: ConditionAssociationSortByType.pipelineName,
-                associationTypes: [ConditionAssociationType.pipelines, ConditionAssociationType.featuredResults],
+                associationTypes: [ConditionAssociationType.pipelineStatements],
+                pipelineStatementType: ConditionPipelineStatementType.rankingExpression,
             });
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(
-                '/rest/search/v1/admin/pipelines/statements/conditionIdTest/associations?page=2&perPage=10&pipelineName=testName&isOrderAscending=true&sortBy=pipelineName&associationTypes=%5B%22pipelines%22%2C%22featuredResults%22%5D',
+                '/rest/search/v1/admin/pipelines/statements/conditionIdTest/associations?page=2&perPage=10&pipelineName=testName&isOrderAscending=true&sortBy=pipelineName&associationTypes=%5B%22pipelineStatements%22%5D&pipelineStatementType=rankingExpression',
             );
         });
     });


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

[PSE-1056](https://coveord.atlassian.net/browse/PSE-1056)

Associations API changes (documented [here](https://platform.cloud.coveo.com/docs?urls.primaryName=Search+API#/Conditions/listConditionAssociations))
- The `feature` property is removed
- The `associationTypes` property now includes: `pipeline` , `pipelineStatementGroups` and `pipelineStatements`
- There will be a new property when `associationType=pipelineStatement` which will be called `pipelineStatementType` and will include: `featuredResults` , `rankingExpressions` , `ml-associations` and other statements like `filters` , `triggers` etc.

<img width="1234" height="187" alt="Screenshot 2026-03-25 at 9 37 32 AM" src="https://github.com/user-attachments/assets/f9acb57a-5f93-48c9-b1fe-d23cbcac00f6" />


### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))


[PSE-1056]: https://coveord.atlassian.net/browse/PSE-1056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ