### PR TITLE
feat: remove SALESFORCE_SITES SourceType - PSTL-98

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -152,7 +152,6 @@ export enum SourceType {
     PUSH = 'PUSH',
     RSS = 'RSS',
     SALESFORCE = 'SALESFORCE',
-    SALESFORCE_SITES = 'SALESFORCE_SITES',
     SAP = 'SAP',
     SERVICENOW = 'SERVICENOW',
     SHAREPOINT = 'SHAREPOINT',


### PR DESCRIPTION
[PSTL-98](https://coveord.atlassian.net/browse/PSTL-98)

This pull request makes a small change to the `SourceType` enum in `src/resources/Enums.ts` by removing the deprecated `SALESFORCE_SITES` entry. This helps keep the codebase clean and up to date with supported source types.

@GermainBergeron This is the last SourceType to be removed this year.

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))


[PSTL-98]: https://coveord.atlassian.net/browse/PSTL-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ