### PR TITLE
feat(SchemaServiceInterface): [CTNAT-4057] Add indexAttachments parameter to otg

### DIFF
--- a/src/resources/SchemaService/SchemaServiceInterfaces.ts
+++ b/src/resources/SchemaService/SchemaServiceInterfaces.ts
@@ -146,6 +146,10 @@ export interface GenericObject {
      * The filter applied to the records of the object
      */
     filter?: string;
+    /**
+     * Whether to index all attachments linked to this object
+     */
+    indexAttachments?: boolean;
 }
 
 export interface ObjectsToGet {


### PR DESCRIPTION
Make new `indexAttachments` parameter on `GenericObject` available in the `SchemaServiceInterface`.

schema service PR adding the parameter: https://github.com/coveo-platform/schema-service/pull/923

### Acceptance Criteria

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [x] JSDoc annotates each property added in the exported interfaces
-   [x] The proposed changes are covered by unit tests
-   [x] Commits containing breaking changes a properly identified as such
-   [x] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))
