### PR TITLE
feat: remove JIVE & JIVE_HOSTED SourceType - PSTL-96

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -147,8 +147,6 @@ export enum SourceType {
     GRAPHQL = 'GRAPHQL',
     JIRA2 = 'JIRA2',
     JIRA2_HOSTED = 'JIRA2_HOSTED',
-    JIVE = 'JIVE',
-    JIVE_HOSTED = 'JIVE_HOSTED',
     LITHIUM = 'LITHIUM',
     MICROSOFT_DYNAMICS = 'MICROSOFT_DYNAMICS',
     PUSH = 'PUSH',
@@ -304,18 +302,10 @@ export enum ActivityOperation {
 }
 
 export enum SecurityProviderType {
-    /**
-     * @deprecated
-     */
-    ACTIVE_DIRECTORY = 'ACTIVE_DIRECTORY',
     ACTIVE_DIRECTORY2 = 'ACTIVE_DIRECTORY2',
     BOX = 'BOX',
     CLAIMS = 'CLAIMS',
     CLAIMS_TO_EMAIL = 'CLAIMS_TO_EMAIL',
-    /**
-     * @deprecated
-     */
-    CONFLUENCE = 'CONFLUENCE',
     CONFLUENCE2 = 'CONFLUENCE2',
     CUSTOM = 'CUSTOM',
     DATABASE = 'DATABASE',
@@ -327,7 +317,6 @@ export enum SecurityProviderType {
     GENERIC_REST = 'GENERIC_REST',
     GRAPHQL = 'GRAPHQL',
     JIRA2 = 'JIRA2',
-    JIVE = 'JIVE',
     KHOROS_COMMUNITY = 'KHOROS_COMMUNITY',
     MICROSOFT_DYNAMICS = 'MICROSOFT_DYNAMICS',
     OFFICE365 = 'OFFICE365',


### PR DESCRIPTION
[PSTL-96](https://coveord.atlassian.net/browse/PSTL-96)

This pull request makes a small change to the `SourceType` enum in `src/resources/Enums.ts` by removing the deprecated `JIVE` & `JIVE_HOSTED` entry. This helps keep the codebase clean and up to date with supported source types.

<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))


[PSTL-96]: https://coveord.atlassian.net/browse/PSTL-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ