### PR TITLE
feat(search): add Search API saml provider list endpoint and samlProv…

### DIFF
--- a/src/resources/HostedInterfacesCore/HostedInterfaceVersionsCore.ts
+++ b/src/resources/HostedInterfacesCore/HostedInterfaceVersionsCore.ts
@@ -156,6 +156,11 @@ export interface IAccesses {
      * @default false
      */
     sharingDomainEnabled?: boolean;
+
+    /**
+     * The name of the Search API SAML identity provider used to authenticate Search Page viewers.
+     */
+    samlProvider?: string;
 }
 
 export interface ISortCriteria {

--- a/src/resources/NextGenSearchPages/tests/NextGenSearchPages.spec.ts
+++ b/src/resources/NextGenSearchPages/tests/NextGenSearchPages.spec.ts
@@ -81,6 +81,7 @@ describe('NextGenSearchPages', () => {
             domains: ['domain1', 'domain2'],
             sharingDomainEnabled: true,
             sharingLinkEnabled: true,
+            samlProvider: 'oktaIntegratorDev',
         },
         layout: SearchPageLayout.List,
         style: {

--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -8,6 +8,7 @@ import {
     RestQueryParams,
     RestQueryResult,
     RestTokenParams,
+    SearchApiSamlIdentityProvider,
     SearchListFieldsParams,
     SearchListFieldsResponse,
     SearchResponse,
@@ -18,9 +19,14 @@ import {ListFieldValuesBodyQueryParams, PostSearchQuerySuggestBodyParams} from '
 
 export default class Search extends Resource {
     static baseUrl = `/rest/search/v2`;
+    static authenticationBaseUrl = `/rest/organizations/${API.orgPlaceholder}/authentication`;
 
     createToken(tokenParams: RestTokenParams) {
         return this.api.post<TokenModel>(`${Search.baseUrl}/token?organizationId=${API.orgPlaceholder}`, tokenParams);
+    }
+
+    listSamlIdentityProviders(): Promise<SearchApiSamlIdentityProvider[]> {
+        return this.api.get<SearchApiSamlIdentityProvider[]>(`${Search.authenticationBaseUrl}/saml`);
     }
 
     listFields(params?: SearchListFieldsParams) {

--- a/src/resources/Search/SearchInterfaces.ts
+++ b/src/resources/Search/SearchInterfaces.ts
@@ -2781,3 +2781,14 @@ export interface RestFacetSearchResponse {
      */
     moreValuesAvailable: boolean;
 }
+
+export interface SearchApiSamlIdentityProvider {
+    /**
+     * Unique identifier of the SAML provider.
+     */
+    id: string;
+    /**
+     * Unique name of the SAML proivder used to connect via the Search API.
+     */
+    name: string;
+}

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -240,4 +240,13 @@ describe('Search', () => {
             Object.defineProperty(api, 'organizationId', {value: tempOrganizationId, writable: true});
         });
     });
+
+    describe('listSamlIdentityProviders', () => {
+        it('should make a GET call to the Search API SAML providers endpoint', async () => {
+            await search.listSamlIdentityProviders();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith('/rest/organizations/{organizationName}/authentication/saml');
+        });
+    });
 });


### PR DESCRIPTION
## [SFINT-6504](https://coveord.atlassian.net/browse/SFINT-6504)

Adds SAML identity provider support for Search Pages.

- Exposes `Platform.search.listSamlIdentityProviders()` to retrieve configured providers from the Search API’s `/authentication/saml` endpoint. (see [doc](https://docs.coveo.com/en/91/build-a-search-ui/configure-a-saml-identity-provider-using-the-search-api))
- Adds `SearchApiSamlIdentityProvider` as the response model.
- Adds `accesses.samlProvider` to Search Page configuration so consumers can persist the selected provider name.

### Acceptance Criteria

- [ ] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
- [ ] JSDoc annotates each property added in the exported interfaces
- [x] The proposed changes are covered by unit tests
- [x] Commits containing breaking changes are properly identified as such
- [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
- [x] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))


[SFINT-6504]: https://coveord.atlassian.net/browse/SFINT-6504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ