### PR TITLE
feat(fields): add fieldNames filter to FieldListingFilters

### DIFF
--- a/src/resources/Fields/FieldsInterfaces.ts
+++ b/src/resources/Fields/FieldsInterfaces.ts
@@ -147,6 +147,10 @@ export interface FieldListingFilters {
      * The origin of the fields to list.
      */
     type?: FieldTypes;
+    /**
+     *  The names of the fields to list.
+     */
+    fieldNames?: string[];
 }
 
 export interface FieldListingOptions extends Paginated {


### PR DESCRIPTION
<!--
If a new Resource class was created in this PR, have you done the following?
- Instantiated the new resource somewhere
    - either on the base [PlatformResource class](https://github.com/coveo/platform-client/blob/master/src/resources/PlatformResources.ts)
    - or on another resource
- Exported the class and its interfaces so that they are reachable from the [Entry file](https://github.com/coveo/platform-client/blob/master/src/Entry.ts)
 -->

[PSE-1765](https://coveord.atlassian.net/browse/PSE-1765)

Fields search API changes (documented [here](https://platform.cloud.coveo.com/docs?urls.primaryName=Field#/Fields/rest_organizations_paramId_indexes_fields_search_post))

- The `FieldListingFilters` now includes `fieldNames`

<img width="239" height="274" alt="Screenshot 2026-09-01 at 3 49 50 PM" src="https://github.com/user-attachments/assets/0e4d5d83-5960-43d6-b472-86788174e3c0" />
<img width="612" height="540" alt="Screenshot 2026-09-01 at 3 47 37 PM" src="https://github.com/user-attachments/assets/b57b5498-1ea2-4baa-9092-634a5ac372fa" />

### Acceptance Criteria

<!-- PRs that don't respect all of those criteria won't be merged. -->

-   [x] My changes are publicly available, documented, and deployed in production. (i.e. on [Swagger](https://platform.cloud.coveo.com/docs))
-   [ ] JSDoc annotates each property added in the exported interfaces
-   [ ] The proposed changes are covered by unit tests
-   [ ] Commits containing breaking changes a properly identified as such
-   [ ] [README.md](https://github.com/coveo/platform-client/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
-   [x] My merge commit message will follow the commit guidelines (See [Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines))


[PSE-1765]: https://coveord.atlassian.net/browse/PSE-1765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ