### PR TITLE
fix(statements-feature): fix enum regarding ml model types

### DIFF
--- a/src/resources/Enums.ts
+++ b/src/resources/Enums.ts
@@ -754,10 +754,10 @@ export enum StatementsFeature {
     Thesaurus = 'thesaurus',
     Top = 'top',
     ResultRankings = 'resultRankings',
-    TopClicks = 'topClicks',
-    QuerySuggest = 'querySuggest',
+    TopClicks = 'mlTopClicks',
+    QuerySuggest = 'mlQuerySuggest',
     RankingWeight = 'rankingweight',
-    Recommendation = 'recommendation',
+    Recommendation = 'mlRecommendation',
     QueryParamOverride = 'queryParamOverride',
 }
 


### PR DESCRIPTION
Changed the `topClicks`, `querySuggest` and `recommendation` values in the `StatementsFeature` enum to match the correct ML model types. This ensures that the feature behaves as expected when interacting with different machine learning models.

BREAKING CHANGE: The values for `topClicks`, `querySuggest`, and `recommendation` in the `StatementsFeature` enum have been updated to `mlTopClicks`, `mlQuerySuggest`, `mlRecommendation` respectively.

See in Swagger [here](https://platformdev.cloud.coveo.com/docs?urls.primaryName=Search+API#/Statements%20V2/exportQueryPipelineStatements).

<img width="1371" height="631" alt="Screenshot 2026-09-04 at 4 50 27 PM" src="https://github.com/user-attachments/assets/83a926ef-507f-41a3-88f3-1e599ef7f46d" />


<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))
