### PR TITLE
fix(search-interfaces): move samlprovider listing to the sis proxy routes

### DIFF
--- a/src/resources/Search/Search.ts
+++ b/src/resources/Search/Search.ts
@@ -8,7 +8,6 @@ import {
     RestQueryParams,
     RestQueryResult,
     RestTokenParams,
-    SearchApiSamlIdentityProvider,
     SearchListFieldsParams,
     SearchListFieldsResponse,
     SearchResponse,
@@ -19,14 +18,9 @@ import {ListFieldValuesBodyQueryParams, PostSearchQuerySuggestBodyParams} from '
 
 export default class Search extends Resource {
     static baseUrl = `/rest/search/v2`;
-    static authenticationBaseUrl = `/rest/organizations/${API.orgPlaceholder}/authentication`;
 
     createToken(tokenParams: RestTokenParams) {
         return this.api.post<TokenModel>(`${Search.baseUrl}/token?organizationId=${API.orgPlaceholder}`, tokenParams);
-    }
-
-    listSamlIdentityProviders(): Promise<SearchApiSamlIdentityProvider[]> {
-        return this.api.get<SearchApiSamlIdentityProvider[]>(`${Search.authenticationBaseUrl}/saml`);
     }
 
     listFields(params?: SearchListFieldsParams) {

--- a/src/resources/Search/SearchInterfaces.ts
+++ b/src/resources/Search/SearchInterfaces.ts
@@ -2781,14 +2781,3 @@ export interface RestFacetSearchResponse {
      */
     moreValuesAvailable: boolean;
 }
-
-export interface SearchApiSamlIdentityProvider {
-    /**
-     * Unique identifier of the SAML provider.
-     */
-    id: string;
-    /**
-     * Unique name of the SAML proivder used to connect via the Search API.
-     */
-    name: string;
-}

--- a/src/resources/Search/test/Search.spec.ts
+++ b/src/resources/Search/test/Search.spec.ts
@@ -240,13 +240,4 @@ describe('Search', () => {
             Object.defineProperty(api, 'organizationId', {value: tempOrganizationId, writable: true});
         });
     });
-
-    describe('listSamlIdentityProviders', () => {
-        it('should make a GET call to the Search API SAML providers endpoint', async () => {
-            await search.listSamlIdentityProviders();
-
-            expect(api.get).toHaveBeenCalledTimes(1);
-            expect(api.get).toHaveBeenCalledWith('/rest/organizations/{organizationName}/authentication/saml');
-        });
-    });
 });

--- a/src/resources/SearchInterfaces/SearchInterfaces.model.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.model.ts
@@ -88,3 +88,15 @@ export interface IListSearchInterfacesParameters extends Paginated {
      */
     perPage?: number;
 }
+
+export interface SearchApiSamlIdentityProvider {
+    /**
+     * Unique identifier of the SAML provider.
+     */
+    id: string;
+
+    /**
+     * Unique name of the SAML provider used to connect via the Search API.
+     */
+    name: string;
+}

--- a/src/resources/SearchInterfaces/SearchInterfaces.ts
+++ b/src/resources/SearchInterfaces/SearchInterfaces.ts
@@ -6,6 +6,7 @@ import {
     IListSearchInterfacesParameters,
     ISearchInterfaceConfiguration,
     ISearchInterfaceConfigurationResponse,
+    SearchApiSamlIdentityProvider,
 } from './SearchInterfaces.model.js';
 
 export default class SearchInterfaces extends Resource {
@@ -13,6 +14,10 @@ export default class SearchInterfaces extends Resource {
 
     list(options: IListSearchInterfacesParameters): Promise<PageModel<ISearchInterfaceConfigurationResponse>> {
         return this.api.get(this.buildPath(SearchInterfaces.baseUrl, options));
+    }
+
+    listSamlIdentityProviders(): Promise<SearchApiSamlIdentityProvider[]> {
+        return this.api.get<SearchApiSamlIdentityProvider[]>(`${SearchInterfaces.baseUrl}/authentication/saml`);
     }
 
     create(searchInterfaceConfig: New<ISearchInterfaceConfiguration>): Promise<ISearchInterfaceConfigurationResponse> {

--- a/src/resources/SearchInterfaces/tests/SearchInterfaces.spec.ts
+++ b/src/resources/SearchInterfaces/tests/SearchInterfaces.spec.ts
@@ -92,6 +92,15 @@ describe('SearchInterfaces', () => {
         });
     });
 
+    describe('listSamlIdentityProviders', () => {
+        it('should make a GET call to the Search API SAML providers endpoint', async () => {
+            await searchInterfaces.listSamlIdentityProviders();
+
+            expect(api.get).toHaveBeenCalledTimes(1);
+            expect(api.get).toHaveBeenCalledWith(`${SearchInterfaces.baseUrl}/authentication/saml`);
+        });
+    });
+
     describe('create', () => {
         it('should make a POST call to the SearchInterfaces base url', async () => {
             await searchInterfaces.create(config);


### PR DESCRIPTION
[SFINT-6504](https://coveord.atlassian.net/browse/SFINT-6504)

Move SAML identity-provider listing to the Search Interface Service resource, since SIS now proxies the endpoint instead of the searchapi.

• Add  platform.searchInterfaces.listSamlIdentityProviders() 
• Call  GET /organizations/:organization/searchinterfaces/authentication/saml 
• Remove the equivalent operation and response model from  platform.search 

Testing

•  npm test -- --runInBand src/resources/SearchInterfaces/tests/SearchInterfaces.spec.ts src/resources/Search/test/Search.spec.ts 
•  npx tsc -p tsconfig.build.esm.json --noEmit 

[SFINT-6504]: https://coveord.atlassian.net/browse/SFINT-6504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ