### PR TITLE
feat: remove deprecated applyChanges call

### DIFF
--- a/src/resources/Sources/Sources.ts
+++ b/src/resources/Sources/Sources.ts
@@ -1,8 +1,8 @@
 import API from '../../APICore.js';
-import {New, PageModel} from '../BaseInterfaces.js';
-import {ActivityOperation} from '../Enums.js';
+import { New, PageModel } from '../BaseInterfaces.js';
+import { ActivityOperation } from '../Enums.js';
 import Resource from '../Resource.js';
-import {ScheduleModel} from '../SecurityCache/index.js';
+import { ScheduleModel } from '../SecurityCache/index.js';
 import SourcesDatasets from './SourcesDatasets/SourcesDatasets.js';
 import SourcesFeedback from './SourcesFeedback/SourcesFeedback.js';
 import SourcesFields from './SourcesFields/SourcesFields.js';
@@ -43,7 +43,7 @@ export default class Sources extends Resource {
     }
 
     create(source: New<CreateSourceModel, 'resourceId'>, options?: CreateSourceOptions) {
-        return this.api.post<{id: string}>(this.buildPath(Sources.baseUrl, options), source);
+        return this.api.post<{ id: string }>(this.buildPath(Sources.baseUrl, options), source);
     }
 
     list(params?: ListSourcesParams) {
@@ -62,7 +62,7 @@ export default class Sources extends Resource {
     }
 
     createFromRaw(rawSourceConfig: RawSourceConfig, options?: CreateSourceOptions) {
-        return this.api.post<{id: string}>(this.buildPath(`${Sources.baseUrl}/raw`, options), rawSourceConfig);
+        return this.api.post<{ id: string }>(this.buildPath(`${Sources.baseUrl}/raw`, options), rawSourceConfig);
     }
 
     getDefaultDocumentConfiguration(params?: DefaultDocumentConfigurationParams) {
@@ -80,28 +80,24 @@ export default class Sources extends Resource {
     }
 
     update(sourceId: string, source: CreateSourceModel, options?: CreateSourceOptions) {
-        return this.api.put<{id: string}>(this.buildPath(`${Sources.baseUrl}/${sourceId}`, options), source);
-    }
-
-    applyChanges(sourceId: string) {
-        return this.api.post(`${Sources.baseUrl}/${sourceId}/applyChanges`);
+        return this.api.put<{ id: string }>(this.buildPath(`${Sources.baseUrl}/${sourceId}`, options), source);
     }
 
     isDedicated(sourceId: string) {
-        return this.api.get<{value: boolean}>(`${Sources.baseUrl}/${sourceId}/dedicated`);
+        return this.api.get<{ value: boolean }>(`${Sources.baseUrl}/${sourceId}/dedicated`);
     }
 
     setDedicated(sourceId: string, enabled?: boolean) {
-        return this.api.put(this.buildPath(`${Sources.baseUrl}/${sourceId}/dedicated`, {enabled}), {});
+        return this.api.put(this.buildPath(`${Sources.baseUrl}/${sourceId}/dedicated`, { enabled }), {});
     }
 
     dumpRefresh(sourceId: string) {
-        return this.api.post<{value: boolean}>(`${Sources.baseUrl}/${sourceId}/dump`);
+        return this.api.post<{ value: boolean }>(`${Sources.baseUrl}/${sourceId}/dump`);
     }
 
     duplicate(sourceId: string, newSourceName: string, logicalIndexId?: string) {
         return this.api.post<SourceModel>(
-            this.buildPath(`${Sources.baseUrl}/${sourceId}/duplicate`, {newSourceName, logicalIndexId}),
+            this.buildPath(`${Sources.baseUrl}/${sourceId}/duplicate`, { newSourceName, logicalIndexId }),
         );
     }
 
@@ -130,7 +126,7 @@ export default class Sources extends Resource {
     }
 
     setPushRefreshStatus(sourceId: string, activityOperation: ActivityOperation) {
-        return this.api.post(this.buildPath(`${Sources.baseUrl}/${sourceId}/pushRefresh`, {activityOperation}));
+        return this.api.post(this.buildPath(`${Sources.baseUrl}/${sourceId}/pushRefresh`, { activityOperation }));
     }
 
     getRawSource(sourceId: string) {
@@ -138,7 +134,7 @@ export default class Sources extends Resource {
     }
 
     updateRawSource(sourceId: string, platformSourceConfig: RawSourceConfig, options?: CreateSourceOptions) {
-        return this.api.put<{id: string}>(
+        return this.api.put<{ id: string }>(
             this.buildPath(`${Sources.baseUrl}/${sourceId}/raw`, options),
             platformSourceConfig,
         );
@@ -181,6 +177,6 @@ export default class Sources extends Resource {
     }
 
     abortTaskForActivity(sourceId: string, activityId: string) {
-        return this.api.post(this.buildPath(`${Sources.baseUrl}/${sourceId}/tasks/abort`, {activityId}));
+        return this.api.post(this.buildPath(`${Sources.baseUrl}/${sourceId}/tasks/abort`, { activityId }));
     }
 }

--- a/src/resources/Sources/Sources.ts
+++ b/src/resources/Sources/Sources.ts
@@ -1,8 +1,8 @@
 import API from '../../APICore.js';
-import { New, PageModel } from '../BaseInterfaces.js';
-import { ActivityOperation } from '../Enums.js';
+import {New, PageModel} from '../BaseInterfaces.js';
+import {ActivityOperation} from '../Enums.js';
 import Resource from '../Resource.js';
-import { ScheduleModel } from '../SecurityCache/index.js';
+import {ScheduleModel} from '../SecurityCache/index.js';
 import SourcesDatasets from './SourcesDatasets/SourcesDatasets.js';
 import SourcesFeedback from './SourcesFeedback/SourcesFeedback.js';
 import SourcesFields from './SourcesFields/SourcesFields.js';
@@ -43,7 +43,7 @@ export default class Sources extends Resource {
     }
 
     create(source: New<CreateSourceModel, 'resourceId'>, options?: CreateSourceOptions) {
-        return this.api.post<{ id: string }>(this.buildPath(Sources.baseUrl, options), source);
+        return this.api.post<{id: string}>(this.buildPath(Sources.baseUrl, options), source);
     }
 
     list(params?: ListSourcesParams) {
@@ -62,7 +62,7 @@ export default class Sources extends Resource {
     }
 
     createFromRaw(rawSourceConfig: RawSourceConfig, options?: CreateSourceOptions) {
-        return this.api.post<{ id: string }>(this.buildPath(`${Sources.baseUrl}/raw`, options), rawSourceConfig);
+        return this.api.post<{id: string}>(this.buildPath(`${Sources.baseUrl}/raw`, options), rawSourceConfig);
     }
 
     getDefaultDocumentConfiguration(params?: DefaultDocumentConfigurationParams) {
@@ -80,24 +80,24 @@ export default class Sources extends Resource {
     }
 
     update(sourceId: string, source: CreateSourceModel, options?: CreateSourceOptions) {
-        return this.api.put<{ id: string }>(this.buildPath(`${Sources.baseUrl}/${sourceId}`, options), source);
+        return this.api.put<{id: string}>(this.buildPath(`${Sources.baseUrl}/${sourceId}`, options), source);
     }
 
     isDedicated(sourceId: string) {
-        return this.api.get<{ value: boolean }>(`${Sources.baseUrl}/${sourceId}/dedicated`);
+        return this.api.get<{value: boolean}>(`${Sources.baseUrl}/${sourceId}/dedicated`);
     }
 
     setDedicated(sourceId: string, enabled?: boolean) {
-        return this.api.put(this.buildPath(`${Sources.baseUrl}/${sourceId}/dedicated`, { enabled }), {});
+        return this.api.put(this.buildPath(`${Sources.baseUrl}/${sourceId}/dedicated`, {enabled}), {});
     }
 
     dumpRefresh(sourceId: string) {
-        return this.api.post<{ value: boolean }>(`${Sources.baseUrl}/${sourceId}/dump`);
+        return this.api.post<{value: boolean}>(`${Sources.baseUrl}/${sourceId}/dump`);
     }
 
     duplicate(sourceId: string, newSourceName: string, logicalIndexId?: string) {
         return this.api.post<SourceModel>(
-            this.buildPath(`${Sources.baseUrl}/${sourceId}/duplicate`, { newSourceName, logicalIndexId }),
+            this.buildPath(`${Sources.baseUrl}/${sourceId}/duplicate`, {newSourceName, logicalIndexId}),
         );
     }
 
@@ -126,7 +126,7 @@ export default class Sources extends Resource {
     }
 
     setPushRefreshStatus(sourceId: string, activityOperation: ActivityOperation) {
-        return this.api.post(this.buildPath(`${Sources.baseUrl}/${sourceId}/pushRefresh`, { activityOperation }));
+        return this.api.post(this.buildPath(`${Sources.baseUrl}/${sourceId}/pushRefresh`, {activityOperation}));
     }
 
     getRawSource(sourceId: string) {
@@ -134,7 +134,7 @@ export default class Sources extends Resource {
     }
 
     updateRawSource(sourceId: string, platformSourceConfig: RawSourceConfig, options?: CreateSourceOptions) {
-        return this.api.put<{ id: string }>(
+        return this.api.put<{id: string}>(
             this.buildPath(`${Sources.baseUrl}/${sourceId}/raw`, options),
             platformSourceConfig,
         );
@@ -177,6 +177,6 @@ export default class Sources extends Resource {
     }
 
     abortTaskForActivity(sourceId: string, activityId: string) {
-        return this.api.post(this.buildPath(`${Sources.baseUrl}/${sourceId}/tasks/abort`, { activityId }));
+        return this.api.post(this.buildPath(`${Sources.baseUrl}/${sourceId}/tasks/abort`, {activityId}));
     }
 }

--- a/src/resources/Sources/tests/Sources.spec.ts
+++ b/src/resources/Sources/tests/Sources.spec.ts
@@ -1,7 +1,7 @@
 import API from '../../../APICore.js';
-import { New } from '../../BaseInterfaces.js';
-import { ActivityOperation, DocumentConfigurationType } from '../../Enums.js';
-import { ScheduleModel } from '../../SecurityCache/index.js';
+import {New} from '../../BaseInterfaces.js';
+import {ActivityOperation, DocumentConfigurationType} from '../../Enums.js';
+import {ScheduleModel} from '../../SecurityCache/index.js';
 import Sources from '../Sources.js';
 import SourcesDatasets from '../SourcesDatasets/SourcesDatasets.js';
 import SourcesFeedback from '../SourcesFeedback/SourcesFeedback.js';
@@ -19,8 +19,8 @@ jest.mock('../../../APICore.js');
 
 describe('Sources', () => {
     let source: Sources;
-    const api = new API({ accessToken: 'some-token' });
-    const serverlessApi = new API({ accessToken: 'some-token' });
+    const api = new API({accessToken: 'some-token'});
+    const serverlessApi = new API({accessToken: 'some-token'});
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/src/resources/Sources/tests/Sources.spec.ts
+++ b/src/resources/Sources/tests/Sources.spec.ts
@@ -1,7 +1,7 @@
 import API from '../../../APICore.js';
-import {New} from '../../BaseInterfaces.js';
-import {ActivityOperation, DocumentConfigurationType} from '../../Enums.js';
-import {ScheduleModel} from '../../SecurityCache/index.js';
+import { New } from '../../BaseInterfaces.js';
+import { ActivityOperation, DocumentConfigurationType } from '../../Enums.js';
+import { ScheduleModel } from '../../SecurityCache/index.js';
 import Sources from '../Sources.js';
 import SourcesDatasets from '../SourcesDatasets/SourcesDatasets.js';
 import SourcesFeedback from '../SourcesFeedback/SourcesFeedback.js';
@@ -19,8 +19,8 @@ jest.mock('../../../APICore.js');
 
 describe('Sources', () => {
     let source: Sources;
-    const api = new API({accessToken: 'some-token'});
-    const serverlessApi = new API({accessToken: 'some-token'});
+    const api = new API({ accessToken: 'some-token' });
+    const serverlessApi = new API({ accessToken: 'some-token' });
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -120,16 +120,6 @@ describe('Sources', () => {
             await source.update(sourceId, sourceModel);
             expect(api.put).toHaveBeenCalledTimes(1);
             expect(api.put).toHaveBeenCalledWith(`${Sources.baseUrl}/${sourceId}`, sourceModel);
-        });
-    });
-
-    describe('applyChanges', () => {
-        it('should make a POST call to the specific Sources url', async () => {
-            const sourceId = '😾';
-
-            await source.applyChanges(sourceId);
-            expect(api.post).toHaveBeenCalledTimes(1);
-            expect(api.post).toHaveBeenCalledWith(`${Sources.baseUrl}/${sourceId}/applyChanges`);
         });
     });
 


### PR DESCRIPTION
BREAKING CHANGE: the applyChanges method is removed
The `/applyChanges` endpoint of the Source Service is deprecated so I removed it from the platform client. I did not find any code calling this method.


### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [ ] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))
