### PR TITLE
feat(result-ranking): add expand support for conditions

### DIFF
--- a/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
@@ -262,6 +262,8 @@ interface CoreGetResultRankingParams extends Paginated {
     kind?: ResultRankingsKind;
 }
 
+export type ListResultRankingExpandOptions = 'condition.detailed';
+
 export interface ListResultRankingParams extends CoreGetResultRankingParams {
     sortBy?: ListStatementSortBy;
 
@@ -285,7 +287,7 @@ export interface ListResultRankingParams extends CoreGetResultRankingParams {
      *
      * Set to `condition.detailed` to include the detailed version of the condition alongside `condition.reference` in each result ranking condition.
      */
-    expand?: Array<'condition.detailed'>;
+    expand?: ListResultRankingExpandOptions[];
 }
 
 export interface CopyResultRankingRequest {

--- a/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
+++ b/src/resources/Pipelines/ResultRankings/ResultRankingsInterfaces.ts
@@ -9,6 +9,7 @@ import {
     ResultRankingsRuleTypes,
     ResultRankingsStatuses,
 } from '../../Enums.js';
+import {DetailedCondition} from '../Conditions/ConditionInterfaces.js';
 
 export interface ResultRanking {
     /**
@@ -95,6 +96,10 @@ export interface ResultRankingProps {
          * The ID of a mandatory condition to satisfy.
          */
         reference: string;
+        /**
+         * The detailed version of the condition.
+         */
+        detailed?: {condition: DetailedCondition};
     };
     statementGroupId?: string;
     associatedGroup?: ResultRankingAssociatedGroup;
@@ -275,6 +280,12 @@ export interface ListResultRankingParams extends CoreGetResultRankingParams {
      * The rule status to allow in the results.
      */
     ruleStatuses?: ResultRankingsStatuses[];
+    /**
+     * The related resources to expand in the response.
+     *
+     * Set to `condition.detailed` to include the detailed version of the condition alongside `condition.reference` in each result ranking condition.
+     */
+    expand?: Array<'condition.detailed'>;
 }
 
 export interface CopyResultRankingRequest {

--- a/src/resources/Pipelines/ResultRankings/tests/ResultRankings.spec.ts
+++ b/src/resources/Pipelines/ResultRankings/tests/ResultRankings.spec.ts
@@ -134,6 +134,7 @@ describe('Result Rankings', () => {
             const associatedGroups = [null, 'g1', 'g2'];
             const ruleStatuses = [ResultRankingsStatuses.active, ResultRankingsStatuses.inactive];
             const ruleTypes = [ResultRankingsRuleTypes.featuredResults, ResultRankingsRuleTypes.rankingExpressions];
+            const expand: Array<'condition.detailed'> = ['condition.detailed'];
             const expectedUri = [
                 ResultRankings.getBaseUrl(pipelineId),
                 '?associatedGroups=',
@@ -142,9 +143,10 @@ describe('Result Rankings', () => {
                 encodeURIComponent(JSON.stringify(ruleStatuses)),
                 '&ruleTypes=',
                 encodeURIComponent(JSON.stringify(ruleTypes)),
+                '&expand=condition.detailed',
             ].join('');
 
-            await resultRankings.list(pipelineId, {associatedGroups, ruleStatuses, ruleTypes});
+            await resultRankings.list(pipelineId, {associatedGroups, ruleStatuses, ruleTypes, expand});
             expect(api.get).toHaveBeenCalledTimes(1);
             expect(api.get).toHaveBeenCalledWith(expectedUri);
         });

--- a/src/resources/Pipelines/ResultRankings/tests/ResultRankings.spec.ts
+++ b/src/resources/Pipelines/ResultRankings/tests/ResultRankings.spec.ts
@@ -7,7 +7,7 @@ import {
     ResultRankingsStatuses,
 } from '../../../Enums.js';
 import ResultRankings from '../ResultRankings.js';
-import {CopyResultRankingRequest, ResultRanking} from '../ResultRankingsInterfaces.js';
+import {CopyResultRankingRequest, ListResultRankingExpandOptions, ResultRanking} from '../ResultRankingsInterfaces.js';
 
 jest.mock('../../../../APICore.js');
 
@@ -134,7 +134,7 @@ describe('Result Rankings', () => {
             const associatedGroups = [null, 'g1', 'g2'];
             const ruleStatuses = [ResultRankingsStatuses.active, ResultRankingsStatuses.inactive];
             const ruleTypes = [ResultRankingsRuleTypes.featuredResults, ResultRankingsRuleTypes.rankingExpressions];
-            const expand: Array<'condition.detailed'> = ['condition.detailed'];
+            const expand: ListResultRankingExpandOptions[] = ['condition.detailed'];
             const expectedUri = [
                 ResultRankings.getBaseUrl(pipelineId),
                 '?associatedGroups=',


### PR DESCRIPTION
https://coveord.atlassian.net/browse/PSE-1493

- Modify the listing Result ranking API call in to accept the `expand` property.
- Modify the response interface to include the `detailed` property.

See in [Swagger](https://internalproxy-us-east-1.dev.cloud.coveo.com/docs/internal?urls.primaryName=Search+API#/Result%20rankings/listResultRankingRules).

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [X] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [X] JSDoc annotates each property added in the exported interfaces
-   [X] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [X] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))
